### PR TITLE
Add helpful logs when there is a validation error

### DIFF
--- a/pkg/auth/tokenparser.go
+++ b/pkg/auth/tokenparser.go
@@ -2,7 +2,10 @@ package auth
 
 import (
 	"errors"
+	"strconv"
+	"time"
 
+	"github.com/codeready-toolchain/registration-service/pkg/log"
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
@@ -26,9 +29,15 @@ type TokenClaims struct {
 	jwt.StandardClaims
 }
 
+// Valid checks whether the token claims are valid
 func (c *TokenClaims) Valid() error {
 	c.StandardClaims.IssuedAt -= leeway
+	now := time.Now().Unix()
 	err := c.StandardClaims.Valid()
+	if err != nil {
+		log.Infof(nil, "Current time: %s", strconv.FormatInt(now, 10))
+		log.Infof(nil, "Token IssuedAt time: %s", strconv.FormatInt(c.StandardClaims.IssuedAt, 10))
+	}
 	c.StandardClaims.IssuedAt += leeway
 	return err
 }

--- a/pkg/auth/tokenparser.go
+++ b/pkg/auth/tokenparser.go
@@ -35,6 +35,7 @@ func (c *TokenClaims) Valid() error {
 	now := time.Now().Unix()
 	err := c.StandardClaims.Valid()
 	if err != nil {
+		log.Error(nil, err, "Token validation failed")
 		log.Infof(nil, "Current time: %s", strconv.FormatInt(now, 10))
 		log.Infof(nil, "Token IssuedAt time: %s", strconv.FormatInt(c.StandardClaims.IssuedAt, 10))
 	}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CRT-534

**What does this PR do?**
Adds logs to the registration-service pod when there is a validation error after the user clicks the register button.

Snippet from the registration-service pod logs:
```
[GIN] 2020/04/23 - 17:20:44 | 200 |     533.406µs |    192.168.64.1 | GET      /
[GIN] 2020/04/23 - 17:20:44 | 200 |      147.21µs |    192.168.64.1 | GET      /api/v1/authconfig
[GIN] 2020/04/23 - 17:20:44 | 200 |     281.159µs |      10.128.0.1 | GET      /api/v1/health
[GIN] 2020/04/23 - 17:20:45 | 401 |    5.765578ms |    192.168.64.1 | GET      /api/v1/signup
{"level":"error","ts":1587662445.1451507,"logger":"registration-service","msg":"Token validation failed","timestamp":"Thu, 23 Apr 2020 17:20:45 +0000","commit":"7364e8e","error":"Token used before issued","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/jeev/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\ngithub.com/codeready-toolchain/registration-service/pkg/log.(*Logger).Errorf\n\t/Users/jeev/work/git/github.com/codeready-toolchain/registration-service/pkg/log/log.go:127\ngithub.com/codeready-toolchain/registration-service/pkg/log.(*Logger).Error\n\t/Users/jeev/work/git/github.com/codeready-toolchain/registration-service/pkg/log/log.go:113\ngithub.com/codeready-toolchain/registration-service/pkg/log.Error\n\t/Users/jeev/work/git/github.com/codeready-toolchain/registration-service/pkg/log/log.go:78\ngithub.com/codeready-toolchain/registration-service/pkg/auth.(*TokenClaims).Valid\n\t/Users/jeev/work/git/github.com/codeready-toolchain/registration-service/pkg/auth/tokenparser.go:38\ngithub.com/dgrijalva/jwt-go.(*Parser).ParseWithClaims\n\t/Users/jeev/go/pkg/mod/github.com/dgrijalva/jwt-go@v3.2.0+incompatible/parser.go:63\ngithub.com/dgrijalva/jwt-go.ParseWithClaims\n\t/Users/jeev/go/pkg/mod/github.com/dgrijalva/jwt-go@v3.2.0+incompatible/token.go:93\ngithub.com/codeready-toolchain/registration-service/pkg/auth.(*TokenParser).FromString\n\t/Users/jeev/work/git/github.com/codeready-toolchain/registration-service/pkg/auth/tokenparser.go:63\ngithub.com/codeready-toolchain/registration-service/pkg/middleware.(*JWTMiddleware).HandlerFunc.func1\n\t/Users/jeev/work/git/github.com/codeready-toolchain/registration-service/pkg/middleware/middleware.go:64\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/Users/jeev/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/context.go:124\ngithub.com/gin-contrib/gzip.Gzip.func2\n\t/Users/jeev/go/pkg/mod/github.com/gin-contrib/gzip@v0.0.1/gzip.go:47\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/Users/jeev/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/context.go:124\ngithub.com/gin-gonic/gin.RecoveryWithWriter.func1\n\t/Users/jeev/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/recovery.go:83\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/Users/jeev/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/context.go:124\ngithub.com/gin-gonic/gin.LoggerWithConfig.func1\n\t/Users/jeev/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/logger.go:240\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/Users/jeev/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/context.go:124\ngithub.com/gin-gonic/gin.(*Engine).handleHTTPRequest\n\t/Users/jeev/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/gin.go:389\ngithub.com/gin-gonic/gin.(*Engine).ServeHTTP\n\t/Users/jeev/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/gin.go:351\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/Cellar/go/1.14.2_1/libexec/src/net/http/server.go:2807\nnet/http.(*conn).serve\n\t/usr/local/Cellar/go/1.14.2_1/libexec/src/net/http/server.go:1895"}
{"level":"info","ts":1587662445.1456628,"logger":"registration-service","msg":"Current time: 1587662445","timestamp":"Thu, 23 Apr 2020 17:20:45 +0000","commit":"7364e8e"}
{"level":"info","ts":1587662445.1456864,"logger":"registration-service","msg":"Token IssuedAt time: 1587667444","timestamp":"Thu, 23 Apr 2020 17:20:45 +0000","commit":"7364e8e"}
[GIN] 2020/04/23 - 17:20:45 | 200 |    1.659191ms |      10.128.0.1 | GET      /api/v1/health
```

**Acceptance criteria**

- Output the error with ERROR level
- Output the timestamps as INFO level since the failure may not be related to the timestamps
- Should be visible in the registration-service pod logs

**How to verify**
To force validation failure you can adjust the leeway time to a negative number which should force a "Token used before issued" error.