### PR TITLE
Fix transformUserName()

### DIFF
--- a/deploy/deployment_dev.yaml
+++ b/deploy/deployment_dev.yaml
@@ -23,6 +23,11 @@ spec:
         command:
         - registration-service
         imagePullPolicy: IfNotPresent
+        env:
+          - name: REGISTRATION_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -13,6 +13,6 @@ rules:
 - apiGroups:
   - toolchain.dev.openshift.com
   resources:
-    - masteruserrecord
+    - masteruserrecords
   verbs:
     - get

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -91,7 +91,7 @@ const (
 
 	varNamespace = "namespace"
 	// DefaultNamespace is the default k8s namespace to use.
-	DefaultNamespace = ""
+	DefaultNamespace = "toolchain-host-operator"
 )
 
 // Registry encapsulates the Viper configuration registry which stores the

--- a/pkg/kubeclient/signup.go
+++ b/pkg/kubeclient/signup.go
@@ -27,6 +27,9 @@ func (c *userSignupClient) Get(name string) (*crtapi.UserSignup, error) {
 		Name(name).
 		Do().
 		Into(result)
+	if err != nil {
+		return nil, err
+	}
 	return result, err
 }
 
@@ -40,5 +43,8 @@ func (c *userSignupClient) Create(obj *crtapi.UserSignup) (*crtapi.UserSignup, e
 		Body(obj).
 		Do().
 		Into(result)
+	if err != nil {
+		return nil, err
+	}
 	return result, err
 }

--- a/pkg/kubeclient/signup.go
+++ b/pkg/kubeclient/signup.go
@@ -19,6 +19,7 @@ type UserSignupInterface interface {
 }
 
 // Get returns the UserSignup with the specified name, or an error if something went wrong while attempting to retrieve it
+// If not found then NotFound error returned
 func (c *userSignupClient) Get(name string) (*crtapi.UserSignup, error) {
 	result := &crtapi.UserSignup{}
 	err := c.client.Get().

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -166,24 +166,22 @@ func (s *ServiceImpl) transformAndValidateUserName(username string) (string, err
 
 	errs := validation.IsQualifiedName(replaced)
 	if len(errs) > 0 {
-		return "", errors2.New(fmt.Sprintf("Transformed username [%s] is invalid", username))
+		return "", errors2.Errorf("transformed username [%s] is invalid", username)
 	}
 
-	iteration := 0
 	transformed := replaced
 
-	for {
+	for i := 1; i < 1001; i++ { // No more than 1000 attempts to find a vacant name
 		_, err := s.UserSignups.Get(transformed)
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				return "", err
 			}
-			break
+			return transformed, nil
 		}
 
-		iteration++
-		transformed = fmt.Sprintf("%s-%d", replaced, iteration)
+		transformed = fmt.Sprintf("%s-%d", replaced, i)
 	}
 
-	return transformed, nil
+	return "", errors2.Errorf("unable to transform username [%s] even after 1000 attempts", username)
 }

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -173,14 +173,11 @@ func (s *ServiceImpl) transformAndValidateUserName(username string) (string, err
 	transformed := replaced
 
 	for {
-		userSignup, err := s.UserSignups.Get(transformed)
+		_, err := s.UserSignups.Get(transformed)
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				return "", err
 			}
-		}
-
-		if userSignup == nil {
 			break
 		}
 

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -72,6 +72,7 @@ func (s *TestSignupServiceSuite) TestUserSignupTransform() {
 			return userSignupToBeReturnedByClient, errToBeReturnedByClient
 		}
 		userID, err := uuid.NewV4()
+		require.NoError(s.T(), err)
 
 		userSignup, err := svc.CreateUserSignup("jane.doe@redhat.com", userID.String())
 		require.NoError(s.T(), err)
