### PR TITLE
adding usersignup annotation for email

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0
+	github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20191206153324-4205c5ebe624
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.10.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgk
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0 h1:APb57ts/dN2/vJb+9Fjc5I3QpOx/OBWzObGKj6zdPPU=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
+github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396 h1:OTMOZninxzV2p2gTfyF825h4rUNb8rBQ5JwvPOVN1nk=
+github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191206153324-4205c5ebe624 h1:m3y0VL12u4Aso1+LfaFHDgvWgj62Q+22kDFWTjaPqrg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191206153324-4205c5ebe624/go.mod h1:fQpxuAw8pI0BwVJhgKHN9vbWko/eWsCzsZ+9pknFVLQ=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -28,7 +28,7 @@ func NewSignup(config *configuration.Registry, signupService signup.Service) *Si
 
 // PostHandler creates a Signup resource
 func (s *Signup) PostHandler(ctx *gin.Context) {
-	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey))
+	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey), ctx.GetString(context.EmailKey))
 	if err != nil {
 		log.Error(ctx, err, "error creating UserSignup resource")
 		errors.AbortWithError(ctx, http.StatusInternalServerError, err, "error creating UserSignup resource")

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -61,11 +61,16 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		expectedUserID := ob.String()
 		ctx.Set(context.SubKey, expectedUserID)
 
+		ctx.Set(context.EmailKey, expectedUserID+"@test.com")
+		email := ctx.GetString(context.EmailKey)
 		signup := &crtapi.UserSignup{
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      userID.String(),
 				Namespace: "namespace-foo",
+				Annotations: map[string]string{
+					crtapi.UserSignupUserEmailAnnotationKey: email,
+				},
 			},
 			Spec: crtapi.UserSignupSpec{
 				Username: "bill",
@@ -82,8 +87,9 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 			},
 		}
 
-		svc.MockCreateUserSignup = func(username, userID string) (*crtapi.UserSignup, error) {
+		svc.MockCreateUserSignup = func(username, userID, email string) (*crtapi.UserSignup, error) {
 			assert.Equal(s.T(), expectedUserID, userID)
+			assert.Equal(s.T(), expectedUserID+"@test.com", email)
 			return signup, nil
 		}
 
@@ -99,7 +105,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		ctx, _ := gin.CreateTestContext(rr)
 		ctx.Request = req
 
-		svc.MockCreateUserSignup = func(username, userID string) (*crtapi.UserSignup, error) {
+		svc.MockCreateUserSignup = func(username, userID, email string) (*crtapi.UserSignup, error) {
 			return nil, errors.New("blah")
 		}
 
@@ -201,13 +207,13 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 
 type FakeSignupService struct {
 	MockGetSignup        func(userID string) (*signup.Signup, error)
-	MockCreateUserSignup func(username, userID string) (*crtapi.UserSignup, error)
+	MockCreateUserSignup func(username, userID, email string) (*crtapi.UserSignup, error)
 }
 
 func (m *FakeSignupService) GetSignup(userID string) (*signup.Signup, error) {
 	return m.MockGetSignup(userID)
 }
 
-func (m *FakeSignupService) CreateUserSignup(username, userID string) (*crtapi.UserSignup, error) {
-	return m.MockCreateUserSignup(username, userID)
+func (m *FakeSignupService) CreateUserSignup(username, userID, email string) (*crtapi.UserSignup, error) {
+	return m.MockCreateUserSignup(username, userID, email)
 }

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -52,7 +52,7 @@ type ServiceConfiguration interface {
 // Service represents the signup service for controllers.
 type Service interface {
 	GetSignup(userID string) (*Signup, error)
-	CreateUserSignup(username, userID string) (*crtapi.UserSignup, error)
+	CreateUserSignup(username, userID, email string) (*crtapi.UserSignup, error)
 }
 
 // ServiceImpl represents the implementation of the signup service.
@@ -84,11 +84,14 @@ func NewSignupService(cfg ServiceConfiguration) (Service, error) {
 }
 
 // CreateUserSignup creates a new UserSignup resource with the specified username and userID
-func (s *ServiceImpl) CreateUserSignup(username, userID string) (*crtapi.UserSignup, error) {
+func (s *ServiceImpl) CreateUserSignup(username, userID, userEmail string) (*crtapi.UserSignup, error) {
 	userSignup := &crtapi.UserSignup{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID,
 			Namespace: s.Namespace,
+			Annotations: map[string]string{
+				crtapi.UserSignupUserEmailAnnotationKey: userEmail,
+			},
 		},
 		Spec: crtapi.UserSignupSpec{
 			TargetCluster: "",

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -39,7 +39,7 @@ func (s *TestSignupServiceSuite) TestCreateUserSignup() {
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 
-	userSignup, err := svc.CreateUserSignup("jsmith", userID.String())
+	userSignup, err := svc.CreateUserSignup("jsmith", userID.String(), "jsmith@gmail.com")
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), userSignup)
 
@@ -59,6 +59,7 @@ func (s *TestSignupServiceSuite) TestCreateUserSignup() {
 	require.Equal(s.T(), userID.String(), val.Name)
 	require.Equal(s.T(), "jsmith", val.Spec.Username)
 	require.False(s.T(), val.Spec.Approved)
+	require.Equal(s.T(), "jsmith@gmail.com", val.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
 }
 
 func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
@@ -70,6 +71,9 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
 			Namespace: TestNamespace,
+			Annotations: map[string]string{
+				v1alpha1.UserSignupUserEmailAnnotationKey: "john@gmail.com",
+			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
 			Username: "john@gmail.com",
@@ -77,7 +81,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 	})
 	require.NoError(s.T(), err)
 
-	_, err = svc.CreateUserSignup("john@gmail.com", userID.String())
+	_, err = svc.CreateUserSignup("john@gmail.com", userID.String(), "john@gmail.com")
 	require.EqualError(s.T(), err, fmt.Sprintf("usersignups.toolchain.dev.openshift.com \"%s\" already exists", userID.String()))
 }
 
@@ -295,6 +299,9 @@ func (s *TestSignupServiceSuite) newUserSignupComplete() *v1alpha1.UserSignup {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
 			Namespace: TestNamespace,
+			Annotations: map[string]string{
+				v1alpha1.UserSignupUserEmailAnnotationKey: "ted@domain.com",
+			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
 			Username: "ted@domain.com",


### PR DESCRIPTION
As an admin, I want to see the user email when approving an account. This makes my work easier as I can see where the user is coming from (e.g. redhat.com).

**Relates to:**
jira - https://jira.coreos.com/browse/CRT-374
api - codeready-toolchain/api#69
host - codeready-toolchain/host-operator#115
e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/59