### PR TITLE
Adding usersignups email

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/ugorji/go/codec v1.1.7 // indirect
+	github.com/ugorji/go v1.1.7 // indirect
 	golang.org/x/crypto v0.0.0-20190926114937-fa1a29108794 // indirect
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
 	golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/ugorji/go v1.1.7 // indirect
+	github.com/ugorji/go/codec v1.1.7 // indirect
 	golang.org/x/crypto v0.0.0-20190926114937-fa1a29108794 // indirect
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
 	golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0
+	github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.10.0+incompatible // indirect
@@ -27,10 +27,12 @@ require (
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/satori/go.uuid v1.2.0
+	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
+	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/ugorji/go/codec v1.1.7 // indirect
+	github.com/ugorji/go v1.1.7 // indirect
 	golang.org/x/crypto v0.0.0-20190926114937-fa1a29108794 // indirect
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
 	golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,12 +27,10 @@ require (
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/satori/go.uuid v1.2.0
-	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
-	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/ugorji/go v1.1.7 // indirect
+	github.com/ugorji/go/codec v1.1.7 // indirect
 	golang.org/x/crypto v0.0.0-20190926114937-fa1a29108794 // indirect
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
 	golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,9 @@ github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1/go.mod h1:/iP1
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 h1:SKI1/fuSdodxmNNyVBR8d7X/HuLnRpvvFO0AgyQk764=
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgkuj+NQRlZcDbAbM1ORAbXjXX77sX7T289U=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0 h1:APb57ts/dN2/vJb+9Fjc5I3QpOx/OBWzObGKj6zdPPU=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
+github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396 h1:OTMOZninxzV2p2gTfyF825h4rUNb8rBQ5JwvPOVN1nk=
+github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7 h1:F8dyoI19Xp+eScSlmUYy2aLCe0dh2DTwk0FaAqFWpqE=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7/go.mod h1:c5EL9bEskD3ViC/ma1OhyIWNdGQMu+0K2nhGs+vfb9M=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -485,6 +486,8 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
+github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/go.sum
+++ b/go.sum
@@ -486,8 +486,6 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
-github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/auth/tokenparser_test.go
+++ b/pkg/auth/tokenparser_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/codeready-toolchain/registration-service/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 
-	"github.com/dgrijalva/jwt-go"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -166,7 +165,8 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 		// generate non-serialized token
 		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, authsupport.WithEmailClaim(email0))
 		// delete preferred_username
-		delete(jwt0.Claims.(jwt.MapClaims), "preferred_username")
+		jwt0.Claims.(*authsupport.MyClaims).PreferredUsername = ""
+
 		// serialize
 		jwt0string, err := tokengenerator.SignToken(jwt0, kid0)
 		require.NoError(s.T(), err)
@@ -201,9 +201,8 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 		}
 		email0 := identity0.Username + "@email.tld"
 		// generate non-serialized token
-		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, authsupport.WithEmailClaim(email0))
-		// delete preferred_username
-		delete(jwt0.Claims.(jwt.MapClaims), "sub")
+		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, authsupport.WithEmailClaim(email0), authsupport.WithSubClaim(""))
+
 		// serialize
 		jwt0string, err := tokengenerator.SignToken(jwt0, kid0)
 		require.NoError(s.T(), err)
@@ -220,11 +219,12 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
+		expTime := time.Now().Add(-60 * time.Second)
+		expClaim := authsupport.WithExpClaim(expTime)
+
 		// generate non-serialized token
-		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, authsupport.WithEmailClaim(email0))
-		// manipulate expiry
-		tDiff := -60 * time.Second
-		jwt0.Claims.(jwt.MapClaims)["exp"] = time.Now().UTC().Add(tDiff).Unix()
+		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, authsupport.WithEmailClaim(email0), expClaim)
+
 		// serialize
 		jwt0string, err := tokengenerator.SignToken(jwt0, kid0)
 		require.NoError(s.T(), err)
@@ -241,11 +241,12 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
+
+		nbfTime := time.Now().Add(60 * time.Second)
+		nbfClaim := authsupport.WithNotBeforeClaim(nbfTime)
 		// generate non-serialized token
