### PR TITLE
removing second creation of the same namespace

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -49,7 +49,6 @@ deploy-rbac:
 .PHONY: deploy-dev
 ## Deploy Registration service on minishift
 deploy-dev: login-as-admin create-namespace deploy-rbac build dev-image
-	$(Q)-oc new-project $(LOCAL_TEST_NAMESPACE) || true
 	$(Q)-sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g' ./deploy/deployment_dev.yaml  | oc apply -f -
 
 .PHONY: update-etc-hosts


### PR DESCRIPTION
The creation of the namespace is done twice when deploy-dev is called. Once during create-namespace and once again in deploy-dev. This PR is to remove the second creation as it is redundant.