### PR TITLE
Extract user information from token and store in UserSignupSpec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb
+	github.com/codeready-toolchain/api v0.0.0-20200416202101-c6481eef49dd
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200403074820-4461b6d5a850
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-contrib/gzip v0.0.1
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/ugorji/go/codec v1.1.7 // indirect
+	github.com/ugorji/go v1.1.7 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.4

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
 github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb h1:jKoTRIPS80hYsFlZs6fIYXcuvr7fbz1y28xbFuTj0Pc=
 github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
+github.com/codeready-toolchain/api v0.0.0-20200416202101-c6481eef49dd h1:j9Bo8CNurfd+8U5PjqVkLsFNPjRHXNoX7NngE9zGVaU=
+github.com/codeready-toolchain/api v0.0.0-20200416202101-c6481eef49dd/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200403074820-4461b6d5a850 h1:HGx1GHJcVxH7aN05EX8Jml5xIj/TP30NHuaRCcgaolY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200403074820-4461b6d5a850/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/codeready-toolchain/registration-service/test"
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
-	uuid "github.com/satori/go.uuid"
 
 	"github.com/dgrijalva/jwt-go"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -145,7 +145,7 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		// Create KeyManager instance.
 		_, err := auth.NewKeyManager(s.Config)
 		// this needs to fail with an error
-		assert.EqualError(s.T(), err, "Get \"not%20an%20url\": unsupported protocol scheme \"\"")
+		assert.EqualError(s.T(), err, "Get not%20an%20url: unsupported protocol scheme \"\"")
 	})
 
 	s.Run("parse keys, server not reachable", func() {

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/codeready-toolchain/registration-service/test"
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -145,7 +145,7 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		// Create KeyManager instance.
 		_, err := auth.NewKeyManager(s.Config)
 		// this needs to fail with an error
-		assert.EqualError(s.T(), err, "Get not%20an%20url: unsupported protocol scheme \"\"")
+		assert.EqualError(s.T(), err, "Get \"not%20an%20url\": unsupported protocol scheme \"\"")
 	})
 
 	s.Run("parse keys, server not reachable", func() {

--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -5,14 +5,14 @@ const (
 	UsernameKey = "username"
 	// EmailKey is the context key for the email claim
 	EmailKey = "email"
+	// NameKey is the context key for the given name claim
+	GivenName = "givenName"
+	// FamilyNameKey is the context key for the family name claim
+	FamilyNameKey = "familyName"
+	// Company is the context key for the company claim
+	Company = "company"
 	// SubKey is the context key for the subject claim
 	SubKey = "subject"
 	// JWTClaimsKey is the context key for the claims struct
 	JWTClaimsKey = "jwtClaims"
-	// FamilyNameKey is the context key for the family name claim
-	FamilyNameKey = "familyName"
-	// NameKey is the context key for the given name claim
-	GivenName = "givenName"
-	// Company is the context key for the company claim
-	Company = "company"
 )

--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -5,12 +5,12 @@ const (
 	UsernameKey = "username"
 	// EmailKey is the context key for the email claim
 	EmailKey = "email"
-	// NameKey is the context key for the given name claim
-	GivenName = "givenName"
+	// GivenNameKey is the context key for the given name claim
+	GivenNameKey = "givenName"
 	// FamilyNameKey is the context key for the family name claim
 	FamilyNameKey = "familyName"
-	// Company is the context key for the company claim
-	Company = "company"
+	// CompanyKey is the context key for the company claim
+	CompanyKey = "company"
 	// SubKey is the context key for the subject claim
 	SubKey = "subject"
 	// JWTClaimsKey is the context key for the claims struct

--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -1,12 +1,18 @@
 package context
 
 const (
-	// UsernameKey is the context key for preferred_username claim
+	// UsernameKey is the context key for the preferred_username claim
 	UsernameKey = "username"
-	// EmailKey is the context key for email claim
+	// EmailKey is the context key for the email claim
 	EmailKey = "email"
-	// SubKey is the context key for subject claim
+	// SubKey is the context key for the subject claim
 	SubKey = "subject"
 	// JWTClaimsKey is the context key for the claims struct
 	JWTClaimsKey = "jwtClaims"
+	// FamilyNameKey is the context key for the family name claim
+	FamilyNameKey = "familyName"
+	// NameKey is the context key for the given name claim
+	GivenName = "givenName"
+	// Company is the context key for the company claim
+	Company = "company"
 )

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -28,7 +28,7 @@ func NewSignup(config *configuration.Registry, signupService signup.Service) *Si
 
 // PostHandler creates a Signup resource
 func (s *Signup) PostHandler(ctx *gin.Context) {
-	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey), ctx.GetString(context.EmailKey), ctx.GetString(context.GivenName), ctx.GetString(context.FamilyNameKey), ctx.GetString(context.Company))
+	userSignup, err := s.signupService.CreateUserSignup(ctx)
 	if err != nil {
 		log.Error(ctx, err, "error creating UserSignup resource")
 		errors.AbortWithError(ctx, http.StatusInternalServerError, err, "error creating UserSignup resource")

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -28,7 +28,7 @@ func NewSignup(config *configuration.Registry, signupService signup.Service) *Si
 
 // PostHandler creates a Signup resource
 func (s *Signup) PostHandler(ctx *gin.Context) {
-	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey), ctx.GetString(context.EmailKey))
+	userSignup, err := s.signupService.CreateUserSignup(ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey), ctx.GetString(context.EmailKey), ctx.GetString(context.GivenName), ctx.GetString(context.FamilyNameKey), ctx.GetString(context.Company))
 	if err != nil {
 		log.Error(ctx, err, "error creating UserSignup resource")
 		errors.AbortWithError(ctx, http.StatusInternalServerError, err, "error creating UserSignup resource")

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -87,7 +87,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 			},
 		}
 
