### PR TITLE
Show error message after auth failed

### DIFF
--- a/pkg/assets/index.html
+++ b/pkg/assets/index.html
@@ -109,6 +109,18 @@
       </nav> 
     </section>
     <section class="pf-c-page__main-section">
+      <div id="state-error">
+        <div class="pf-c-alert pf-m-danger pf-m-inline" aria-label="error">
+          <div class="pf-c-alert__icon">
+            <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+          </div>
+          <h4 class="pf-c-alert__title">
+          <span class="pf-screen-reader">Error:</span>Something went wrong, please try again.</h4>
+          <div class="pf-c-alert__description">
+            <p><span id="errorStatus"></span></p>
+          </div>
+        </div>
+      </div>
       <div class="pf-c-content">
         <div class="toolchain-state" id="state-getstarted">
           <button class="getstartedbutton" onclick="login()">Get Started with CodeReady Toolchain</button>
@@ -182,15 +194,6 @@
             </div>
           </div>    
         </div>  
-      </div>
-      <div id="state-error">
-        <div class="pf-c-alert pf-m-danger pf-m-inline" aria-label="error">
-          <div class="pf-c-alert__icon">
-            <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
-          </div>
-          <h4 class="pf-c-alert__title">
-          <span class="pf-screen-reader">Error:</span>Something went wrong, please try again. <span id="errorStatus"></span></h4>
-        </div>
       </div>
     </section>
     <section class="pf-c-page__main-section pf-m-light">

--- a/pkg/assets/index.html
+++ b/pkg/assets/index.html
@@ -109,15 +109,6 @@
       </nav> 
     </section>
     <section class="pf-c-page__main-section">
-      <div id="state-error">
-        <div class="pf-c-alert pf-m-danger pf-m-inline" aria-label="error">
-          <div class="pf-c-alert__icon">
-            <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
-          </div>
-          <h4 class="pf-c-alert__title">
-          <span class="pf-screen-reader">Error:</span>Something went wrong, please try again. <span id="errorStatus"></span></h4>
-        </div>
-      </div>
       <div class="pf-c-content">
         <div class="toolchain-state" id="state-getstarted">
           <button class="getstartedbutton" onclick="login()">Get Started with CodeReady Toolchain</button>
@@ -191,6 +182,15 @@
             </div>
           </div>    
         </div>  
+      </div>
+      <div id="state-error">
+        <div class="pf-c-alert pf-m-danger pf-m-inline" aria-label="error">
+          <div class="pf-c-alert__icon">
+            <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+          </div>
+          <h4 class="pf-c-alert__title">
+          <span class="pf-screen-reader">Error:</span>Something went wrong, please try again. <span id="errorStatus"></span></h4>
+        </div>
       </div>
     </section>
     <section class="pf-c-page__main-section pf-m-light">

--- a/pkg/assets/landingpage.js
+++ b/pkg/assets/landingpage.js
@@ -151,6 +151,7 @@ function updateSignupState() {
       hideUser();
       hideAll();
       show('state-getstarted');
+      show('state-error');
     } else {
       // other error, show error box.
       showError(err);

--- a/pkg/assets/landingpage.js
+++ b/pkg/assets/landingpage.js
@@ -88,7 +88,7 @@ function loadAuthLibrary(url, cbSuccess, cbError) {
 function getSignupState(cbSuccess, cbError) {
   getJSON('GET', '/api/v1/signup', keycloak.idToken, function(err, data) {
     if (err != null) {
-      cbError(err);
+      cbError(err, data);
     } else {
       cbSuccess(data);
     }
@@ -132,7 +132,7 @@ function updateSignupState() {
         intervalRef = setInterval(updateSignupState, 1000);
       }
     }
-  }, function(err) {
+  }, function(err, data) {
     if (err === 404) {
       // signup does not exist, but user is authorized, check if we can start signup process.
       if ('true' === window.sessionStorage.getItem('autoSignup')) {
@@ -152,6 +152,9 @@ function updateSignupState() {
       hideAll();
       show('state-getstarted');
       show('state-error');
+      if(data != null && data.error != null){
+        document.getElementById('errorStatus').textContent = data.error;
+      }
     } else {
       // other error, show error box.
       showError(err);


### PR DESCRIPTION
**Related Issue(s)**
https://issues.redhat.com/browse/CRT-533

**What does this PR do?**

Updates the front end registration service page to show authentication errors when the problem occurs. The error was previously only visible in the browser's dev console.

**Acceptance Criteria**

- [x] Show error in the UI after auth failure
- [x] Error should disappear after successful auth (See note 2 below)
- [x] Error should still be shown in the browser's dev console
- [x] Display error message if there is one

Before:
![image](https://user-images.githubusercontent.com/20015929/80156866-ef9d3c00-8592-11ea-8062-0afa672b8f77.png)

After:
![image](https://user-images.githubusercontent.com/20015929/80214356-aee00a00-8608-11ea-9073-bcfff7dc3f3b.png)


**Notes**

1. Moved the div for the error message below the button because it looked a bit odd to me that it was on top but I'm happy to change it back if that breaks some UX guidelines or something. This is how it looked with the message on the top:
![image](https://user-images.githubusercontent.com/20015929/80157164-8e299d00-8593-11ea-92b1-95855082521c.png)

2. Was able to verify the error disappears after auth is successful by testing with a leeway that increases after each request. This was only for testing, not a part of the change.

```
var leeway int64 = -5000

func (c *TokenClaims) Valid() error {
	c.StandardClaims.IssuedAt -= leeway
	err := c.StandardClaims.Valid()
	c.StandardClaims.IssuedAt += leeway
	leeway += 2000
	return err
}
```
