### PR TITLE
Add Che Dashboard URL to GET /v1/signup response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396
+	github.com/codeready-toolchain/api v0.0.0-20191212002517-882a587d15ce
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20191206153324-4205c5ebe624
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.10.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgk
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0 h1:APb57ts/dN2/vJb+9Fjc5I3QpOx/OBWzObGKj6zdPPU=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
-github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396 h1:OTMOZninxzV2p2gTfyF825h4rUNb8rBQ5JwvPOVN1nk=
-github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
+github.com/codeready-toolchain/api v0.0.0-20191212002517-882a587d15ce h1:Ipie8qsA9Vkonj/y2p+Ddlo2Z4wtg2OQzWruUO8te0I=
+github.com/codeready-toolchain/api v0.0.0-20191212002517-882a587d15ce/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191206153324-4205c5ebe624 h1:m3y0VL12u4Aso1+LfaFHDgvWgj62Q+22kDFWTjaPqrg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191206153324-4205c5ebe624/go.mod h1:fQpxuAw8pI0BwVJhgKHN9vbWko/eWsCzsZ+9pknFVLQ=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -144,8 +144,9 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 		require.NoError(s.T(), err)
 
 		expected := &signup.Signup{
-			ConsoleURL: "https://console." + targetCluster.String(),
-			Username:   "jsmith",
+			ConsoleURL:      "https://console." + targetCluster.String(),
+			CheDashboardURL: "http://che-toolchain-che.member-123.com",
+			Username:        "jsmith",
 			Status: signup.Status{
 				Reason: "Provisioning",
 			},

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -24,6 +24,8 @@ const (
 type Signup struct {
 	// The Web Console URL of the cluster which the user was provisioned to
 	ConsoleURL string `json:"consoleURL,omitempty"`
+	// The Che Dashboard URL of the cluster which the user was provisioned to
+	CheDashboardURL string `json:"cheDashboardURL,omitempty"`
 	// The complaint username.  This may differ from the corresponding Identity Provider username, because of the the
 	// limited character set available for naming (see RFC1123) in K8s. If the username contains characters which are
 	// disqualified from the resource name, the username is transformed into an acceptable resource name instead.
@@ -162,6 +164,7 @@ func (s *ServiceImpl) GetSignup(userID string) (*Signup, error) {
 	if mur.Status.UserAccounts != nil && len(mur.Status.UserAccounts) > 0 {
 		// TODO Set ConsoleURL in UserSignup.Status. For now it's OK to get it from the first embedded UserAccount status from MUR.
 		signupResponse.ConsoleURL = mur.Status.UserAccounts[0].Cluster.ConsoleURL
+		signupResponse.CheDashboardURL = mur.Status.UserAccounts[0].Cluster.CheDashboardURL
 	}
 
 	return signupResponse, nil

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -153,6 +153,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 	require.Equal(s.T(), response.Status.Reason, "test_reason")
 	require.Equal(s.T(), response.Status.Message, "test_message")
 	require.Equal(s.T(), "", response.ConsoleURL)
+	require.Equal(s.T(), "", response.CheDashboardURL)
 }
 
 func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
@@ -184,6 +185,7 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 	require.Equal(s.T(), "PendingApproval", response.Status.Reason)
 	require.Equal(s.T(), "", response.Status.Message)
 	require.Equal(s.T(), "", response.ConsoleURL)
+	require.Equal(s.T(), "", response.CheDashboardURL)
 }
 
 func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
@@ -212,8 +214,9 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 				},
 			},
 			UserAccounts: []v1alpha1.UserAccountStatusEmbedded{{Cluster: v1alpha1.Cluster{
-				Name:       "member-123",
-				ConsoleURL: "https://console.member-123.com",
+				Name:            "member-123",
+				ConsoleURL:      "https://console.member-123.com",
+				CheDashboardURL: "http://che-toolchain-che.member-123.com",
 			}}},
 		},
 	})
@@ -229,6 +232,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 	assert.Equal(s.T(), response.Status.Reason, "mur_ready_reason")
 	assert.Equal(s.T(), response.Status.Message, "mur_ready_message")
 	assert.Equal(s.T(), response.ConsoleURL, "https://console.member-123.com")
+	assert.Equal(s.T(), response.CheDashboardURL, "http://che-toolchain-che.member-123.com")
 }
 
 func (s *TestSignupServiceSuite) TestGetSignupMURGetFails() {


### PR DESCRIPTION
It pulls Che URL from MUR: https://github.com/codeready-toolchain/host-operator/pull/123

There is no e2e tests for this change because we do not install Che Operator on our tests clusters.
This is something to address later.