-		svc.MockCreateUserSignup = func(username, userID, email string) (*crtapi.UserSignup, error) {
+		svc.MockCreateUserSignup = func(username, userID, email, givenName, familyName, company string) (*crtapi.UserSignup, error) {
 			assert.Equal(s.T(), expectedUserID, userID)
 			assert.Equal(s.T(), expectedUserID+"@test.com", email)
 			return signup, nil
@@ -105,7 +105,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		ctx, _ := gin.CreateTestContext(rr)
 		ctx.Request = req
 
-		svc.MockCreateUserSignup = func(username, userID, email string) (*crtapi.UserSignup, error) {
+		svc.MockCreateUserSignup = func(username, userID, email, familyName, givenName, company string) (*crtapi.UserSignup, error) {
 			return nil, errors.New("blah")
 		}
 
@@ -208,13 +208,13 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 
 type FakeSignupService struct {
 	MockGetSignup        func(userID string) (*signup.Signup, error)
-	MockCreateUserSignup func(username, userID, email string) (*crtapi.UserSignup, error)
+	MockCreateUserSignup func(username, userID, email, givenName, familyName, company string) (*crtapi.UserSignup, error)
 }
 
 func (m *FakeSignupService) GetSignup(userID string) (*signup.Signup, error) {
 	return m.MockGetSignup(userID)
 }
 
-func (m *FakeSignupService) CreateUserSignup(username, userID, email string) (*crtapi.UserSignup, error) {
-	return m.MockCreateUserSignup(username, userID, email)
+func (m *FakeSignupService) CreateUserSignup(username, userID, email, givenName, familyName, company string) (*crtapi.UserSignup, error) {
+	return m.MockCreateUserSignup(username, userID, email, givenName, familyName, company)
 }

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -105,7 +105,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		ctx, _ := gin.CreateTestContext(rr)
 		ctx.Request = req
 
-		svc.MockCreateUserSignup = func(username, userID, email, familyName, givenName, company string) (*crtapi.UserSignup, error) {
+		svc.MockCreateUserSignup = func(username, userID, email, givenName, familyName, company string) (*crtapi.UserSignup, error) {
 			return nil, errors.New("blah")
 		}
 

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -60,7 +60,6 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		require.NoError(s.T(), err)
 		expectedUserID := ob.String()
 		ctx.Set(context.SubKey, expectedUserID)
-
 		ctx.Set(context.EmailKey, expectedUserID+"@test.com")
 		email := ctx.GetString(context.EmailKey)
 		signup := &crtapi.UserSignup{
@@ -87,9 +86,9 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 			},
 		}
 
-		svc.MockCreateUserSignup = func(username, userID, email, givenName, familyName, company string) (*crtapi.UserSignup, error) {
-			assert.Equal(s.T(), expectedUserID, userID)
-			assert.Equal(s.T(), expectedUserID+"@test.com", email)
+		svc.MockCreateUserSignup = func(ctx *gin.Context) (*crtapi.UserSignup, error) {
+			assert.Equal(s.T(), expectedUserID, ctx.GetString(context.SubKey))
+			assert.Equal(s.T(), expectedUserID+"@test.com", ctx.GetString(context.EmailKey))
 			return signup, nil
 		}
 
@@ -105,7 +104,7 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		ctx, _ := gin.CreateTestContext(rr)
 		ctx.Request = req
 
-		svc.MockCreateUserSignup = func(username, userID, email, givenName, familyName, company string) (*crtapi.UserSignup, error) {
+		svc.MockCreateUserSignup = func(ctx *gin.Context) (*crtapi.UserSignup, error) {
 			return nil, errors.New("blah")
 		}
 
@@ -208,13 +207,13 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 
 type FakeSignupService struct {
 	MockGetSignup        func(userID string) (*signup.Signup, error)
-	MockCreateUserSignup func(username, userID, email, givenName, familyName, company string) (*crtapi.UserSignup, error)
+	MockCreateUserSignup func(ctx *gin.Context) (*crtapi.UserSignup, error)
 }
 
 func (m *FakeSignupService) GetSignup(userID string) (*signup.Signup, error) {
 	return m.MockGetSignup(userID)
 }
 
-func (m *FakeSignupService) CreateUserSignup(username, userID, email, givenName, familyName, company string) (*crtapi.UserSignup, error) {
-	return m.MockCreateUserSignup(username, userID, email, givenName, familyName, company)
+func (m *FakeSignupService) CreateUserSignup(ctx *gin.Context) (*crtapi.UserSignup, error) {
+	return m.MockCreateUserSignup(ctx)
 }

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -73,6 +73,7 @@ func (m *JWTMiddleware) HandlerFunc() gin.HandlerFunc {
 		c.Set(context.SubKey, token.Subject)
 		c.Set(context.GivenName, token.GivenName)
 		c.Set(context.FamilyNameKey, token.FamilyName)
+		c.Set(context.Company, token.Company)
 		// for convenience, add the claims to the context.
 		c.Set(context.JWTClaimsKey, token)
 		c.Next()

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -71,6 +71,8 @@ func (m *JWTMiddleware) HandlerFunc() gin.HandlerFunc {
 		c.Set(context.UsernameKey, token.Username)
 		c.Set(context.EmailKey, token.Email)
 		c.Set(context.SubKey, token.Subject)
+		c.Set(context.GivenName, token.GivenName)
+		c.Set(context.FamilyNameKey, token.FamilyName)
 		// for convenience, add the claims to the context.
 		c.Set(context.JWTClaimsKey, token)
 		c.Next()

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -71,9 +71,9 @@ func (m *JWTMiddleware) HandlerFunc() gin.HandlerFunc {
 		c.Set(context.UsernameKey, token.Username)
 		c.Set(context.EmailKey, token.Email)
 		c.Set(context.SubKey, token.Subject)
-		c.Set(context.GivenName, token.GivenName)
+		c.Set(context.GivenNameKey, token.GivenName)
 		c.Set(context.FamilyNameKey, token.FamilyName)
-		c.Set(context.Company, token.Company)
+		c.Set(context.CompanyKey, token.Company)
 		// for convenience, add the claims to the context.
 		c.Set(context.JWTClaimsKey, token)
 		c.Next()

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -56,7 +56,7 @@ type ServiceConfiguration interface {
 // Service represents the signup service for controllers.
 type Service interface {
 	GetSignup(userID string) (*Signup, error)
-	CreateUserSignup(username, userID, email string) (*crtapi.UserSignup, error)
+	CreateUserSignup(username, userID, email, givenName, familyName, company string) (*crtapi.UserSignup, error)
 }
 
 // ServiceImpl represents the implementation of the signup service.
@@ -90,7 +90,7 @@ func NewSignupService(cfg ServiceConfiguration) (Service, error) {
 }
 
 // CreateUserSignup creates a new UserSignup resource with the specified username and userID
-func (s *ServiceImpl) CreateUserSignup(username, userID, userEmail string) (*crtapi.UserSignup, error) {
+func (s *ServiceImpl) CreateUserSignup(username, userID, userEmail, givenName, familyName, company string) (*crtapi.UserSignup, error) {
 	md5hash := md5.New()
 	// Ignore the error, as this implementation cannot return one
 	_, _ = md5hash.Write([]byte(userEmail))
@@ -124,6 +124,9 @@ func (s *ServiceImpl) CreateUserSignup(username, userID, userEmail string) (*crt
 			TargetCluster: "",
 			Approved:      false,
 			Username:      username,
+			GivenName:     givenName,
+			FamilyName:    familyName,
+			Company:       company,
 		},
 	}
 

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -159,10 +159,7 @@ func (s *ServiceImpl) GetSignup(userID string) (*Signup, error) {
 	}
 
 	signupResponse := &Signup{
-		Username:   userSignup.Spec.Username,
-		GivenName:  userSignup.Spec.GivenName,
-		FamilyName: userSignup.Spec.FamilyName,
-		Company:    userSignup.Spec.Company,
+		Username: userSignup.Spec.Username,
 	}
 	if userSignup.Status.CompliantUsername != "" {
 		signupResponse.CompliantUsername = userSignup.Status.CompliantUsername

--- a/pkg/signup/signup_service.go
+++ b/pkg/signup/signup_service.go
@@ -35,7 +35,13 @@ type Signup struct {
 	CompliantUsername string `json:"compliantUsername"`
 	// Original username from the Identity Provider
 	Username string `json:"username"`
-	Status   Status `json:"status,omitempty"`
+	// GivenName from the Identity Provider
+	GivenName string `json:"givenName"`
+	// FamilyName from the Identity Provider
+	FamilyName string `json:"familyName"`
+	// Company from the Identity Provider
+	Company string `json:"company"`
+	Status  Status `json:"status,omitempty"`
 }
 
 // Status represents UserSignup resource status
@@ -153,7 +159,10 @@ func (s *ServiceImpl) GetSignup(userID string) (*Signup, error) {
 	}
 
 	signupResponse := &Signup{
-		Username: userSignup.Spec.Username,
+		Username:   userSignup.Spec.Username,
+		GivenName:  userSignup.Spec.GivenName,
+		FamilyName: userSignup.Spec.FamilyName,
+		Company:    userSignup.Spec.Company,
 	}
 	if userSignup.Status.CompliantUsername != "" {
 		signupResponse.CompliantUsername = userSignup.Status.CompliantUsername

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -258,10 +258,7 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 			Namespace: TestNamespace,
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:   "bill",
-			GivenName:  "william",
-			FamilyName: "franko",
-			Company:    "test company",
+			Username: "bill",
 		},
 		Status: v1alpha1.UserSignupStatus{},
 	})

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -41,7 +41,7 @@ func (s *TestSignupServiceSuite) TestCreateUserSignup() {
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 
-	userSignup, err := svc.CreateUserSignup("jsmith", userID.String(), "jsmith@gmail.com")
+	userSignup, err := svc.CreateUserSignup("jsmith", userID.String(), "jsmith@gmail.com", "jane", "doe", "red hat")
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), userSignup)
 
@@ -60,9 +60,13 @@ func (s *TestSignupServiceSuite) TestCreateUserSignup() {
 	require.Equal(s.T(), TestNamespace, val.Namespace)
 	require.Equal(s.T(), userID.String(), val.Name)
 	require.Equal(s.T(), "jsmith", val.Spec.Username)
+	require.Equal(s.T(), "jane", val.Spec.GivenName)
+	require.Equal(s.T(), "doe", val.Spec.FamilyName)
+	require.Equal(s.T(), "red hat", val.Spec.Company)
 	require.False(s.T(), val.Spec.Approved)
 	require.Equal(s.T(), "jsmith@gmail.com", val.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
 	require.Equal(s.T(), "a7b1b413c1cbddbcd19a51222ef8e20a", val.Labels[v1alpha1.UserSignupUserEmailHashLabelKey])
+
 }
 
 func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
@@ -84,7 +88,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 	})
 	require.NoError(s.T(), err)
 
-	_, err = svc.CreateUserSignup("john@gmail.com", userID.String(), "john@gmail.com")
+	_, err = svc.CreateUserSignup("john@gmail.com", userID.String(), "john@gmail.com", "", "", "")
 	require.EqualError(s.T(), err, fmt.Sprintf("usersignups.toolchain.dev.openshift.com \"%s\" already exists", userID.String()))
 }
 
@@ -111,7 +115,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserBanned() {
 	})
 	require.NoError(s.T(), err)
 
-	_, err = svc.CreateUserSignup("jsmith@gmail.com", userID.String(), "jsmith@gmail.com")
+	_, err = svc.CreateUserSignup("jsmith@gmail.com", userID.String(), "jsmith@gmail.com", "", "", "")
 	require.Error(s.T(), err)
 	require.IsType(s.T(), &errors2.StatusError{}, err)
 	errStatus := err.(*errors2.StatusError).ErrStatus
@@ -143,7 +147,7 @@ func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
 	})
 	require.NoError(s.T(), err)
 
-	userSignup, err := svc.CreateUserSignup("jsmith@gmail.com", userID.String(), "jsmith@gmail.com")
+	userSignup, err := svc.CreateUserSignup("jsmith@gmail.com", userID.String(), "jsmith@gmail.com", "", "", "")
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), userSignup)
 
@@ -162,6 +166,9 @@ func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
 	require.Equal(s.T(), TestNamespace, val.Namespace)
 	require.Equal(s.T(), userID.String(), val.Name)
 	require.Equal(s.T(), "jsmith@gmail.com", val.Spec.Username)
+	require.Equal(s.T(), "", val.Spec.GivenName)
+	require.Equal(s.T(), "", val.Spec.FamilyName)
+	require.Equal(s.T(), "", val.Spec.Company)
 	require.False(s.T(), val.Spec.Approved)
 	require.Equal(s.T(), "jsmith@gmail.com", val.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
 	require.Equal(s.T(), "a7b1b413c1cbddbcd19a51222ef8e20a", val.Labels[v1alpha1.UserSignupUserEmailHashLabelKey])

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -258,7 +258,10 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 			Namespace: TestNamespace,
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username: "bill",
+			Username:   "bill",
+			GivenName:  "william",
+			FamilyName: "franko",
+			Company:    "test company",
 		},
 		Status: v1alpha1.UserSignupStatus{},
 	})
@@ -269,6 +272,9 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 	require.NotNil(s.T(), response)
 
 	require.Equal(s.T(), "bill", response.Username)
+	require.Equal(s.T(), "william", response.GivenName)
+	require.Equal(s.T(), "franko", response.FamilyName)
+	require.Equal(s.T(), "test company", response.Company)
 	require.Equal(s.T(), "", response.CompliantUsername)
 	require.False(s.T(), response.Status.Ready)
 	require.Equal(s.T(), "PendingApproval", response.Status.Reason)
@@ -316,6 +322,9 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 	require.NotNil(s.T(), response)
 
 	require.Equal(s.T(), "ted@domain.com", response.Username)
+	require.Equal(s.T(), "ted", response.GivenName)
+	require.Equal(s.T(), "teddy", response.FamilyName)
+	require.Equal(s.T(), "test company", response.Company)
 	require.Equal(s.T(), "ted", response.CompliantUsername)
 	assert.True(s.T(), response.Status.Ready)
 	assert.Equal(s.T(), response.Status.Reason, "mur_ready_reason")
@@ -399,7 +408,10 @@ func (s *TestSignupServiceSuite) newUserSignupComplete() *v1alpha1.UserSignup {
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username: "ted@domain.com",
+			Username:   "ted@domain.com",
+			GivenName:  "ted",
+			FamilyName: "teddy",
+			Company:    "test company",
 		},
 		Status: v1alpha1.UserSignupStatus{
 			Conditions: []v1alpha1.Condition{

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -399,10 +399,7 @@ func (s *TestSignupServiceSuite) newUserSignupComplete() *v1alpha1.UserSignup {
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:   "ted@domain.com",
-			GivenName:  "ted",
-			FamilyName: "teddy",
-			Company:    "test company",
+			Username: "ted@domain.com",
 		},
 		Status: v1alpha1.UserSignupStatus{
 			Conditions: []v1alpha1.Condition{

--- a/pkg/signup/signup_service_test.go
+++ b/pkg/signup/signup_service_test.go
@@ -272,9 +272,6 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 	require.NotNil(s.T(), response)
 
 	require.Equal(s.T(), "bill", response.Username)
-	require.Equal(s.T(), "william", response.GivenName)
-	require.Equal(s.T(), "franko", response.FamilyName)
-	require.Equal(s.T(), "test company", response.Company)
 	require.Equal(s.T(), "", response.CompliantUsername)
 	require.False(s.T(), response.Status.Ready)
 	require.Equal(s.T(), "PendingApproval", response.Status.Reason)
@@ -322,9 +319,6 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 	require.NotNil(s.T(), response)
 
 	require.Equal(s.T(), "ted@domain.com", response.Username)
-	require.Equal(s.T(), "ted", response.GivenName)
-	require.Equal(s.T(), "teddy", response.FamilyName)
-	require.Equal(s.T(), "test company", response.Company)
 	require.Equal(s.T(), "ted", response.CompliantUsername)
 	assert.True(s.T(), response.Status.Ready)
 	assert.Equal(s.T(), response.Status.Reason, "mur_ready_reason")


### PR DESCRIPTION
In order to customize notification messages to users, we require additional user information which we should store in the UserSignup CRD when the user first registers. The new fields being added for the notification service messages are givenName, familyName and company. This PR will extract these fields from the token and populate the crd accordingly.

jira: https://issues.redhat.com/browse/CRT-518
related e2e-tests PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/102/files