### PR TITLE
Use AbortWithError() when failed to create UserSignup

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,3 +12,4 @@ coverage:
     - "make/*"
     - "build/*"
     - "openshift-ci/*"
+    - "test/*"

--- a/pkg/auth/defaultmanager_test.go
+++ b/pkg/auth/defaultmanager_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,11 +13,11 @@ import (
 )
 
 type TestDefaultManagerSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunDefaultManagerSuite(t *testing.T) {
-	suite.Run(t, &TestDefaultManagerSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestDefaultManagerSuite{test.UnitTestSuite{}})
 }
 
 func (s *TestDefaultManagerSuite) TestKeyManagerDefaultKeyManager() {

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/satori/go.uuid"
@@ -17,11 +17,11 @@ import (
 )
 
 type TestKeyManagerSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunKeyManagerSuite(t *testing.T) {
-	suite.Run(t, &TestKeyManagerSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestKeyManagerSuite{test.UnitTestSuite{}})
 }
 
 func (s *TestKeyManagerSuite) TestKeyManager() {
@@ -38,7 +38,7 @@ func (s *TestKeyManagerSuite) TestKeyManager() {
 
 func (s *TestKeyManagerSuite) TestKeyFetching() {
 	// create test keys
-	tokengenerator := testutils.NewTokenManager()
+	tokengenerator := test.NewTokenManager()
 	kid0 := uuid.NewV4().String()
 	_, err := tokengenerator.AddPrivateKey(kid0)
 	require.NoError(s.T(), err)
@@ -48,20 +48,20 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 
 	// create two test tokens, both valid
 	username0 := uuid.NewV4().String()
-	identity0 := &testutils.Identity{
+	identity0 := &test.Identity{
 		ID:       uuid.NewV4(),
 		Username: username0,
 	}
 	email0 := identity0.Username + "@email.tld"
-	jwt0, err := tokengenerator.GenerateSignedToken(*identity0, kid0, testutils.WithEmailClaim(email0))
+	jwt0, err := tokengenerator.GenerateSignedToken(*identity0, kid0, test.WithEmailClaim(email0))
 	require.NoError(s.T(), err)
 	username1 := uuid.NewV4().String()
-	identity1 := &testutils.Identity{
+	identity1 := &test.Identity{
 		ID:       uuid.NewV4(),
 		Username: username1,
 	}
 	email1 := identity1.Username + "@email.tld"
-	jwt1, err := tokengenerator.GenerateSignedToken(*identity1, kid1, testutils.WithEmailClaim(email1))
+	jwt1, err := tokengenerator.GenerateSignedToken(*identity1, kid1, test.WithEmailClaim(email1))
 	require.NoError(s.T(), err)
 
 	// startup public key service

--- a/pkg/auth/tokenparser_test.go
+++ b/pkg/auth/tokenparser_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 
 	"github.com/dgrijalva/jwt-go"
 	uuid "github.com/satori/go.uuid"
@@ -19,7 +19,7 @@ func TestTokenParser(t *testing.T) {
 	configRegistry := configuration.CreateEmptyRegistry()
 
 	// create test keys
-	tokengenerator := testutils.NewTokenManager()
+	tokengenerator := test.NewTokenManager()
 	kid0 := uuid.NewV4().String()
 	_, err := tokengenerator.AddPrivateKey(kid0)
 	require.NoError(t, err)
@@ -54,20 +54,20 @@ func TestTokenParser(t *testing.T) {
 	t.Run("parse valid tokens", func(t *testing.T) {
 		// create two test tokens, both valid
 		username0 := uuid.NewV4().String()
-		identity0 := &testutils.Identity{
+		identity0 := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
-		jwt0, err := tokengenerator.GenerateSignedToken(*identity0, kid0, testutils.WithEmailClaim(email0))
+		jwt0, err := tokengenerator.GenerateSignedToken(*identity0, kid0, test.WithEmailClaim(email0))
 		require.NoError(t, err)
 		username1 := uuid.NewV4().String()
-		identity1 := &testutils.Identity{
+		identity1 := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: username1,
 		}
 		email1 := identity1.Username + "@email.tld"
-		jwt1, err := tokengenerator.GenerateSignedToken(*identity1, kid1, testutils.WithEmailClaim(email1))
+		jwt1, err := tokengenerator.GenerateSignedToken(*identity1, kid1, test.WithEmailClaim(email1))
 		require.NoError(t, err)
 
 		// check if the keys can be used to verify a JWT
@@ -93,7 +93,7 @@ func TestTokenParser(t *testing.T) {
 	t.Run("parse invalid token", func(t *testing.T) {
 		// create invalid test token (wrong set of claims, no email), signed with key1
 		username_invalid := uuid.NewV4().String()
-		identity_invalid := &testutils.Identity{
+		identity_invalid := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: username_invalid,
 		}
@@ -112,12 +112,12 @@ func TestTokenParser(t *testing.T) {
 		require.NoError(t, err)
 		// generate valid token
 		usernameX := uuid.NewV4().String()
-		identityX := &testutils.Identity{
+		identityX := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: usernameX,
 		}
 		emailX := identityX.Username + "@email.tld"
-		jwtX, err := tokengenerator.GenerateSignedToken(*identityX, kidX, testutils.WithEmailClaim(emailX))
+		jwtX, err := tokengenerator.GenerateSignedToken(*identityX, kidX, test.WithEmailClaim(emailX))
 		require.NoError(t, err)
 		// remove key from known keys
 		tokengenerator.RemovePrivateKey(kidX)
@@ -129,13 +129,13 @@ func TestTokenParser(t *testing.T) {
 
 	t.Run("no KID header in token", func(t *testing.T) {
 		username0 := uuid.NewV4().String()
-		identity0 := &testutils.Identity{
+		identity0 := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
 		// generate non-serialized token
-		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, testutils.WithEmailClaim(email0))
+		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, test.WithEmailClaim(email0))
 		delete(jwt0.Header, "kid")
 		// serialize
 		jwt0string, err := tokengenerator.SignToken(jwt0, kid0)
@@ -148,13 +148,13 @@ func TestTokenParser(t *testing.T) {
 
 	t.Run("missing claim: preferred_username", func(t *testing.T) {
 		username0 := uuid.NewV4().String()
-		identity0 := &testutils.Identity{
+		identity0 := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
 		// generate non-serialized token
-		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, testutils.WithEmailClaim(email0))
+		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, test.WithEmailClaim(email0))
 		// delete preferred_username
 		delete(jwt0.Claims.(jwt.MapClaims), "preferred_username")
 		// serialize
@@ -168,7 +168,7 @@ func TestTokenParser(t *testing.T) {
 
 	t.Run("missing claim: email", func(t *testing.T) {
 		username0 := uuid.NewV4().String()
-		identity0 := &testutils.Identity{
+		identity0 := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: username0,
 		}
@@ -185,13 +185,13 @@ func TestTokenParser(t *testing.T) {
 
 	t.Run("missing claim: sub", func(t *testing.T) {
 		username0 := uuid.NewV4().String()
-		identity0 := &testutils.Identity{
+		identity0 := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
 		// generate non-serialized token
-		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, testutils.WithEmailClaim(email0))
+		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, test.WithEmailClaim(email0))
 		// delete preferred_username
 		delete(jwt0.Claims.(jwt.MapClaims), "sub")
 		// serialize
@@ -205,13 +205,13 @@ func TestTokenParser(t *testing.T) {
 
 	t.Run("signature is good but token expired", func(t *testing.T) {
 		username0 := uuid.NewV4().String()
-		identity0 := &testutils.Identity{
+		identity0 := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
 		// generate non-serialized token
-		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, testutils.WithEmailClaim(email0))
+		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, test.WithEmailClaim(email0))
 		// manipulate expiry
 		tDiff := -60 * time.Second
 		jwt0.Claims.(jwt.MapClaims)["exp"] = time.Now().UTC().Add(tDiff).Unix()
@@ -226,13 +226,13 @@ func TestTokenParser(t *testing.T) {
 
 	t.Run("signature is good but token not valid yet", func(t *testing.T) {
 		username0 := uuid.NewV4().String()
-		identity0 := &testutils.Identity{
+		identity0 := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
 		// generate non-serialized token
-		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, testutils.WithEmailClaim(email0))
+		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, test.WithEmailClaim(email0))
 		// manipulate expiry
 		tDiff := 60 * time.Second
 		jwt0.Claims.(jwt.MapClaims)["nbf"] = time.Now().UTC().Add(tDiff).Unix()
@@ -247,13 +247,13 @@ func TestTokenParser(t *testing.T) {
 
 	t.Run("token signed by known key but the signature is invalid", func(t *testing.T) {
 		username0 := uuid.NewV4().String()
-		identity0 := &testutils.Identity{
+		identity0 := &test.Identity{
 			ID:       uuid.NewV4(),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
 		// generate non-serialized token
-		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, testutils.WithEmailClaim(email0))
+		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, test.WithEmailClaim(email0))
 		// serialize
 		jwt0string, err := tokengenerator.SignToken(jwt0, kid0)
 		require.NoError(t, err)

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,11 +16,11 @@ import (
 )
 
 type TestConfigurationSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunConfigurationSuite(t *testing.T) {
-	suite.Run(t, &TestConfigurationSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestConfigurationSuite{test.UnitTestSuite{}})
 }
 
 // getDefaultConfiguration returns a configuration registry without anything but
@@ -69,14 +69,14 @@ func (s *TestConfigurationSuite) TestGetHTTPAddress() {
 	key := configuration.EnvPrefix + "_" + "HTTP_ADDRESS"
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultHTTPAddress, config.GetHTTPAddress())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		u, err := uuid.NewV4()
 		require.NoError(s.T(), err)
@@ -97,18 +97,18 @@ func (s *TestConfigurationSuite) TestGetHTTPAddress() {
 
 func (s *TestConfigurationSuite) TestGetLogLevel() {
 	key := configuration.EnvPrefix + "_" + "LOG_LEVEL"
-	resetFunc := testutils.UnsetEnvVarAndRestore(key)
+	resetFunc := test.UnsetEnvVarAndRestore(key)
 	defer resetFunc()
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultLogLevel, config.GetLogLevel())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		u, err := uuid.NewV4()
 		require.NoError(s.T(), err)
@@ -129,18 +129,18 @@ func (s *TestConfigurationSuite) TestGetLogLevel() {
 
 func (s *TestConfigurationSuite) TestIsLogJSON() {
 	key := configuration.EnvPrefix + "_" + "LOG_JSON"
-	resetFunc := testutils.UnsetEnvVarAndRestore(key)
+	resetFunc := test.UnsetEnvVarAndRestore(key)
 	defer resetFunc()
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultLogJSON, config.IsLogJSON())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		newVal := !configuration.DefaultLogJSON
 		config := s.getFileConfiguration(`log.json: "` + strconv.FormatBool(newVal) + `"`)
@@ -159,14 +159,14 @@ func (s *TestConfigurationSuite) TestGetGracefulTimeout() {
 	key := configuration.EnvPrefix + "_" + "GRACEFUL_TIMEOUT"
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultGracefulTimeout, config.GetGracefulTimeout())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		newVal := 333 * time.Second
 		config := s.getFileConfiguration(`graceful_timeout: "` + newVal.String() + `"`)
@@ -185,14 +185,14 @@ func (s *TestConfigurationSuite) TestGetHTTPWriteTimeout() {
 	key := configuration.EnvPrefix + "_" + "HTTP_WRITE_TIMEOUT"
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultHTTPWriteTimeout, config.GetHTTPWriteTimeout())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		newVal := 333 * time.Second
 		config := s.getFileConfiguration(`http.write_timeout: "` + newVal.String() + `"`)
@@ -211,14 +211,14 @@ func (s *TestConfigurationSuite) TestGetHTTPReadTimeout() {
 	key := configuration.EnvPrefix + "_" + "HTTP_READ_TIMEOUT"
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultHTTPReadTimeout, config.GetHTTPReadTimeout())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		newVal := 444 * time.Second
 		config := s.getFileConfiguration(`http.read_timeout: "` + newVal.String() + `"`)
@@ -237,14 +237,14 @@ func (s *TestConfigurationSuite) TestGetHTTPIdleTimeout() {
 	key := configuration.EnvPrefix + "_" + "HTTP_IDLE_TIMEOUT"
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultHTTPIdleTimeout, config.GetHTTPIdleTimeout())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		newVal := 111 * time.Second
 		config := s.getFileConfiguration(`http.idle_timeout: "` + newVal.String() + `"`)
@@ -263,14 +263,14 @@ func (s *TestConfigurationSuite) TestGetHTTPCompressResponses() {
 	key := configuration.EnvPrefix + "_" + "HTTP_COMPRESS"
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultHTTPCompressResponses, config.GetHTTPCompressResponses())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		newVal := !configuration.DefaultHTTPCompressResponses
 		config := s.getFileConfiguration(`http.compress: "` + strconv.FormatBool(newVal) + `"`)
@@ -287,18 +287,18 @@ func (s *TestConfigurationSuite) TestGetHTTPCompressResponses() {
 
 func (s *TestConfigurationSuite) TestIsTestingMode() {
 	key := configuration.EnvPrefix + "_" + "TESTINGMODE"
-	resetFunc := testutils.UnsetEnvVarAndRestore(key)
+	resetFunc := test.UnsetEnvVarAndRestore(key)
 	defer resetFunc()
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultTestingMode, config.IsTestingMode())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		newVal := !configuration.DefaultTestingMode
 		config := s.getFileConfiguration(`testingmode: "` + strconv.FormatBool(newVal) + `"`)
@@ -317,14 +317,14 @@ func (s *TestConfigurationSuite) TestGetAuthClientConfigRaw() {
 	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW"
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultAuthClientConfigRaw, config.GetAuthClientConfigAuthRaw())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		u, err := uuid.NewV4()
 		require.NoError(s.T(), err)
@@ -347,14 +347,14 @@ func (s *TestConfigurationSuite) TestGetAuthClientConfigContentType() {
 	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_CONTENT_TYPE"
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultAuthClientConfigContentType, config.GetAuthClientConfigAuthContentType())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		u, err := uuid.NewV4()
 		require.NoError(s.T(), err)
@@ -375,18 +375,18 @@ func (s *TestConfigurationSuite) TestGetAuthClientConfigContentType() {
 
 func (s *TestConfigurationSuite) TestGetAuthClientLibraryURL() {
 	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_LIBRARY_URL"
-	resetFunc := testutils.UnsetEnvVarAndRestore(key)
+	resetFunc := test.UnsetEnvVarAndRestore(key)
 	defer resetFunc()
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultAuthClientLibraryURL, config.GetAuthClientLibraryURL())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		u, err := uuid.NewV4()
 		require.NoError(s.T(), err)
@@ -407,18 +407,18 @@ func (s *TestConfigurationSuite) TestGetAuthClientLibraryURL() {
 
 func (s *TestConfigurationSuite) TestGetAuthClientPublicKeysURL() {
 	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_PUBLIC_KEYS_URL"
-	resetFunc := testutils.UnsetEnvVarAndRestore(key)
+	resetFunc := test.UnsetEnvVarAndRestore(key)
 	defer resetFunc()
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultAuthClientPublicKeysURL, config.GetAuthClientPublicKeysURL())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		u, err := uuid.NewV4()
 		require.NoError(s.T(), err)
@@ -439,18 +439,18 @@ func (s *TestConfigurationSuite) TestGetAuthClientPublicKeysURL() {
 
 func (s *TestConfigurationSuite) TestGetNamespace() {
 	key := configuration.EnvPrefix + "_" + "NAMESPACE"
-	resetFunc := testutils.UnsetEnvVarAndRestore(key)
+	resetFunc := test.UnsetEnvVarAndRestore(key)
 	defer resetFunc()
 
 	s.Run("default", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
 		assert.Equal(s.T(), configuration.DefaultNamespace, config.GetNamespace())
 	})
 
 	s.Run("file", func() {
-		resetFunc := testutils.UnsetEnvVarAndRestore(key)
+		resetFunc := test.UnsetEnvVarAndRestore(key)
 		defer resetFunc()
 		u, err := uuid.NewV4()
 		require.NoError(s.T(), err)

--- a/pkg/controller/authconfig_test.go
+++ b/pkg/controller/authconfig_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -15,11 +15,11 @@ import (
 )
 
 type TestAuthConfigSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunAuthClientConfigSuite(t *testing.T) {
-	suite.Run(t, &TestAuthConfigSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestAuthConfigSuite{test.UnitTestSuite{}})
 }
 
 func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {

--- a/pkg/controller/health_check_test.go
+++ b/pkg/controller/health_check_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/controller"
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -17,11 +17,11 @@ import (
 )
 
 type TestHealthCheckSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunHealthCheckSuite(t *testing.T) {
-	suite.Run(t, &TestHealthCheckSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestHealthCheckSuite{test.UnitTestSuite{}})
 }
 
 func (s *TestHealthCheckSuite) TestHealthCheckHandler() {

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -34,10 +34,8 @@ func (s *Signup) PostHandler(ctx *gin.Context) {
 
 	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey))
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{
-			"message": "Error creating UserSignup",
-			"error":   err,
-		})
+		log.Error(ctx, err, "error creating UserSignup resource")
+		errors.AbortWithError(ctx, http.StatusInternalServerError, err, "error creating UserSignup resource")
 		return
 	}
 

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -10,9 +10,8 @@ import (
 	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/context"
 	"github.com/codeready-toolchain/registration-service/pkg/controller"
-	errs "github.com/codeready-toolchain/registration-service/pkg/errors"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 	"github.com/gofrs/uuid"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,11 +23,11 @@ import (
 )
 
 type TestSignupSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunSignupSuite(t *testing.T) {
-	suite.Run(t, &TestSignupSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestSignupSuite{test.UnitTestSuite{}})
 }
 
 func (s *TestSignupSuite) TestSignupPostHandler() {
@@ -52,6 +51,12 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		rr := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(rr)
 		ctx.Request = req
+
+		// Put userID to the context
+		ob, err := uuid.NewV4()
+		require.NoError(s.T(), err)
+		expectedUserID := ob.String()
+		ctx.Set(context.SubKey, expectedUserID)
 
 		signup := &crtapi.UserSignup{
 			TypeMeta: v1.TypeMeta{},
@@ -77,6 +82,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		}
 
 		svc.MockCreateUserSignup = func(username, userID string) (*crtapi.UserSignup, error) {
+			assert.Equal(s.T(), expectedUserID, userID)
 			return signup, nil
 		}
 
@@ -98,8 +104,8 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 
 		handler(ctx)
 
-		// Check the status code is what we expect.
-		require.Equal(s.T(), http.StatusInternalServerError, rr.Code)
+		// Check the error is what we expect.
+		test.AssertError(s.T(), rr, http.StatusInternalServerError, "blah", "error creating UserSignup resource")
 	})
 }
 
@@ -187,20 +193,8 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 
 		handler(ctx)
 
-		// Check the status code is what we expect.
-		assert.Equal(s.T(), http.StatusInternalServerError, rr.Code, "handler returned wrong status code")
-
-		// Check the response body is what we expect.
-		data := &errs.Error{}
-		err := json.Unmarshal(rr.Body.Bytes(), &data)
-		require.NoError(s.T(), err)
-
-		assert.Equal(s.T(), &errs.Error{
-			Status:  http.StatusText(http.StatusInternalServerError),
-			Code:    http.StatusInternalServerError,
-			Message: "oopsie woopsie",
-			Details: "error getting UserSignup resource",
-		}, data)
+		// Check the error is what we expect.
+		test.AssertError(s.T(), rr, http.StatusInternalServerError, "oopsie woopsie", "error getting UserSignup resource")
 	})
 }
 

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	err "github.com/codeready-toolchain/registration-service/pkg/errors"
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -17,11 +17,11 @@ import (
 )
 
 type TestErrorsSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunErrorsSuite(t *testing.T) {
-	suite.Run(t, &TestErrorsSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestErrorsSuite{test.UnitTestSuite{}})
 }
 
 func (s *TestErrorsSuite) TestErrors() {

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -12,21 +12,21 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/controller"
 	"github.com/codeready-toolchain/registration-service/pkg/middleware"
 	"github.com/codeready-toolchain/registration-service/pkg/server"
-	testutils "github.com/codeready-toolchain/registration-service/test"
-	"github.com/dgrijalva/jwt-go"
-	uuid "github.com/satori/go.uuid"
+	"github.com/codeready-toolchain/registration-service/test"
 
+	"github.com/dgrijalva/jwt-go"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type TestAuthMiddlewareSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunAuthMiddlewareSuite(t *testing.T) {
-	suite.Run(t, &TestAuthMiddlewareSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestAuthMiddlewareSuite{test.UnitTestSuite{}})
 }
 
 func (s *TestAuthMiddlewareSuite) TestAuthMiddleware() {
@@ -40,17 +40,17 @@ func (s *TestAuthMiddlewareSuite) TestAuthMiddleware() {
 
 func (s *TestAuthMiddlewareSuite) TestAuthMiddlewareService() {
 	// create a TokenGenerator and a key
-	tokengenerator := testutils.NewTokenManager()
+	tokengenerator := test.NewTokenManager()
 	kid0 := uuid.NewV4().String()
 	_, err := tokengenerator.AddPrivateKey(kid0)
 	require.NoError(s.T(), err)
 
 	// create some test tokens
-	identity0 := testutils.Identity{
+	identity0 := test.Identity{
 		ID:       uuid.NewV4(),
 		Username: uuid.NewV4().String(),
 	}
-	emailClaim0 := testutils.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
+	emailClaim0 := test.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
 	// valid token
 	tokenValid, err := tokengenerator.GenerateSignedToken(identity0, kid0, emailClaim0)
 	require.NoError(s.T(), err)

--- a/pkg/server/routes_test.go
+++ b/pkg/server/routes_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/codeready-toolchain/registration-service/pkg/server"
 	"github.com/codeready-toolchain/registration-service/pkg/static"
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,11 +17,11 @@ import (
 )
 
 type TestRoutesSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunRoutesSuite(t *testing.T) {
-	suite.Run(t, &TestRoutesSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestRoutesSuite{test.UnitTestSuite{}})
 }
 
 func (s *TestRoutesSuite) TestStaticContent() {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -4,18 +4,18 @@ import (
 	"testing"
 
 	"github.com/codeready-toolchain/registration-service/pkg/server"
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type TestServerSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunServerSuite(t *testing.T) {
-	suite.Run(t, &TestServerSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestServerSuite{test.UnitTestSuite{}})
 }
 
 func (s *TestServerSuite) TestServer() {

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -11,8 +11,9 @@ import (
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
-	testutils "github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test"
 	"github.com/codeready-toolchain/registration-service/test/fake"
+
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -25,11 +26,11 @@ const (
 )
 
 type TestSignupServiceSuite struct {
-	testutils.UnitTestSuite
+	test.UnitTestSuite
 }
 
 func TestRunSignupServiceSuite(t *testing.T) {
-	suite.Run(t, &TestSignupServiceSuite{testutils.UnitTestSuite{}})
+	suite.Run(t, &TestSignupServiceSuite{test.UnitTestSuite{}})
 }
 
 func (s *TestSignupServiceSuite) TestNewSignupService() {

--- a/test/error.go
+++ b/test/error.go
@@ -1,0 +1,37 @@
+package test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/codeready-toolchain/registration-service/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AssertError asserts that the provided response contains the expected error
+func AssertError(t *testing.T, actualResponse *httptest.ResponseRecorder, expectedErrorCode int, expectedMessageAndDetails ...string) {
+	// Check the status code is what we expect.
+	assert.Equal(t, expectedErrorCode, actualResponse.Code, "handler returned wrong status code")
+
+	// Check the response body is what we expect.
+	data := &errors.Error{}
+	err := json.Unmarshal(actualResponse.Body.Bytes(), &data)
+	require.NoError(t, err)
+
+	var message, details string
+	if len(expectedMessageAndDetails) > 0 {
+		message = expectedMessageAndDetails[0]
+	}
+	if len(expectedMessageAndDetails) > 0 {
+		details = expectedMessageAndDetails[1]
+	}
+	assert.Equal(t, &errors.Error{
+		Status:  http.StatusText(expectedErrorCode),
+		Code:    expectedErrorCode,
+		Message: message,
+		Details: details,
+	}, data)
+}

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -1,4 +1,4 @@
-package testutils
+package test
 
 import (
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"

--- a/test/tokenmanager.go
+++ b/test/tokenmanager.go
@@ -1,4 +1,4 @@
-package testutils
+package test
 
 import (
 	"crypto/rand"

--- a/test/tokenmanager_test.go
+++ b/test/tokenmanager_test.go
@@ -1,4 +1,4 @@
-package testutils
+package test
 
 import (
 	"bytes"

--- a/test/unset_env_var_and_restore.go
+++ b/test/unset_env_var_and_restore.go
@@ -1,4 +1,4 @@
-package testutils
+package test
 
 import "os"
 
@@ -9,7 +9,7 @@ import "os"
 // In a test you can use this to temporarily set an environment variable:
 //
 //    func TestFoo(t *testing.T) {
-//        restoreFunc := testutils.UnsetEnvVarAndRestore("foo")
+//        restoreFunc := test.UnsetEnvVarAndRestore("foo")
 //        defer restoreFunc()
 //        os.Setenv(key, "bar")
 //

--- a/test/unset_env_var_and_restore_test.go
+++ b/test/unset_env_var_and_restore_test.go
@@ -1,4 +1,4 @@
-package testutils
+package test
 
 import (
 	"os"


### PR DESCRIPTION
Followup on https://github.com/codeready-toolchain/registration-service/pull/43#pullrequestreview-303521374

- Use AbortWithError() to handle errors in the controller
- More tests
- fixes `test` package (and this is why there are so many changes in the tests). The folder is `test` but we used `testutil` package. Now it's aligned.
- Introduces `test.AssertError()` for easier error checking in the http responses in the tests