### PR TITLE
chore: add manifests targets that will be used by CD

### DIFF
--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -7,6 +7,8 @@ PATH_TO_RECOVERY_FILE=scripts/recover-operator-dir.sh
 PATH_TO_OLM_GENERATE_FILE=scripts/olm-catalog-generate.sh
 
 TMP_DIR?=/tmp
+IMAGE_BUILDER?=docker
+INDEX_IMAGE?=hosted-toolchain-index
 
 .PHONY: push-to-quay-nightly
 ## Creates a new version of CSV and pushes it to quay
@@ -39,7 +41,7 @@ endif
 .PHONY: push-bundle-and-index-image
 ## Pushes generated manifests as a bundle image to quay and adds is to the image index
 push-bundle-and-index-image:
-	$(eval PUSH_BUNDLE_PARAMS = -pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/ -qn ${QUAY_NAMESPACE} -ch staging -im hosted-toolchain-index -td ${TMP_DIR})
+	$(eval PUSH_BUNDLE_PARAMS = -pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/ -qn ${QUAY_NAMESPACE} -ch staging -td ${TMP_DIR} -ib ${IMAGE_BUILDER} -im ${INDEX_IMAGE})
 ifneq ("$(wildcard ../api/$(PATH_TO_BUNDLE_FILE))","")
 	@echo "pushing to quay in staging channel using script from local api repo..."
 	../api/${PATH_TO_BUNDLE_FILE} ${PUSH_BUNDLE_PARAMS}

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -1,15 +1,54 @@
 
 PATH_TO_PUSH_NIGHTLY_FILE=scripts/push-to-quay-nightly.sh
+PATH_TO_CD_GENERATE_FILE=scripts/generate-cd-release-manifests.sh
+PATH_TO_PUSH_APP_FILE=scripts/push-manifests-as-app.sh
+PATH_TO_BUNDLE_FILE=scripts/push-bundle-and-index-image.sh
+PATH_TO_RECOVERY_FILE=scripts/recover-operator-dir.sh
 PATH_TO_OLM_GENERATE_FILE=scripts/olm-catalog-generate.sh
+
+TMP_DIR?=/tmp
 
 .PHONY: push-to-quay-nightly
 ## Creates a new version of CSV and pushes it to quay
-push-to-quay-nightly:
-	$(eval PUSH_PARAMS = -pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/ -ch nightly)
-ifneq ("$(wildcard ../api/$(PATH_TO_PUSH_NIGHTLY_FILE))","")
+push-to-quay-nightly: generate-cd-release-manifests push-manifests-as-app recover-operator-dir
+
+.PHONY: generate-cd-release-manifests
+## Generates a new version of operator manifests
+generate-cd-release-manifests:
+	$(eval CD_GENERATE_PARAMS = -pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/ -qn ${QUAY_NAMESPACE} -td ${TMP_DIR})
+ifneq ("$(wildcard ../api/$(PATH_TO_CD_GENERATE_FILE))","")
+	@echo "generating manifests for CD using script from local api repo..."
+	../api/${PATH_TO_CD_GENERATE_FILE} ${CD_GENERATE_PARAMS}
+else
+	@echo "generating manifests for CD using script from GH api repo (using latest version in master)..."
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${PATH_TO_CD_GENERATE_FILE} | bash -s -- ${CD_GENERATE_PARAMS}
+endif
+
+.PHONY: push-manifests-as-app
+## Pushes generated manifests as an application to quay
+push-manifests-as-app:
+	$(eval PUSH_APP_PARAMS = -pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/ -qn ${QUAY_NAMESPACE} -ch nightly -td ${TMP_DIR})
+ifneq ("$(wildcard ../api/$(PATH_TO_PUSH_APP_FILE))","")
 	@echo "pushing to quay in nightly channel using script from local api repo..."
-	../api/${PATH_TO_PUSH_NIGHTLY_FILE} ${PUSH_PARAMS}
+	../api/${PATH_TO_PUSH_APP_FILE} ${PUSH_APP_PARAMS}
 else
 	@echo "pushing to quay in nightly channel using script from GH api repo (using latest version in master)..."
-	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${PATH_TO_PUSH_NIGHTLY_FILE} | bash -s -- ${PUSH_PARAMS}
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${PATH_TO_PUSH_APP_FILE} | bash -s -- ${PUSH_APP_PARAMS}
 endif
+
+.PHONY: push-bundle-and-index-image
+## Pushes generated manifests as a bundle image to quay and adds is to the image index
+push-bundle-and-index-image:
+	$(eval PUSH_BUNDLE_PARAMS = -pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/ -qn ${QUAY_NAMESPACE} -ch staging -im hosted-toolchain-index -td ${TMP_DIR})
+ifneq ("$(wildcard ../api/$(PATH_TO_BUNDLE_FILE))","")
+	@echo "pushing to quay in staging channel using script from local api repo..."
+	../api/${PATH_TO_BUNDLE_FILE} ${PUSH_BUNDLE_PARAMS}
+else
+	@echo "pushing to quay in staging channel using script from GH api repo (using latest version in master)..."
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${PATH_TO_BUNDLE_FILE} | bash -s -- ${PUSH_BUNDLE_PARAMS}
+endif
+
+.PHONY: recover-operator-dir
+## Does nothing - registration-service doesn't contain operator-bundle that could be recovered
+recover-operator-dir:
+	@echo "there is nothing to be recovered - registration-service doesn't contain operator-bundle"


### PR DESCRIPTION
Add new targets to manifests makefile - these targets will be used by CD to release a new nightly/staging releases.
* generate-cd-release-manifests - generates a new version of operator manifests
* push-manifests-as-app - pushes manifests as an application to quay
* push-bundle-and-index-image - pushes manifests as a bundle image to quay and adds it to the index image
* recover-operator-dir - does nothing since registration-service doesn't contain operator bundle directory, but keep it there in case it's invoked by CD