@@ -104,6 +105,7 @@ func (s *TestSignupServiceSuite) TestUserSignupTransform() {
 	s.Run("unable to transform after N attempts", func() {
 		svc, userSignupsClient, _ := newSignupServiceWithFakeClient()
 		userID, err := uuid.NewV4()
+		require.NoError(s.T(), err)
 		userSignupsClient.MockGet = func(s string) (*v1alpha1.UserSignup, error) {
 			return &v1alpha1.UserSignup{}, nil // Always return some UserSignup
 		}

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/test"
 	"github.com/codeready-toolchain/registration-service/test/fake"
+	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
@@ -62,29 +63,54 @@ func (s *TestSignupServiceSuite) TestCreateUserSignup() {
 }
 
 func (s *TestSignupServiceSuite) TestUserSignupTransform() {
-	svc, fakeClient, _ := newSignupServiceWithFakeClient()
-
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
+	check := func(userSignupToBeReturnedByClient *v1alpha1.UserSignup, errToBeReturnedByClient error) {
+		svc, userSignupsClient, _ := newSignupServiceWithFakeClient()
 
-	userSignup, err := svc.CreateUserSignup("jane.doe@redhat.com", userID.String())
-	require.NoError(s.T(), err)
-	require.NotNil(s.T(), userSignup)
+		userSignupsClient.MockGet = func(s string) (*v1alpha1.UserSignup, error) {
+			return userSignupToBeReturnedByClient, errToBeReturnedByClient
+		}
+		userID, err := uuid.NewV4()
 
-	gvk, err := apiutil.GVKForObject(userSignup, fakeClient.Scheme)
-	require.NoError(s.T(), err)
-	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+		userSignup, err := svc.CreateUserSignup("jane.doe@redhat.com", userID.String())
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), userSignup)
 
-	values, err := fakeClient.Tracker.List(gvr, gvk, TestNamespace)
-	require.NoError(s.T(), err)
+		gvk, err := apiutil.GVKForObject(userSignup, userSignupsClient.Scheme)
+		require.NoError(s.T(), err)
+		gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 
-	userSignups := values.(*v1alpha1.UserSignupList)
-	require.NotEmpty(s.T(), userSignups.Items)
-	require.Len(s.T(), userSignups.Items, 1)
+		values, err := userSignupsClient.Tracker.List(gvr, gvk, TestNamespace)
+		require.NoError(s.T(), err)
 
-	val := userSignups.Items[0]
-	require.Equal(s.T(), "jane-doe-at-redhat-com", val.Name)
-	require.Equal(s.T(), userID.String(), val.Spec.UserID)
+		userSignups := values.(*v1alpha1.UserSignupList)
+		require.NotEmpty(s.T(), userSignups.Items)
+		require.Len(s.T(), userSignups.Items, 1)
+
+		val := userSignups.Items[0]
+		require.Equal(s.T(), "jane-doe-at-redhat-com", val.Name)
+		require.Equal(s.T(), userID.String(), val.Spec.UserID)
+	}
+
+	s.Run("UserSignup not found and client returns nil", func() {
+		check(nil, kubeerr.NewNotFound(v1alpha1.SchemeGroupVersion.WithResource(userID.String()).GroupResource(), userID.String()))
+	})
+
+	s.Run("UserSignup not found and client returns empty UserSignup", func() {
+		check(&v1alpha1.UserSignup{}, kubeerr.NewNotFound(v1alpha1.SchemeGroupVersion.WithResource(userID.String()).GroupResource(), userID.String()))
+	})
+
+	s.Run("unable to transform after N attempts", func() {
+		svc, userSignupsClient, _ := newSignupServiceWithFakeClient()
+		userID, err := uuid.NewV4()
+		userSignupsClient.MockGet = func(s string) (*v1alpha1.UserSignup, error) {
+			return &v1alpha1.UserSignup{}, nil // Always return some UserSignup
+		}
+
+		_, err = svc.CreateUserSignup("jane.doe@redhat.com", userID.String())
+		require.EqualError(s.T(), err, "unable to transform username [jane.doe@redhat.com] even after 1000 attempts")
+	})
 }
 
 func (s *TestSignupServiceSuite) TestUserSignupInvalidName() {
@@ -94,7 +120,7 @@ func (s *TestSignupServiceSuite) TestUserSignupInvalidName() {
 	require.NoError(s.T(), err)
 
 	_, err = svc.CreateUserSignup("john#gmail.com", userID.String())
-	require.EqualError(s.T(), err, "Transformed username [john#gmail.com] is invalid")
+	require.EqualError(s.T(), err, "transformed username [john#gmail.com] is invalid")
 }
 
 func (s *TestSignupServiceSuite) TestUserSignupNameExists() {
@@ -118,7 +144,7 @@ func (s *TestSignupServiceSuite) TestUserSignupNameExists() {
 	created, err := svc.CreateUserSignup("john@gmail.com", userID.String())
 	require.NoError(s.T(), err)
 
-	require.NotEqual(s.T(), "john-at-gmail-com", created.Name)
+	require.Equal(s.T(), "john-at-gmail-com-1", created.Name)
 }
 
 func (s *TestSignupServiceSuite) TestUserSignupCreateFails() {


### PR DESCRIPTION
This PR fixes `transformAndValidateUserName()` function which didn't take into account that `s.UserSignups.Get(transformed)` never returned nil so it caused endless loop.

Also added a limit to username transformation attempts. It will fail after 1000 attempts. Just to avoid endless loops in case of some regression bugs in the future ;) 

And this PR fixes RBAC for the namespace that the reg-service is deployed to.