-		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, authsupport.WithEmailClaim(email0))
-		// manipulate expiry
-		tDiff := 60 * time.Second
-		jwt0.Claims.(jwt.MapClaims)["nbf"] = time.Now().UTC().Add(tDiff).Unix()
+		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, authsupport.WithEmailClaim(email0), nbfClaim)
+
 		// serialize
 		jwt0string, err := tokengenerator.SignToken(jwt0, kid0)
 		require.NoError(s.T(), err)

--- a/pkg/auth/tokenparser_test.go
+++ b/pkg/auth/tokenparser_test.go
@@ -166,6 +166,7 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, authsupport.WithEmailClaim(email0))
 		// delete preferred_username
 		jwt0.Claims.(*authsupport.MyClaims).PreferredUsername = ""
+
 		// serialize
 		jwt0string, err := tokengenerator.SignToken(jwt0, kid0)
 		require.NoError(s.T(), err)
@@ -220,6 +221,7 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 		email0 := identity0.Username + "@email.tld"
 		expTime := time.Now().Add(-60 * time.Second)
 		expClaim := authsupport.WithExpClaim(expTime)
+
 		// generate non-serialized token
 		jwt0 := tokengenerator.GenerateToken(*identity0, kid0, authsupport.WithEmailClaim(email0), expClaim)
 
@@ -239,6 +241,7 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
+
 		nbfTime := time.Now().Add(60 * time.Second)
 		nbfClaim := authsupport.WithNotBeforeClaim(nbfTime)
 		// generate non-serialized token

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -8,7 +8,6 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/errors"
 	"github.com/codeready-toolchain/registration-service/pkg/log"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
-	"github.com/codeready-toolchain/toolchain-common/pkg/toolchain"
 
 	"github.com/gin-gonic/gin"
 )
@@ -29,8 +28,7 @@ func NewSignup(config *configuration.Registry, signupService signup.Service) *Si
 
 // PostHandler creates a Signup resource
 func (s *Signup) PostHandler(ctx *gin.Context) {
-	compliantEmailLabel := toolchain.ToValidValue(ctx.GetString(context.EmailKey))
-	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey), compliantEmailLabel)
+	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey), ctx.GetString(context.EmailKey))
 	if err != nil {
 		log.Error(ctx, err, "error creating UserSignup resource")
 		errors.AbortWithError(ctx, http.StatusInternalServerError, err, "error creating UserSignup resource")

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/errors"
 	"github.com/codeready-toolchain/registration-service/pkg/log"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
+	"github.com/codeready-toolchain/toolchain-common/pkg/toolchain"
 
 	"github.com/gin-gonic/gin"
 )
