### PR TITLE
Scaffolding for signup service

### DIFF
--- a/pkg/health/health_check_handler_test.go
+++ b/pkg/health/health_check_handler_test.go
@@ -18,7 +18,7 @@ import (
 func TestHealthCheckHandler(t *testing.T) {
 	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
 	// pass 'nil' as the third parameter.
-	req, err := http.NewRequest("GET", "/api/health", nil)
+	req, err := http.NewRequest("GET", "/api/v1/health", nil)
 	require.NoError(t, err)
 
 	// create logger and registry.

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/codeready-toolchain/registration-service/pkg/health"
+	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/pkg/static"
 )
 
@@ -53,13 +54,13 @@ func (srv *RegistrationServer) SetupRoutes() error {
 		// /status is something you should always have in any of your services,
 		// please leave it as is.
 		healthService := health.New(srv.logger, srv.Config())
+		signupService := signup.New(srv.logger, srv.Config())
 
 		v1 := srv.router.Group("/api/v1")
 		{
 			v1.GET("/health", healthService.HealthCheckHandler)
+			v1.POST("/signup", signupService.HandleRequest)
 		}
-
-		// ADD YOUR OWN ROUTES HERE - DON'T FORGET TO ADD A TEST TABLE ENTRY
 
 		// create the route for static content, served from /
 		spa := SpaHandler{Assets: static.Assets}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/codeready-toolchain/registration-service/pkg/health"
-	"github.com/codeready-toolchain/registration-service/pkg/signup"
+	//"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/pkg/static"
 )
 
@@ -54,12 +54,16 @@ func (srv *RegistrationServer) SetupRoutes() error {
 		// /status is something you should always have in any of your services,
 		// please leave it as is.
 		healthService := health.New(srv.logger, srv.Config())
-		signupService := signup.New(srv.logger, srv.Config())
+		// TODO uncomment these once the services are available
+		//signupService := signup.NewSignupService(srv.logger, srv.Config())
+		//signupCallbackService := signup.NewSignupCallbackService(srv.logger, srv.Config())
 
 		v1 := srv.router.Group("/api/v1")
 		{
 			v1.GET("/health", healthService.HealthCheckHandler)
-			v1.POST("/signup", signupService.HandleRequest)
+			// TODO uncomment these once the services are available
+			//v1.GET("/signup", signupService.HandleRequest)
+			//v1.POST("/signup_callback", signupCallbackService.HandleRequest)
 		}
 
 		// create the route for static content, served from /

--- a/pkg/signup/signup_callback_handler.go
+++ b/pkg/signup/signup_callback_handler.go
@@ -8,22 +8,22 @@ import (
 	"net/http"
 )
 
-// SignupService implements the signup endpoint, which is invoked for new user registrations.
-type SignupService struct {
+// SignupCallbackService implements the signup callback endpoint.
+type SignupCallbackService struct {
 	config *configuration.Registry
 	logger *log.Logger
 }
 
-// NewSignupService returns a new SignupService instance.
-func NewSignupService(logger *log.Logger, config *configuration.Registry) *SignupService {
-	return &SignupService{
+// NewSignupCallbackService returns a new SignupCallbackService instance.
+func NewSignupCallbackService(logger *log.Logger, config *configuration.Registry) *SignupCallbackService {
+	return &SignupCallbackService{
 		logger: logger,
 		config: config,
 	}
 }
 
 // HandleRequest returns a default heath check result.
-func (srv *SignupService) HandleRequest(ctx *gin.Context) {
+func (srv *SignupCallbackService) HandleRequest(ctx *gin.Context) {
 	ctx.Writer.Header().Set("Content-Type", "application/json")
 
 	err := json.NewEncoder(ctx.Writer).Encode(nil)

--- a/pkg/signup/signup_callback_handler_test.go
+++ b/pkg/signup/signup_callback_handler_test.go
@@ -1,0 +1,1 @@
+package signup

--- a/pkg/signup/signup_callback_handler_test.go
+++ b/pkg/signup/signup_callback_handler_test.go
@@ -1,1 +1,45 @@
-package signup
+package signup_test
+
+import (
+	"github.com/codeready-toolchain/registration-service/pkg/configuration"
+	"github.com/codeready-toolchain/registration-service/pkg/signup"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestSignupCallbackHandler(t *testing.T) {
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req, err := http.NewRequest("GET", "/api/v1/signup_callback", nil)
+	require.NoError(t, err)
+
+	// create logger and registry.
+	logger := log.New(os.Stderr, "", 0)
+	configRegistry := configuration.CreateEmptyRegistry()
+
+	// set the config for testing mode, the handler may use this.
+	configRegistry.GetViperInstance().Set("testingmode", true)
+	assert.True(t, configRegistry.IsTestingMode(), "testing mode not set correctly to true")
+
+	// create handler instance.
+	signupCallbackService := signup.NewSignupCallbackService(logger, configRegistry)
+	handler := gin.HandlerFunc(signupCallbackService.HandleRequest)
+
+	t.Run("signup", func(t *testing.T) {
+		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Request = req
+
+		handler(ctx)
+
+		// Check the status code is what we expect.
+		require.Equal(t, http.StatusOK, rr.Code)
+	})
+}

--- a/pkg/signup/signup_handler.go
+++ b/pkg/signup/signup_handler.go
@@ -1,0 +1,34 @@
+package signup
+
+import (
+	"encoding/json"
+	"github.com/codeready-toolchain/registration-service/pkg/configuration"
+	"github.com/gin-gonic/gin"
+	"log"
+	"net/http"
+)
+
+// SignupService implements the signup endpoint.
+type SignupService struct {
+	config *configuration.Registry
+	logger *log.Logger
+}
+
+// New returns a new healthService instance.
+func New(logger *log.Logger, config *configuration.Registry) *SignupService {
+	r := new(SignupService)
+	r.logger = logger
+	r.config = config
+	return r
+}
+
+// HandleRequest returns a default heath check result.
+func (srv *SignupService) HandleRequest(ctx *gin.Context) {
+	ctx.Writer.Header().Set("Content-Type", "application/json")
+
+	err := json.NewEncoder(ctx.Writer).Encode(nil)
+	if err != nil {
+		http.Error(ctx.Writer, err.Error(), 500)
+		return
+	}
+}

--- a/pkg/signup/signup_handler_test.go
+++ b/pkg/signup/signup_handler_test.go
@@ -1,0 +1,1 @@
+package signup

--- a/pkg/signup/signup_handler_test.go
+++ b/pkg/signup/signup_handler_test.go
@@ -1,1 +1,45 @@
-package signup
+package signup_test
+
+import (
+	"github.com/codeready-toolchain/registration-service/pkg/configuration"
+	"github.com/codeready-toolchain/registration-service/pkg/signup"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestSignupHandler(t *testing.T) {
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req, err := http.NewRequest("GET", "/api/v1/signup", nil)
+	require.NoError(t, err)
+
+	// create logger and registry.
+	logger := log.New(os.Stderr, "", 0)
+	configRegistry := configuration.CreateEmptyRegistry()
+
+	// set the config for testing mode, the handler may use this.
+	configRegistry.GetViperInstance().Set("testingmode", true)
+	assert.True(t, configRegistry.IsTestingMode(), "testing mode not set correctly to true")
+
+	// create handler instance.
+	signupService := signup.NewSignupService(logger, configRegistry)
+	handler := gin.HandlerFunc(signupService.HandleRequest)
+
+	t.Run("signup", func(t *testing.T) {
+		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Request = req
+
+		handler(ctx)
+
+		// Check the status code is what we expect.
+		require.Equal(t, http.StatusOK, rr.Code)
+	})
+}


### PR DESCRIPTION
Subtask of https://jira.coreos.com/browse/CRT-67

This PR adds empty scaffolding for both the `/signup` and `/signup_callback` endpoints.  

Signed-off-by: Shane Bryzak <sbryzak@gmail.com>