### PR TITLE
chore: install github.com/kislyuk/yq binary

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -30,7 +30,11 @@ RUN yum install epel-release -y \
     jq \
     gcc \
     go-bindata \
+    pip3 \
     && yum clean all
+
+# Install yq that will be used for parsing/reading yaml files.
+RUN pip3 install yq
 
 WORKDIR /tmp
 


### PR DESCRIPTION
`yq` binary is needed in the script introduced here codeready-toolchain/api#88. The script will be then used for e2e tests as well as for CD