@@ -28,7 +29,8 @@ func NewSignup(config *configuration.Registry, signupService signup.Service) *Si
 
 // PostHandler creates a Signup resource
 func (s *Signup) PostHandler(ctx *gin.Context) {
-	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey), ctx.GetString(context.EmailKey))
+	compliantEmailLabel := toolchain.ToValidValue(ctx.GetString(context.EmailKey))
+	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey), compliantEmailLabel)
 	if err != nil {
 		log.Error(ctx, err, "error creating UserSignup resource")
 		errors.AbortWithError(ctx, http.StatusInternalServerError, err, "error creating UserSignup resource")

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -28,7 +28,7 @@ func NewSignup(config *configuration.Registry, signupService signup.Service) *Si
 
 // PostHandler creates a Signup resource
 func (s *Signup) PostHandler(ctx *gin.Context) {
-	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey))
+	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey), ctx.GetString(context.EmailKey))
 	if err != nil {
 		log.Error(ctx, err, "error creating UserSignup resource")
 		errors.AbortWithError(ctx, http.StatusInternalServerError, err, "error creating UserSignup resource")

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/controller"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/test"
-	"github.com/codeready-toolchain/toolchain-common/pkg/toolchain"
 	"github.com/gofrs/uuid"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +62,6 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		ctx.Set(context.SubKey, expectedUserID)
 
 		ctx.Set(context.EmailKey, expectedUserID+"@test.com")
-		compliantEmailLabel := toolchain.ToValidValue(ctx.GetString(context.EmailKey))
 
 		signup := &crtapi.UserSignup{
 			TypeMeta: v1.TypeMeta{},
@@ -71,7 +69,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 				Name:      userID.String(),
 				Namespace: "namespace-foo",
 				Annotations: map[string]string{
-					crtapi.UserSignupUserEmailLabelKey: compliantEmailLabel,
+					crtapi.UserSignupUserEmailLabelKey: ctx.GetString(context.EmailKey),
 				},
 			},
 			Spec: crtapi.UserSignupSpec{
@@ -90,7 +88,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		}
 
 		svc.MockCreateUserSignup = func(username, userID, email string) (*crtapi.UserSignup, error) {
-			assert.Equal(s.T(), expectedUserID, userID, compliantEmailLabel)
+			assert.Equal(s.T(), expectedUserID, userID, expectedUserID+"@test.com")
 			return signup, nil
 		}
 

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -89,7 +89,8 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		}
 
 		svc.MockCreateUserSignup = func(username, userID, email string) (*crtapi.UserSignup, error) {
-			assert.Equal(s.T(), expectedUserID, userID, email)
+			assert.Equal(s.T(), expectedUserID, userID)
+			assert.Equal(s.T(), expectedEmail, email)
 			return signup, nil
 		}
 

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -69,7 +69,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 				Name:      userID.String(),
 				Namespace: "namespace-foo",
 				Annotations: map[string]string{
-					"toolchain.dev.openshift.com/user-email": ctx.GetString(context.EmailKey),
+					crtapi.UserSignupUserEmailLabelKey: ctx.GetString(context.EmailKey),
 				},
 			},
 			Spec: crtapi.UserSignupSpec{

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/controller"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/test"
-	"github.com/codeready-toolchain/toolchain-common/pkg/toolchain"
+
 	"github.com/gofrs/uuid"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,15 +63,14 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		ctx.Set(context.SubKey, expectedUserID)
 
 		ctx.Set(context.EmailKey, expectedUserID+"@test.com")
-		compliantEmailLabel := toolchain.ToValidValue(ctx.GetString(context.EmailKey))
-
+		email := ctx.GetString(context.EmailKey)
 		signup := &crtapi.UserSignup{
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      userID.String(),
 				Namespace: "namespace-foo",
 				Annotations: map[string]string{
-					crtapi.UserSignupUserEmailLabelKey: compliantEmailLabel,
+					crtapi.UserSignupUserEmailLabelKey: email,
 				},
 			},
 			Spec: crtapi.UserSignupSpec{
@@ -90,7 +89,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		}
 
 		svc.MockCreateUserSignup = func(username, userID, email string) (*crtapi.UserSignup, error) {
-			assert.Equal(s.T(), expectedUserID, userID, compliantEmailLabel)
+			assert.Equal(s.T(), expectedUserID, userID, email)
 			return signup, nil
 		}
 

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -90,7 +90,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 
 		svc.MockCreateUserSignup = func(username, userID, email string) (*crtapi.UserSignup, error) {
 			assert.Equal(s.T(), expectedUserID, userID)
-			assert.Equal(s.T(), expectedEmail, email)
+			assert.Equal(s.T(), expectedUserID+"@test.com", email)
 			return signup, nil
 		}
 

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -70,7 +70,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 				Name:      userID.String(),
 				Namespace: "namespace-foo",
 				Annotations: map[string]string{
-					crtapi.UserSignupUserEmailLabelKey: email,
+					crtapi.UserSignupUserEmailAnnotationKey: email,
 				},
 			},
 			Spec: crtapi.UserSignupSpec{

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/controller"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/toolchain-common/pkg/toolchain"
 	"github.com/gofrs/uuid"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		ctx.Set(context.SubKey, expectedUserID)
 
 		ctx.Set(context.EmailKey, expectedUserID+"@test.com")
+		compliantEmailLabel := toolchain.ToValidValue(ctx.GetString(context.EmailKey))
 
 		signup := &crtapi.UserSignup{
 			TypeMeta: v1.TypeMeta{},
@@ -69,7 +71,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 				Name:      userID.String(),
 				Namespace: "namespace-foo",
 				Annotations: map[string]string{
-					crtapi.UserSignupUserEmailLabelKey: ctx.GetString(context.EmailKey),
+					crtapi.UserSignupUserEmailLabelKey: compliantEmailLabel,
 				},
 			},
 			Spec: crtapi.UserSignupSpec{
@@ -88,7 +90,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		}
 
 		svc.MockCreateUserSignup = func(username, userID, email string) (*crtapi.UserSignup, error) {
-			assert.Equal(s.T(), expectedUserID, userID, expectedUserID+"@test.com")
+			assert.Equal(s.T(), expectedUserID, userID, compliantEmailLabel)
 			return signup, nil
 		}
 

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -90,7 +90,7 @@ func (s *ServiceImpl) CreateUserSignup(username, userID, userEmail string) (*crt
 			Name:      userID,
 			Namespace: s.Namespace,
 			Annotations: map[string]string{
-				crtapi.UserSignupUserEmailLabelKey: userEmail,
+				crtapi.UserSignupUserEmailAnnotationKey: userEmail,
 			},
 		},
 		Spec: crtapi.UserSignupSpec{

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -52,7 +52,7 @@ type ServiceConfiguration interface {
 // Service represents the signup service for controllers.
 type Service interface {
 	GetSignup(userID string) (*Signup, error)
-	CreateUserSignup(username, userID string) (*crtapi.UserSignup, error)
+	CreateUserSignup(username, userID, userEmail string) (*crtapi.UserSignup, error)
 }
 
 // ServiceImpl represents the implementation of the signup service.
@@ -84,13 +84,13 @@ func NewSignupService(cfg ServiceConfiguration) (Service, error) {
 }
 
 // CreateUserSignup creates a new UserSignup resource with the specified username and userID
-func (s *ServiceImpl) CreateUserSignup(username, userID string) (*crtapi.UserSignup, error) {
+func (s *ServiceImpl) CreateUserSignup(username, userID, userEmail string) (*crtapi.UserSignup, error) {
 	userSignup := &crtapi.UserSignup{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID,
 			Namespace: s.Namespace,
 			Annotations: map[string]string{
-				"Email": "tk@redhat.com",
+				"toolchain.dev.openshift.com/user-email": userEmail,
 			},
 		},
 		Spec: crtapi.UserSignupSpec{

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -90,7 +90,7 @@ func (s *ServiceImpl) CreateUserSignup(username, userID, userEmail string) (*crt
 			Name:      userID,
 			Namespace: s.Namespace,
 			Annotations: map[string]string{
-				"toolchain.dev.openshift.com/user-email": userEmail,
+				crtapi.UserSignupUserEmailLabelKey: userEmail,
 			},
 		},
 		Spec: crtapi.UserSignupSpec{

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -89,6 +89,9 @@ func (s *ServiceImpl) CreateUserSignup(username, userID string) (*crtapi.UserSig
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID,
 			Namespace: s.Namespace,
+			Annotations: map[string]string{
+				"Email": "tk@redhat.com",
+			},
 		},
 		Spec: crtapi.UserSignupSpec{
 			TargetCluster: "",

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -71,7 +71,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				"toolchain.dev.openshift.com/user-email": "john@gmail.com",
+				v1alpha1.UserSignupUserEmailLabelKey: "john@gmail.com",
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
@@ -299,7 +299,7 @@ func (s *TestSignupServiceSuite) newUserSignupComplete() *v1alpha1.UserSignup {
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				"toolchain.dev.openshift.com/user-email": "ted@domain.com",
+				v1alpha1.UserSignupUserEmailLabelKey: "ted@domain.com",
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -59,6 +59,7 @@ func (s *TestSignupServiceSuite) TestCreateUserSignup() {
 	require.Equal(s.T(), userID.String(), val.Name)
 	require.Equal(s.T(), "jsmith", val.Spec.Username)
 	require.False(s.T(), val.Spec.Approved)
+	require.Equal(s.T(), "jsmith", val.Spec.Username)
 }
 
 func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -71,7 +71,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailLabelKey: "john@gmail.com",
+				v1alpha1.UserSignupUserEmailLabelKey: "john-at-gmail-com",
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
@@ -293,13 +293,14 @@ func newSignupServiceWithFakeClient() (signup.Service, *fake.FakeUserSignupClien
 func (s *TestSignupServiceSuite) newUserSignupComplete() *v1alpha1.UserSignup {
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
+
 	return &v1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailLabelKey: "ted@domain.com",
+				v1alpha1.UserSignupUserEmailLabelKey: "ted-at-domain-com",
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -295,6 +295,9 @@ func (s *TestSignupServiceSuite) newUserSignupComplete() *v1alpha1.UserSignup {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
 			Namespace: TestNamespace,
+			Annotations: map[string]string{
+				"toolchain.dev.openshift.com/user-email": "ted@domain.com",
+			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
 			Username: "ted@domain.com",

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -71,7 +71,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailLabelKey: "john@gmail.com",
+				v1alpha1.UserSignupUserEmailAnnotationKey: "john@gmail.com",
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
@@ -300,7 +300,7 @@ func (s *TestSignupServiceSuite) newUserSignupComplete() *v1alpha1.UserSignup {
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailLabelKey: "ted@domain.com",
+				v1alpha1.UserSignupUserEmailAnnotationKey: "ted@domain.com",
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -71,7 +71,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailLabelKey: "john-at-gmail-com",
+				v1alpha1.UserSignupUserEmailLabelKey: "john@gmail.com",
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
@@ -300,7 +300,7 @@ func (s *TestSignupServiceSuite) newUserSignupComplete() *v1alpha1.UserSignup {
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailLabelKey: "ted-at-domain-com",
+				v1alpha1.UserSignupUserEmailLabelKey: "ted@domain.com",
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -39,7 +39,7 @@ func (s *TestSignupServiceSuite) TestCreateUserSignup() {
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 
-	userSignup, err := svc.CreateUserSignup("jsmith", userID.String())
+	userSignup, err := svc.CreateUserSignup("jsmith", userID.String(), "jsmith@gmail.com")
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), userSignup)
 
@@ -70,6 +70,9 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
 			Namespace: TestNamespace,
+			Annotations: map[string]string{
+				"toolchain.dev.openshift.com/user-email": "john@gmail.com",
+			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
 			Username: "john@gmail.com",
@@ -77,7 +80,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 	})
 	require.NoError(s.T(), err)
 
-	_, err = svc.CreateUserSignup("john@gmail.com", userID.String())
+	_, err = svc.CreateUserSignup("john@gmail.com", userID.String(), "john@gmail.com")
 	require.EqualError(s.T(), err, fmt.Sprintf("usersignups.toolchain.dev.openshift.com \"%s\" already exists", userID.String()))
 }
 

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -59,7 +59,7 @@ func (s *TestSignupServiceSuite) TestCreateUserSignup() {
 	require.Equal(s.T(), userID.String(), val.Name)
 	require.Equal(s.T(), "jsmith", val.Spec.Username)
 	require.False(s.T(), val.Spec.Approved)
-	require.Equal(s.T(), "jsmith", val.Spec.Username)
+	require.Equal(s.T(), "jsmith@gmail.com", val.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
 }
 
 func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -71,7 +71,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailLabelKey: "john-at-gmail-com",
+				v1alpha1.UserSignupUserEmailLabelKey: "john@gmail.com",
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
@@ -293,14 +293,13 @@ func newSignupServiceWithFakeClient() (signup.Service, *fake.FakeUserSignupClien
 func (s *TestSignupServiceSuite) newUserSignupComplete() *v1alpha1.UserSignup {
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
-
 	return &v1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailLabelKey: "ted-at-domain-com",
+				v1alpha1.UserSignupUserEmailLabelKey: "ted@domain.com",
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{


### PR DESCRIPTION
As an admin, I want to see the user email when approving an account. This makes my work easier as I can see where the user is coming from (e.g. redhat.com).

Relates to:
Jira - https://jira.coreos.com/browse/CRT-374
API - codeready-toolchain/api#69
E2E- codeready-toolchain/toolchain-e2e#55
host - https://github.com/codeready-toolchain/host-operator/pull/115