### PR TITLE
chore(CRT-362): add travis job generating new version of host-operator CSV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+dist: "trusty"
+
+language: go
+
+env:
+- GO111MODULE=on
+
+python:
+- "3.6.3"
+
+git:
+  depth: false
+
+branches:
+  only:
+  - master
+
+go:
+- 1.13.x
+
+before_install:
+- pyenv shell 3.6.3
+- OPERATOR_SDK_VERSION=v0.11.0
+
+install:
+- curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk
+- curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu.asc -o operator-sdk.asc
+- gpg --keyserver keyserver.ubuntu.com --recv-key 78086003
+- gpg --verify operator-sdk.asc
+- chmod +x operator-sdk
+- cp operator-sdk /home/travis/bin/operator-sdk
+- rm operator-sdk
+- pip3 install operator-courier
+- pip3 install yq
+
+script:
+- make build && make docker-login && make docker-push && curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/push-to-quay-nightly.sh | bash -s -- -pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/
+
+

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -2,8 +2,6 @@ MINISHIFT_IP?=$(shell minishift ip)
 MINISHIFT_HOSTNAME=minishift.local
 MINISHIFT_HOSTNAME_REGEX='minishift\.local'
 ETC_HOSTS=/etc/hosts
-TIMESTAMP:=$(shell date +%s)
-IMAGE_NAME_DEV?=${IMAGE_NAME}-$(TIMESTAMP)
 
 # to watch all namespaces, keep namespace empty
 APP_NAMESPACE ?= $(LOCAL_TEST_NAMESPACE)
@@ -41,9 +39,9 @@ reset-namespace: login-as-admin clean-namespace create-namespace
 
 .PHONY: deploy-dev
 ## Deploy Registration service on minishift
-deploy-dev: login-as-admin create-namespace build dev-image
+deploy-dev: login-as-admin create-namespace build docker-image-dev
 	$(Q)oc process -f ./deploy/registration-service.yaml \
-        -p IMAGE=${IMAGE_NAME_DEV} \
+        -p IMAGE=${IMAGE_DEV} \
         -p ENVIRONMENT=dev \
         -p NAMESPACE=${LOCAL_TEST_NAMESPACE} \
         | oc apply -f -
@@ -52,9 +50,3 @@ deploy-dev: login-as-admin create-namespace build dev-image
 deploy-e2e: get-e2e-repo
 ## Deploy the e2e resources with the local 'registration-service' repository only
 	$(MAKE) -C ${E2E_REPO_PATH} dev-deploy-e2e REG_REPO_PATH=${PWD}
-
-.PHONY: dev-image
-## Build the docker image locally that can be deployed to dev environment
-dev-image: build
-	$(Q)docker build -f build/Dockerfile -t quay.io/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}:latest \
-	 -t ${IMAGE_NAME_DEV} .

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -1,0 +1,48 @@
+QUAY_NAMESPACE ?= ${GO_PACKAGE_ORG_NAME}
+TARGET_REGISTRY := quay.io
+IMAGE ?= ${TARGET_REGISTRY}/${QUAY_NAMESPACE}/${GO_PACKAGE_REPO_NAME}:${GIT_COMMIT_ID_SHORT}
+QUAY_USERNAME ?= ${QUAY_NAMESPACE}
+TIMESTAMP := $(shell date +%s)
+IMAGE_DEV ?= ${TARGET_REGISTRY}/${QUAY_NAMESPACE}/${GO_PACKAGE_REPO_NAME}:${TIMESTAMP}
+
+.PHONY: docker-image
+## Build the docker image locally that can be deployed (only contains bare operator)
+docker-image: build
+	$(Q)docker build -f build/Dockerfile -t ${IMAGE} .
+
+.PHONY: docker-image-dev
+## Build the docker image locally that can be deployed to dev environment
+docker-image-dev: build
+	$(Q)docker build -f build/Dockerfile -t ${IMAGE_DEV}
+
+.PHONY: docker-push
+## Push the docker image to quay.io registry
+docker-push: docker-image
+ifeq ($(QUAY_NAMESPACE),${GO_PACKAGE_ORG_NAME})
+	@echo "#################################################### WARNING ####################################################"
+	@echo you are going to push to $(QUAY_NAMESPACE) namespace, make sure you have set QUAY_NAMESPACE variable appropriately
+	@echo "#################################################################################################################"
+endif
+	$(Q)docker push ${IMAGE}
+
+.PHONY: docker-push-to-local
+## Push the docker image to the local docker.io registry
+docker-push-to-local: set-local-registry docker-image docker-push
+
+.PHONY: set-local-registry
+## Sets TARGET_REGISTRY:=docker.io
+set-local-registry:
+	$(eval TARGET_REGISTRY:=docker.io)
+
+.PHONY: docker-push-to-os
+## Push the docker image to the OS internal registry
+docker-push-to-os: set-os-registry docker-image docker-push
+
+.PHONY: set-os-registry
+## Sets TARGET_REGISTRY:=$(shell oc get images.config.openshift.io/cluster  -o jsonpath={.status.externalRegistryHostnames[0]})
+set-os-registry:
+	$(eval TARGET_REGISTRY:=$(shell oc get images.config.openshift.io/cluster  -o jsonpath={.status.externalRegistryHostnames[0]}))
+
+.PHONY: docker-login
+docker-login:
+	@echo "${DOCKER_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin

--- a/make/image.mk
+++ b/make/image.mk
@@ -1,8 +1,0 @@
-TAG?=$(GIT_COMMIT_ID_SHORT)
-IMAGE_NAME?=quay.io/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}:${TAG}
-
-.PHONY: image
-## Build the docker image locally that can be deployed (only contains bare registration-service)
-image: build
-	$(Q)docker build -f build/Dockerfile -t quay.io/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}:latest \
-	 -t ${IMAGE_NAME} .


### PR DESCRIPTION
The travis job will generate a new version of host-operator CSV and the registration-service repo is used as an embedded repo. That means that the new CSV version will contain an updated env variable `REGISTRATION_SERVICE_IMAGE` set to the latest image

it also adds necessary makefile targets for docker commands

verified in: https://travis-ci.org/MatousJobanek/registration-service/builds/640938984