### PR TITLE
Cleanup JSON response encoding

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -76,7 +76,7 @@ const (
 
 	varAuthClientConfigContentType = "auth_client.config.content_type"
 	// DefaultAuthClientConfigContentType specifies the auth client config content type.
-	DefaultAuthClientConfigContentType = "application/json"
+	DefaultAuthClientConfigContentType = "application/json; charset=utf-8"
 
 	varAuthClientPublicKeysURL = "auth_client.public_keys_url"
 	// DefaultAuthClientPublicKeysURL is the default log level used in your service.

--- a/pkg/controller/authconfig.go
+++ b/pkg/controller/authconfig.go
@@ -32,7 +32,6 @@ func NewAuthConfig(logger *log.Logger, config *configuration.Registry) *AuthConf
 
 // GetHandler returns raw auth config content for UI.
 func (ac *AuthConfig) GetHandler(ctx *gin.Context) {
-	ctx.Writer.Header().Set("Content-Type", "application/json")
 	configRespData := configResponse{
 		AuthClientLibraryURL: ac.config.GetAuthClientLibraryURL(),
 		AuthClientConfigRaw:  ac.config.GetAuthClientConfigAuthRaw(),

--- a/pkg/controller/health_check.go
+++ b/pkg/controller/health_check.go
@@ -1,19 +1,23 @@
 package controller
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
 
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
-	"github.com/codeready-toolchain/registration-service/pkg/errors"
+
 	"github.com/gin-gonic/gin"
 )
 
+type HealthCheckConfig interface {
+	IsTestingMode() bool
+}
+
 // HealthCheck implements the health endpoint.
 type HealthCheck struct {
-	config *configuration.Registry
-	logger *log.Logger
+	config  HealthCheckConfig
+	logger  *log.Logger
+	checker HealthChecker
 }
 
 // Health payload
@@ -26,17 +30,18 @@ type Health struct {
 }
 
 // HealthCheck returns a new HealthCheck instance.
-func NewHealthCheck(logger *log.Logger, config *configuration.Registry) *HealthCheck {
+func NewHealthCheck(logger *log.Logger, config HealthCheckConfig, checker HealthChecker) *HealthCheck {
 	return &HealthCheck{
-		logger: logger,
-		config: config,
+		logger:  logger,
+		config:  config,
+		checker: checker,
 	}
 }
 
 // getHealthInfo returns the health info.
 func (hc *HealthCheck) getHealthInfo() *Health {
 	return &Health{
-		Alive:       true,
+		Alive:       hc.checker.Alive(),
 		TestingMode: hc.config.IsTestingMode(),
 		Revision:    configuration.Commit,
 		BuildTime:   configuration.BuildTime,
@@ -47,16 +52,27 @@ func (hc *HealthCheck) getHealthInfo() *Health {
 // GetHandler returns a default heath check result.
 func (hc *HealthCheck) GetHandler(ctx *gin.Context) {
 	// Default handler for system health
-	ctx.Writer.Header().Set("Content-Type", "application/json")
 	healthInfo := hc.getHealthInfo()
 	if healthInfo.Alive {
-		ctx.Writer.WriteHeader(http.StatusOK)
+		ctx.JSON(http.StatusOK, healthInfo)
 	} else {
-		ctx.Writer.WriteHeader(http.StatusInternalServerError)
+		ctx.JSON(http.StatusServiceUnavailable, healthInfo)
 	}
-	err := json.NewEncoder(ctx.Writer).Encode(healthInfo)
-	if err != nil {
-		hc.logger.Println("error writing response body", err.Error())
-		errors.EncodeError(ctx, err, http.StatusInternalServerError, "error writing response body")
-	}
+}
+
+type HealthChecker interface {
+	Alive() bool
+}
+
+func NewHealthChecker(config HealthCheckConfig) HealthChecker {
+	return &healthCheckerImpl{config: config}
+}
+
+type healthCheckerImpl struct {
+	config HealthCheckConfig
+}
+
+func (c *healthCheckerImpl) Alive() bool {
+	// TODO check if there are errors in configuration
+	return true
 }

--- a/pkg/controller/health_check_test.go
+++ b/pkg/controller/health_check_test.go
@@ -34,11 +34,8 @@ func (s *TestHealthCheckSuite) TestHealthCheckHandler() {
 	// Create logger and registry.
 	logger := log.New(os.Stderr, "", 0)
 
-	// Check if the config is set to testing mode, so the handler may use this.
-	assert.True(s.T(), s.Config.IsTestingMode(), "testing mode not set correctly to true")
-
 	// Create health check instance.
-	healthCheckCtrl := controller.NewHealthCheck(logger, s.Config)
+	healthCheckCtrl := controller.NewHealthCheck(logger, s.Config, controller.NewHealthChecker(s.Config))
 	handler := gin.HandlerFunc(healthCheckCtrl.GetHandler)
 
 	s.Run("health in testing mode", func() {
@@ -50,15 +47,14 @@ func (s *TestHealthCheckSuite) TestHealthCheckHandler() {
 		handler(ctx)
 
 		// Check the status code is what we expect.
-		assert.Equal(s.T(), rr.Code, http.StatusOK, "handler returned wrong status code: got %v want %v", rr.Code, http.StatusOK)
+		assert.Equal(s.T(), http.StatusOK, rr.Code, "handler returned wrong status code")
 
 		// Check the response body is what we expect.
 		data := &controller.Health{}
 		err := json.Unmarshal(rr.Body.Bytes(), &data)
 		require.NoError(s.T(), err)
 
-		val := data.Alive
-		assert.True(s.T(), val, "alive is false in test mode health response")
+		assertHealth(s.T(), true, true, data)
 	})
 
 	s.Run("health in production mode", func() {
@@ -76,80 +72,54 @@ func (s *TestHealthCheckSuite) TestHealthCheckHandler() {
 		handler(ctx)
 
 		// Check the status code is what we expect.
-		assert.Equal(s.T(), rr.Code, http.StatusOK, "handler returned wrong status code: got %v want %v", rr.Code, http.StatusOK)
+		assert.Equal(s.T(), http.StatusOK, rr.Code, "handler returned wrong status code")
 
 		// Check the response body is what we expect.
 		data := &controller.Health{}
 		err := json.Unmarshal(rr.Body.Bytes(), &data)
 		require.NoError(s.T(), err)
 
-		val := data.Alive
-		assert.True(s.T(), val, "alive is false in test mode health response")
+		assertHealth(s.T(), true, false, data)
 	})
 
-	s.Run("revision", func() {
+	s.Run("service Unavailable", func() {
+		// Setting production mode
+		s.Config.GetViperInstance().Set("testingmode", false)
+
+		healthCheckCtrl := controller.NewHealthCheck(logger, s.Config, &mockHealthChecker{})
+		handler := gin.HandlerFunc(healthCheckCtrl.GetHandler)
+
 		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
 		rr := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(rr)
 		ctx.Request = req
 
-		// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
-		// directly and pass in our Request and ResponseRecorder.
 		handler(ctx)
 
 		// Check the status code is what we expect.
-		assert.Equal(s.T(), rr.Code, http.StatusOK, "handler returned wrong status code: got %v want %v", rr.Code, http.StatusOK)
+		assert.Equal(s.T(), http.StatusServiceUnavailable, rr.Code, "handler returned wrong status code")
 
 		// Check the response body is what we expect.
 		data := &controller.Health{}
 		err := json.Unmarshal(rr.Body.Bytes(), &data)
 		require.NoError(s.T(), err)
 
-		val := data.Revision
-		assert.Equal(s.T(), configuration.Commit, val, "wrong revision in health response, got %s want %s", val, configuration.Commit)
+		assertHealth(s.T(), false, false, data)
 	})
+}
 
-	s.Run("build time", func() {
-		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
-		rr := httptest.NewRecorder()
-		ctx, _ := gin.CreateTestContext(rr)
-		ctx.Request = req
+func assertHealth(t *testing.T, expectedAlive, expectedTestingMode bool, actual *controller.Health) {
+	assert.Equal(t, expectedAlive, actual.Alive, "wrong alive in health response")
+	assert.Equal(t, configuration.Commit, actual.Revision, "wrong revision in health response")
+	assert.Equal(t, configuration.BuildTime, actual.BuildTime, "wrong build_time in health response")
+	assert.Equal(t, configuration.StartTime, actual.StartTime, "wrong start_time in health response")
+	assert.Equal(t, expectedTestingMode, actual.TestingMode, "wrong testing mode in health response")
+}
 
-		// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
-		// directly and pass in our Request and ResponseRecorder.
-		handler(ctx)
+type mockHealthChecker struct {
+	alive bool
+}
 
-		// Check the status code is what we expect.
-		assert.Equal(s.T(), rr.Code, http.StatusOK, "handler returned wrong status code: got %v want %v", rr.Code, http.StatusOK)
-
-		// Check the response body is what we expect.
-		data := &controller.Health{}
-		err := json.Unmarshal(rr.Body.Bytes(), &data)
-		require.NoError(s.T(), err)
-
-		val := data.BuildTime
-		assert.Equal(s.T(), configuration.BuildTime, val, "wrong build_time in health response, got %s want %s", val, configuration.BuildTime)
-	})
-
-	s.Run("start time", func() {
-		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
-		rr := httptest.NewRecorder()
-		ctx, _ := gin.CreateTestContext(rr)
-		ctx.Request = req
-
-		// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
-		// directly and pass in our Request and ResponseRecorder.
-		handler(ctx)
-
-		// Check the status code is what we expect.
-		assert.Equal(s.T(), rr.Code, http.StatusOK, "handler returned wrong status code: got %v want %v", rr.Code, http.StatusOK)
-
-		// Check the response body is what we expect.
-		data := &controller.Health{}
-		err := json.Unmarshal(rr.Body.Bytes(), &data)
-		require.NoError(s.T(), err)
-
-		val := data.StartTime
-		assert.Equal(s.T(), configuration.StartTime, val, "wrong start_time in health response, got %s want %s", val, configuration.StartTime)
-	})
+func (c *mockHealthChecker) Alive() bool {
+	return c.alive
 }

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -1,12 +1,10 @@
 package controller
 
 import (
-	"encoding/json"
 	"log"
-	"net/http"
 
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
-	"github.com/codeready-toolchain/registration-service/pkg/errors"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -27,12 +25,4 @@ func NewSignup(logger *log.Logger, config *configuration.Registry) *Signup {
 // PostHandler returns signup info.
 func (s *Signup) PostHandler(ctx *gin.Context) {
 	ctx.Writer.Header().Set("Content-Type", "application/json")
-
-	// the KeyManager can be accessed here: auth.DefaultKeyManager()
-
-	err := json.NewEncoder(ctx.Writer).Encode(nil)
-	if err != nil {
-		s.logger.Println("error writing response body", err.Error())
-		errors.EncodeError(ctx, err, http.StatusInternalServerError, "error writing response body")
-	}
 }

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -14,19 +13,12 @@ type Error struct {
 	Details string `json:"details"`
 }
 
-// EncodeError encodes a json error response.
-func EncodeError(ctx *gin.Context, err error, code int, details string) {
-	// construct an error.
-	errorStruct := &Error{
+// AbortWithError stops the chain, writes the status code and the given error
+func AbortWithError(ctx *gin.Context, code int, err error, details string) {
+	ctx.AbortWithStatusJSON(code, &Error{
 		Status:  http.StatusText(code),
 		Code:    code,
 		Message: err.Error(),
 		Details: details,
-	}
-
-	// encode it.
-	e := json.NewEncoder(ctx.Writer).Encode(errorStruct)
-	if e != nil {
-		http.Error(ctx.Writer, e.Error(), http.StatusInternalServerError)
-	}
+	})
 }

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -9,6 +9,7 @@ import (
 
 	err "github.com/codeready-toolchain/registration-service/pkg/errors"
 	testutils "github.com/codeready-toolchain/registration-service/test"
+
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -32,7 +33,7 @@ func (s *TestErrorsSuite) TestErrors() {
 		errMsg := "testing new error"
 		code := http.StatusInternalServerError
 
-		err.EncodeError(ctx, errors.New(errMsg), code, details)
+		err.AbortWithError(ctx, code, errors.New(errMsg), details)
 
 		res := err.Error{}
 		err := json.Unmarshal(rr.Body.Bytes(), &res)

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -60,7 +60,7 @@ func (srv *RegistrationServer) SetupRoutes() error {
 		}
 
 		// creating the controllers
-		healthCheckCtrl := controller.NewHealthCheck(srv.logger, srv.Config())
+		healthCheckCtrl := controller.NewHealthCheck(srv.logger, srv.Config(), controller.NewHealthChecker(srv.Config()))
 		authConfigCtrl := controller.NewAuthConfig(srv.logger, srv.Config())
 		signupCtrl := controller.NewSignup(srv.logger, srv.Config())
 


### PR DESCRIPTION
- Fixed `error.EncodeError()` (and also renamed it to `AbortWithError()`). It didn't properly write the response before.
- Cleaned up `HealthCheck` controller & fixed the 503 response in case of failed health check.
- Added more tests for `HealthCheck` controller