### PR TITLE
redirect to https at the OpenShift route(r) level

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -91,6 +91,8 @@ objects:
   - kind: Route
     apiVersion: v1
     metadata:
+      annotations:
+        haproxy.router.openshift.io/hsts_header: max-age=31536000
       labels:
         run: registration-service
       name: registration-service


### PR DESCRIPTION
see docs on https://docs.openshift.com/container-platform/4.1/networking/routes/route-configuration.html#nw-enabling-hsts_route-configuration

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>