### PR TITLE
Move logger output to zap.Options

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	// create logger and registry
-	log.Init("registration-service", nil)
+	log.Init("registration-service")
 
 	// Parse flags
 	var configFilePath string

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -32,7 +31,7 @@ type Logger struct {
 }
 
 // Init initializes the logger.
-func Init(withName string, out io.Writer) {
+func Init(withName string, opts ...zap.Opts) {
 	once.Do(func() {
 		zapFlagSet := pflag.NewFlagSet("zap", pflag.ExitOnError)
 
@@ -54,15 +53,7 @@ func Init(withName string, out io.Writer) {
 		// implementing the logr.Logger interface. This logger will
 		// be propagated through the whole operator, generating
 		// uniform and structured logs.
-		if out == nil {
-			logf.SetLogger(zap.New())
-		} else {
-			opts := func(o *zap.Options) {
-				o.DestWritter = out
-			}
-
-			logf.SetLogger(zap.New(opts))
-		}
+		logf.SetLogger(zap.New(opts...))
 		logger = newLogger(withName)
 	})
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/context"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestLog(t *testing.T) {
 	var buf bytes.Buffer
 	once.Reset()
-	Init("logger_tests", &buf)
+	Init("logger_tests", func(o *zap.Options) {
+		o.DestWritter = &buf
+	})
 
 	t.Run("log info", func(t *testing.T) {
 		rr := httptest.NewRecorder()

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -16,7 +16,7 @@ type UnitTestSuite struct {
 // SetupSuite sets the suite up and sets testmode.
 func (s *UnitTestSuite) SetupSuite() {
 	// create logger and registry
-	log.Init("registration-service-testing", nil)
+	log.Init("registration-service-testing")
 
 	s.Config = configuration.CreateEmptyRegistry()
 


### PR DESCRIPTION
It's followup on https://github.com/codeready-toolchain/registration-service/pull/46