### PR TITLE
E2e registration service

### DIFF
--- a/pkg/auth/defaultmanager.go
+++ b/pkg/auth/defaultmanager.go
@@ -9,6 +9,8 @@ import (
 // that is used for configuring the default TokenParser.
 type DefaultTokenParserConfiguration interface {
 	GetAuthClientPublicKeysURL() string
+	IsE2ETestingMode() bool
+	GetE2EToken() string
 }
 
 var muKM sync.Mutex

--- a/pkg/auth/keymanager.go
+++ b/pkg/auth/keymanager.go
@@ -19,7 +19,7 @@ import (
 type KeyManagerConfiguration interface {
 	GetAuthClientPublicKeysURL() string
 	IsE2ETestingMode() bool
-    GetE2EToken() string
+	GetE2EToken() string
 }
 
 // PublicKey represents an RSA public key with a Key ID
@@ -53,14 +53,14 @@ func NewKeyManager(config KeyManagerConfiguration) (*KeyManager, error) {
 	// fetch raw keys
 	if keysEndpointURL != "" {
 		if config.IsE2ETestingMode() {
-            log.Infof(nil, "fetching public keys from config")
-            keys, err := km.fetchKeysFromBytes([]byte(config.GetE2EToken()))
-            if err != nil {
-                return nil, err
-            }
-            // add them to the kid map
-            for _, key := range keys {
-                km.keyMap[key.KeyID] = key.Key
+			log.Infof(nil, "fetching public keys from config")
+			keys, err := km.fetchKeysFromBytes([]byte(config.GetE2EToken()))
+			if err != nil {
+				return nil, err
+			}
+			// add them to the kid map
+			for _, key := range keys {
+				km.keyMap[key.KeyID] = key.Key
 			}
 		} else {
 			log.Infof(nil, "fetching public keys from url: %s", keysEndpointURL)

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -28,12 +28,26 @@ func TestRunKeyManagerSuite(t *testing.T) {
 func (s *TestKeyManagerSuite) TestKeyManager() {
 	// Set the config for testing mode, the handler may use this.
 	s.Config.GetViperInstance().Set("testingmode", true)
+	s.Config.GetViperInstance().Set("e2etestingmode", false)
 	assert.True(s.T(), s.Config.IsTestingMode(), "testing mode not set correctly to true")
 
 	s.Run("missing config", func() {
 		_, err := auth.NewKeyManager(nil)
 		require.Error(s.T(), err)
 		require.Equal(s.T(), "no config given when creating KeyManager", err.Error())
+	})
+}
+
+func (s *TestKeyManagerSuite) TestE2EKeyFetching() {
+	s.Config.GetViperInstance().Set("testingmode", true)
+	s.Config.GetViperInstance().Set("e2etestingmode", true)
+	s.Run("e2e testing mode", func() {
+		keyManager, err := auth.NewKeyManager(s.Config)
+		require.NoError(s.T(), err)
+
+		// check if the keys are parsed correctly
+		_, err = keyManager.Key("nBVBNiFNxSiX7Znyg4lUx89HQkV2gtJp11zTP6qLg-4")
+		require.NoError(s.T(), err)
 	})
 }
 
@@ -70,7 +84,9 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 
 	// Set the config for testing mode, the handler may use this.
 	s.Config.GetViperInstance().Set("testingmode", false)
+	s.Config.GetViperInstance().Set("e2etestingmode", false)
 	assert.False(s.T(), s.Config.IsTestingMode(), "testing mode not set correctly to false")
+	assert.False(s.T(), s.Config.IsTestingMode(), "e2etesting mode not set correctly to false")
 	// set the key service url in the config
 	s.Config.GetViperInstance().Set("auth_client.public_keys_url", keysEndpointURL)
 	assert.Equal(s.T(), keysEndpointURL, s.Config.GetAuthClientPublicKeysURL(), "key url not set correctly")

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -67,7 +67,7 @@ const (
 	DefaultTestingMode = false
 
 	varE2ETestingMode = "e2etestingmode"
-	// DefaultE2ETestingMode specifies whether the services should run in testing mode.
+	// DefaultE2ETestingMode specifies whether the services should run in e2e testing mode.
 	DefaultE2ETestingMode = false
 
 	varAuthClientLibraryURL = "auth_client.library_url"
@@ -209,7 +209,7 @@ func (c *Registry) IsTestingMode() bool {
 	return c.v.GetBool(varTestingMode)
 }
 
-// IsE2ETestingMode returns if the service should run in testing mode (as set via
+// IsE2ETestingMode returns if the service should run in e2e testing mode (as set via
 // config file or environment variable).
 func (c *Registry) IsE2ETestingMode() bool {
 	return c.v.GetBool(varE2ETestingMode)
@@ -244,6 +244,7 @@ func (c *Registry) GetNamespace() string {
 	return c.v.GetString(varNamespace)
 }
 
-func (c *Registry) GetE2EToken() string {
+// Returns a hard-coded jwk for e2e tests to be used by the keymanager
+func (c *Registry) GetE2EJWK() string {
 	return `{"keys":[{"kid":"nBVBNiFNxSiX7Znyg4lUx89HQkV2gtJp11zTP6qLg-4","kty":"RSA","alg":"RS256","use":"sig","n":"i04yxaQb7e1-tfcDoXe8K2DZ-rJ2yVVjBoT9Tw0jOout5w84x2_r5t_4aCBQjo9IO7UVWTtvE0cOk1WtykXvso7iYh9ry9jsZtrJNS0QXykcOJZJLVxyh1uatrbpM5heKYNz5fs5hp-3Qh5XkyCkLigIkOoLMXO1tLkNvjiEdR1zslqEOXaqWsp6HlUcu1JOuEv1LsxFuCnKc9ZvZDm0mQQJiOAl1QRvSU3pgX3IjuoefY6-6NQAYm1MQjOzWSnNkQTTEIWgIRu8QVgxko50pR3fTC7LWj6AQCv5GkW1r5zIv9OSzjoiN8A_UHASWh0Z6oy0eLeY775EhVfrg_KjYw","e":"AQAB","x5c":["MIICoTCCAYkCBgFtIFN1nTANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAlkZW1vUmVhbG0wHhcNMTkwOTExMTIzNTAzWhcNMjkwOTExMTIzNjQzWjAUMRIwEAYDVQQDDAlkZW1vUmVhbG0wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCLTjLFpBvt7X619wOhd7wrYNn6snbJVWMGhP1PDSM6i63nDzjHb+vm3/hoIFCOj0g7tRVZO28TRw6TVa3KRe+yjuJiH2vL2Oxm2sk1LRBfKRw4lkktXHKHW5q2tukzmF4pg3Pl+zmGn7dCHleTIKQuKAiQ6gsxc7W0uQ2+OIR1HXOyWoQ5dqpaynoeVRy7Uk64S/UuzEW4Kcpz1m9kObSZBAmI4CXVBG9JTemBfciO6h59jr7o1ABibUxCM7NZKc2RBNMQhaAhG7xBWDGSjnSlHd9MLstaPoBAK/kaRbWvnMi/05LOOiI3wD9QcBJaHRnqjLR4t5jvvkSFV+uD8qNjAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADGGFneSXwWrT4Yk4PMcY14gfc6ta91Qz5xZDWiPz0ZaX1ULLEOu4k/rIKwN7tCMxBxCgnxaMj372JvAPAUqwLmRhvDxtcJDYHQwM77NqU3ZQARchqyDsd5aYW6cYFMF8D60PdFOgMRKJiRGpRbJgPt7+hFdbEw2XnWN9lnzXmbeXxCn7GZKZiKmWZU3eBa/pQVCjTb4JICs+1uBJj0VfgLNYHUbZXdvg4ismSEqXnBKX/V3lPJQWXU/yyMS6G9lHGcAisxWIthcA8C6gWUaJe1FwJrCeqDIJDABw72VAYvUaIf0pBVyXtr8A2JrBD9jdb8KOyC//X+LLiXqD1fpltw="],"x5t":"l_5tiA15SUVfBXx18njAbbs3wds","x5t#S256":"T8ef_9jOHIlDQVYCJOXPtyOkoRF-e8eJtyh7pswQclg"}]}`
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -245,42 +245,5 @@ func (c *Registry) GetNamespace() string {
 }
 
 func (c *Registry) GetE2EToken() string {
-	return `{
-            "keys": [{
-                "kid": "nBVBNiFNxSiX7Znyg4lUx89HQkV2gtJp11zTP6qLg-4",
-                "kty": "RSA",
-                "alg": "RS256",
-                "use": "sig",
-                "n": "i04yxaQb7e1-tfcDoXe8K2DZ-rJ2yVVjBoT9Tw0jOout5"+
-                "w84x2_r5t_4aCBQjo9IO7UVWTtvE0cOk1WtykXvso7iYh9ry9j"+
-                "sZtrJNS0QXykcOJZJLVxyh1uatrbpM5heKYNz5fs5hp-3Qh5Xk"+
-                "yCkLigIkOoLMXO1tLkNvjiEdR1zslqEOXaqWsp6HlUcu1JOuEv"+
-                "1LsxFuCnKc9ZvZDm0mQQJiOAl1QRvSU3pgX3IjuoefY6-6NQAY"+
-                "m1MQjOzWSnNkQTTEIWgIRu8QVgxko50pR3fTC7LWj6AQCv5GkW"+
-                "1r5zIv9OSzjoiN8A_UHASWh0Z6oy0eLeY775EhVfrg_KjYw",
-                "e": "AQAB",
-                "x5c": [
-                "MIICoTCCAYkCBgFtIFN1nTANBgkqhkiG9w0BAQsFADAUMRIwEA"+
-                "YDVQQDDAlkZW1vUmVhbG0wHhcNMTkwOTExMTIzNTAzWhcNMjkw"+
-                "OTExMTIzNjQzWjAUMRIwEAYDVQQDDAlkZW1vUmVhbG0wggEiMA"+
-                "0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCLTjLFpBvt7X61"+
-                "9wOhd7wrYNn6snbJVWMGhP1PDSM6i63nDzjHb+vm3/hoIFCOj0"+
-                "g7tRVZO28TRw6TVa3KRe+yjuJiH2vL2Oxm2sk1LRBfKRw4lkkt"+
-                "XHKHW5q2tukzmF4pg3Pl+zmGn7dCHleTIKQuKAiQ6gsxc7W0uQ"+
-                "2+OIR1HXOyWoQ5dqpaynoeVRy7Uk64S/UuzEW4Kcpz1m9kObSZ"+
-                "BAmI4CXVBG9JTemBfciO6h59jr7o1ABibUxCM7NZKc2RBNMQha"+
-                "AhG7xBWDGSjnSlHd9MLstaPoBAK/kaRbWvnMi/05LOOiI3wD9Q"+
-                "cBJaHRnqjLR4t5jvvkSFV+uD8qNjAgMBAAEwDQYJKoZIhvcNAQ"+
-                "ELBQADggEBADGGFneSXwWrT4Yk4PMcY14gfc6ta91Qz5xZDWiP"+
-                "z0ZaX1ULLEOu4k/rIKwN7tCMxBxCgnxaMj372JvAPAUqwLmRhv"+
-                "DxtcJDYHQwM77NqU3ZQARchqyDsd5aYW6cYFMF8D60PdFOgMRK"+
-                "JiRGpRbJgPt7+hFdbEw2XnWN9lnzXmbeXxCn7GZKZiKmWZU3eB"+
-                "a/pQVCjTb4JICs+1uBJj0VfgLNYHUbZXdvg4ismSEqXnBKX/V3"+
-                "lPJQWXU/yyMS6G9lHGcAisxWIthcA8C6gWUaJe1FwJrCeqDIJD"+
-                "ABw72VAYvUaIf0pBVyXtr8A2JrBD9jdb8KOyC//X+LLiXqD1fpltw="
-                ],
-                "x5t": "l_5tiA15SUVfBXx18njAbbs3wds",
-                "x5t#S256": "T8ef_9jOHIlDQVYCJOXPtyOkoRF-e8eJtyh7pswQclg"
-            }]
-        }`
+	return `{"keys":[{"kid":"nBVBNiFNxSiX7Znyg4lUx89HQkV2gtJp11zTP6qLg-4","kty":"RSA","alg":"RS256","use":"sig","n":"i04yxaQb7e1-tfcDoXe8K2DZ-rJ2yVVjBoT9Tw0jOout5w84x2_r5t_4aCBQjo9IO7UVWTtvE0cOk1WtykXvso7iYh9ry9jsZtrJNS0QXykcOJZJLVxyh1uatrbpM5heKYNz5fs5hp-3Qh5XkyCkLigIkOoLMXO1tLkNvjiEdR1zslqEOXaqWsp6HlUcu1JOuEv1LsxFuCnKc9ZvZDm0mQQJiOAl1QRvSU3pgX3IjuoefY6-6NQAYm1MQjOzWSnNkQTTEIWgIRu8QVgxko50pR3fTC7LWj6AQCv5GkW1r5zIv9OSzjoiN8A_UHASWh0Z6oy0eLeY775EhVfrg_KjYw","e":"AQAB","x5c":["MIICoTCCAYkCBgFtIFN1nTANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAlkZW1vUmVhbG0wHhcNMTkwOTExMTIzNTAzWhcNMjkwOTExMTIzNjQzWjAUMRIwEAYDVQQDDAlkZW1vUmVhbG0wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCLTjLFpBvt7X619wOhd7wrYNn6snbJVWMGhP1PDSM6i63nDzjHb+vm3/hoIFCOj0g7tRVZO28TRw6TVa3KRe+yjuJiH2vL2Oxm2sk1LRBfKRw4lkktXHKHW5q2tukzmF4pg3Pl+zmGn7dCHleTIKQuKAiQ6gsxc7W0uQ2+OIR1HXOyWoQ5dqpaynoeVRy7Uk64S/UuzEW4Kcpz1m9kObSZBAmI4CXVBG9JTemBfciO6h59jr7o1ABibUxCM7NZKc2RBNMQhaAhG7xBWDGSjnSlHd9MLstaPoBAK/kaRbWvnMi/05LOOiI3wD9QcBJaHRnqjLR4t5jvvkSFV+uD8qNjAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADGGFneSXwWrT4Yk4PMcY14gfc6ta91Qz5xZDWiPz0ZaX1ULLEOu4k/rIKwN7tCMxBxCgnxaMj372JvAPAUqwLmRhvDxtcJDYHQwM77NqU3ZQARchqyDsd5aYW6cYFMF8D60PdFOgMRKJiRGpRbJgPt7+hFdbEw2XnWN9lnzXmbeXxCn7GZKZiKmWZU3eBa/pQVCjTb4JICs+1uBJj0VfgLNYHUbZXdvg4ismSEqXnBKX/V3lPJQWXU/yyMS6G9lHGcAisxWIthcA8C6gWUaJe1FwJrCeqDIJDABw72VAYvUaIf0pBVyXtr8A2JrBD9jdb8KOyC//X+LLiXqD1fpltw="],"x5t":"l_5tiA15SUVfBXx18njAbbs3wds","x5t#S256":"T8ef_9jOHIlDQVYCJOXPtyOkoRF-e8eJtyh7pswQclg"}]}`
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -66,6 +66,10 @@ const (
 	// DefaultTestingMode specifies whether the services should run in testing mode.
 	DefaultTestingMode = false
 
+	varE2ETestingMode = "e2etestingmode"
+	// DefaultE2ETestingMode specifies whether the services should run in testing mode.
+	DefaultE2ETestingMode = false
+
 	varAuthClientLibraryURL = "auth_client.library_url"
 	// DefaultAuthClientLibraryURL is the default auth library location.
 	DefaultAuthClientLibraryURL = "https://sso.prod-preview.openshift.io/auth/js/keycloak.js"
@@ -146,6 +150,7 @@ func (c *Registry) setConfigDefaults() {
 	c.v.SetDefault(varLogJSON, DefaultLogJSON)
 	c.v.SetDefault(varGracefulTimeout, DefaultGracefulTimeout)
 	c.v.SetDefault(varTestingMode, DefaultTestingMode)
+	c.v.SetDefault(varE2ETestingMode, DefaultE2ETestingMode)
 	c.v.SetDefault(varAuthClientLibraryURL, DefaultAuthClientLibraryURL)
 	c.v.SetDefault(varAuthClientConfigRaw, DefaultAuthClientConfigRaw)
 	c.v.SetDefault(varAuthClientConfigContentType, DefaultAuthClientConfigContentType)
@@ -204,6 +209,12 @@ func (c *Registry) IsTestingMode() bool {
 	return c.v.GetBool(varTestingMode)
 }
 
+// IsE2ETestingMode returns if the service should run in testing mode (as set via
+// config file or environment variable).
+func (c *Registry) IsE2ETestingMode() bool {
+	return c.v.GetBool(varE2ETestingMode)
+}
+
 // GetAuthClientLibraryURL returns the auth library location (as set via
 // config file or environment variable).
 func (c *Registry) GetAuthClientLibraryURL() string {
@@ -231,4 +242,45 @@ func (c *Registry) GetAuthClientPublicKeysURL() string {
 // GetNamespace returns the namespace in which the registration service and host operator is running
 func (c *Registry) GetNamespace() string {
 	return c.v.GetString(varNamespace)
+}
+
+func (c *Registry) GetE2EToken() string {
+	return `{
+            "keys": [{
+                "kid": "nBVBNiFNxSiX7Znyg4lUx89HQkV2gtJp11zTP6qLg-4",
+                "kty": "RSA",
+                "alg": "RS256",
+                "use": "sig",
+                "n": "i04yxaQb7e1-tfcDoXe8K2DZ-rJ2yVVjBoT9Tw0jOout5"+
+                "w84x2_r5t_4aCBQjo9IO7UVWTtvE0cOk1WtykXvso7iYh9ry9j"+
+                "sZtrJNS0QXykcOJZJLVxyh1uatrbpM5heKYNz5fs5hp-3Qh5Xk"+
+                "yCkLigIkOoLMXO1tLkNvjiEdR1zslqEOXaqWsp6HlUcu1JOuEv"+
+                "1LsxFuCnKc9ZvZDm0mQQJiOAl1QRvSU3pgX3IjuoefY6-6NQAY"+
+                "m1MQjOzWSnNkQTTEIWgIRu8QVgxko50pR3fTC7LWj6AQCv5GkW"+
+                "1r5zIv9OSzjoiN8A_UHASWh0Z6oy0eLeY775EhVfrg_KjYw",
+                "e": "AQAB",
+                "x5c": [
+                "MIICoTCCAYkCBgFtIFN1nTANBgkqhkiG9w0BAQsFADAUMRIwEA"+
+                "YDVQQDDAlkZW1vUmVhbG0wHhcNMTkwOTExMTIzNTAzWhcNMjkw"+
+                "OTExMTIzNjQzWjAUMRIwEAYDVQQDDAlkZW1vUmVhbG0wggEiMA"+
+                "0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCLTjLFpBvt7X61"+
+                "9wOhd7wrYNn6snbJVWMGhP1PDSM6i63nDzjHb+vm3/hoIFCOj0"+
+                "g7tRVZO28TRw6TVa3KRe+yjuJiH2vL2Oxm2sk1LRBfKRw4lkkt"+
+                "XHKHW5q2tukzmF4pg3Pl+zmGn7dCHleTIKQuKAiQ6gsxc7W0uQ"+
+                "2+OIR1HXOyWoQ5dqpaynoeVRy7Uk64S/UuzEW4Kcpz1m9kObSZ"+
+                "BAmI4CXVBG9JTemBfciO6h59jr7o1ABibUxCM7NZKc2RBNMQha"+
+                "AhG7xBWDGSjnSlHd9MLstaPoBAK/kaRbWvnMi/05LOOiI3wD9Q"+
+                "cBJaHRnqjLR4t5jvvkSFV+uD8qNjAgMBAAEwDQYJKoZIhvcNAQ"+
+                "ELBQADggEBADGGFneSXwWrT4Yk4PMcY14gfc6ta91Qz5xZDWiP"+
+                "z0ZaX1ULLEOu4k/rIKwN7tCMxBxCgnxaMj372JvAPAUqwLmRhv"+
+                "DxtcJDYHQwM77NqU3ZQARchqyDsd5aYW6cYFMF8D60PdFOgMRK"+
+                "JiRGpRbJgPt7+hFdbEw2XnWN9lnzXmbeXxCn7GZKZiKmWZU3eB"+
+                "a/pQVCjTb4JICs+1uBJj0VfgLNYHUbZXdvg4ismSEqXnBKX/V3"+
+                "lPJQWXU/yyMS6G9lHGcAisxWIthcA8C6gWUaJe1FwJrCeqDIJD"+
+                "ABw72VAYvUaIf0pBVyXtr8A2JrBD9jdb8KOyC//X+LLiXqD1fpltw="
+                ],
+                "x5t": "l_5tiA15SUVfBXx18njAbbs3wds",
+                "x5t#S256": "T8ef_9jOHIlDQVYCJOXPtyOkoRF-e8eJtyh7pswQclg"
+            }]
+        }`
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -313,6 +313,34 @@ func (s *TestConfigurationSuite) TestIsTestingMode() {
 	})
 }
 
+func (s *TestConfigurationSuite) TestIsE2ETestingMode() {
+	key := configuration.EnvPrefix + "_" + "E2ETESTINGMODE"
+	resetFunc := test.UnsetEnvVarAndRestore(key)
+	defer resetFunc()
+
+	s.Run("default", func() {
+		resetFunc := test.UnsetEnvVarAndRestore(key)
+		defer resetFunc()
+		config := s.getDefaultConfiguration()
+		assert.Equal(s.T(), configuration.DefaultE2ETestingMode, config.IsE2ETestingMode())
+	})
+
+	s.Run("file", func() {
+		resetFunc := test.UnsetEnvVarAndRestore(key)
+		defer resetFunc()
+		newVal := !configuration.DefaultE2ETestingMode
+		config := s.getFileConfiguration(`e2etestingmode: "` + strconv.FormatBool(newVal) + `"`)
+		assert.Equal(s.T(), newVal, config.IsE2ETestingMode())
+	})
+
+	s.Run("env overwrite", func() {
+		newVal := !configuration.DefaultE2ETestingMode
+		os.Setenv(key, strconv.FormatBool(newVal))
+		config := s.getDefaultConfiguration()
+		assert.Equal(s.T(), newVal, config.IsE2ETestingMode())
+	})
+}
+
 func (s *TestConfigurationSuite) TestGetAuthClientConfigRaw() {
 	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW"
 


### PR DESCRIPTION
Adding the e2etestingmode variable and using it in keymanager. 

This will override fetching keys from the given url and use the keys hard-coded in the configuration file. 