### PR TITLE
secret configuration for registration-service

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,7 +46,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// create client that will be used for retrieving the host operator secret
+	// create client that will be used for retrieving the registration service configmaps and secrets
 	cl, err := client.New(cfg, client.Options{})
 	if err != nil {
 		panic(err.Error())
@@ -82,12 +82,12 @@ func main() {
 }
 
 func printConfig(cfg *configuration.Registry) {
-	log.Info(nil, "AuthRawSSLRequired: "+cfg.GetAuthClientConfigAuthRawSSLReuired())
-	log.Info(nil, "AuthRawServerURL: "+cfg.GetAuthClientConfigAuthRawServerURL())
-	log.Info(nil, "AuthRawResource: "+cfg.GetAuthClientConfigAuthRawResource())
-	log.Info(nil, "AuthRawRealm: "+cfg.GetAuthClientConfigAuthRawRealm())
-	log.Info(nil, "AuthRawPublicClient: "+strconv.FormatBool(cfg.GetAuthClientConfigAuthRawPublicClient()))
-	log.Info(nil, "AuthRawClientID: "+cfg.GetAuthClientConfigAuthRawClientID())
+	log.Info(nil, "AuthRawSSLRequired: "+cfg.GetAuthClientConfigRawSSLRequired())
+	log.Info(nil, "AuthRawServerURL: "+cfg.GetAuthClientConfigRawAuthServerURL())
+	log.Info(nil, "AuthRawResource: "+cfg.GetAuthClientConfigRawResource())
+	log.Info(nil, "AuthRawRealm: "+cfg.GetAuthClientConfigRawRealm())
+	log.Info(nil, "AuthRawPublicClient: "+strconv.FormatBool(cfg.GetAuthClientConfigRawPublicClient()))
+	log.Info(nil, "AuthRawClientID: "+cfg.GetAuthClientConfigRawClientID())
 	log.Info(nil, "VerificationEnabled: "+strconv.FormatBool(cfg.GetVerificationEnabled()))
 	log.Info(nil, "VerificationDailyLimit: "+strconv.Itoa(cfg.GetVerificationDailyLimit()))
 	log.Info(nil, "VerificationAttemptsAllowed: "+strconv.Itoa(cfg.GetVerificationAttemptsAllowed()))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,12 +82,7 @@ func main() {
 }
 
 func printConfig(cfg *configuration.Registry) {
-	log.Info(nil, "AuthRawSSLRequired: "+cfg.GetAuthClientConfigRawSSLRequired())
-	log.Info(nil, "AuthRawServerURL: "+cfg.GetAuthClientConfigRawAuthServerURL())
-	log.Info(nil, "AuthRawResource: "+cfg.GetAuthClientConfigRawResource())
-	log.Info(nil, "AuthRawRealm: "+cfg.GetAuthClientConfigRawRealm())
-	log.Info(nil, "AuthRawPublicClient: "+strconv.FormatBool(cfg.GetAuthClientConfigRawPublicClient()))
-	log.Info(nil, "AuthRawClientID: "+cfg.GetAuthClientConfigRawClientID())
+	log.Info(nil, "AuthRawConfig: "+cfg.GetAuthClientConfigAuthRaw())
 	log.Info(nil, "VerificationEnabled: "+strconv.FormatBool(cfg.GetVerificationEnabled()))
 	log.Info(nil, "VerificationDailyLimit: "+strconv.Itoa(cfg.GetVerificationDailyLimit()))
 	log.Info(nil, "VerificationAttemptsAllowed: "+strconv.Itoa(cfg.GetVerificationAttemptsAllowed()))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -56,14 +57,7 @@ func main() {
 		panic(err.Error())
 	}
 
-	log.Info(nil, "AuthRawSSLRequired: "+crtConfig.GetAuthClientConfigAuthRawSSLReuired())
-	log.Info(nil, "AuthRawServerURL: "+crtConfig.GetAuthClientConfigAuthRawServerURL())
-	log.Info(nil, "AuthRawResource: "+crtConfig.GetAuthClientConfigAuthRawResource())
-	log.Info(nil, "AuthRawRealm: "+crtConfig.GetAuthClientConfigAuthRawRealm())
-	log.Info(nil, "AuthRawPublicClient: "+crtConfig.GetAuthClientConfigAuthRawPublicClient())
-	log.Info(nil, "AuthRawClientID: "+crtConfig.GetAuthClientConfigAuthRawClientID())
-	log.Info(nil, "TwilioAccountSID:"+crtConfig.GetTwilioAccountSID())
-	log.Info(nil, "TwilioAuthToken:"+crtConfig.GetTwilioAuthToken())
+	printConfig(crtConfig)
 
 	srv := server.New(crtConfig)
 
@@ -85,6 +79,18 @@ func main() {
 	}()
 
 	gracefulShutdown(srv.HTTPServer(), srv.Config().GetGracefulTimeout())
+}
+
+func printConfig(cfg *configuration.Registry) {
+	log.Info(nil, "AuthRawSSLRequired: "+cfg.GetAuthClientConfigAuthRawSSLReuired())
+	log.Info(nil, "AuthRawServerURL: "+cfg.GetAuthClientConfigAuthRawServerURL())
+	log.Info(nil, "AuthRawResource: "+cfg.GetAuthClientConfigAuthRawResource())
+	log.Info(nil, "AuthRawRealm: "+cfg.GetAuthClientConfigAuthRawRealm())
+	log.Info(nil, "AuthRawPublicClient: "+strconv.FormatBool(cfg.GetAuthClientConfigAuthRawPublicClient()))
+	log.Info(nil, "AuthRawClientID: "+cfg.GetAuthClientConfigAuthRawClientID())
+	log.Info(nil, "VerificationEnabled: "+strconv.FormatBool(cfg.GetVerificationEnabled()))
+	log.Info(nil, "VerificationDailyLimit: "+strconv.Itoa(cfg.GetVerificationDailyLimit()))
+	log.Info(nil, "VerificationAttemptsAllowed: "+strconv.Itoa(cfg.GetVerificationAttemptsAllowed()))
 }
 
 func gracefulShutdown(hs *http.Server, timeout time.Duration) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -57,7 +56,7 @@ func main() {
 		panic(err.Error())
 	}
 
-	printConfig(crtConfig)
+	crtConfig.PrintConfig()
 
 	srv := server.New(crtConfig)
 
@@ -79,13 +78,6 @@ func main() {
 	}()
 
 	gracefulShutdown(srv.HTTPServer(), srv.Config().GetGracefulTimeout())
-}
-
-func printConfig(cfg *configuration.Registry) {
-	log.Info(nil, "AuthRawConfig: "+cfg.GetAuthClientConfigAuthRaw())
-	log.Info(nil, "VerificationEnabled: "+strconv.FormatBool(cfg.GetVerificationEnabled()))
-	log.Info(nil, "VerificationDailyLimit: "+strconv.Itoa(cfg.GetVerificationDailyLimit()))
-	log.Info(nil, "VerificationAttemptsAllowed: "+strconv.Itoa(cfg.GetVerificationAttemptsAllowed()))
 }
 
 func gracefulShutdown(hs *http.Server, timeout time.Duration) {

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -112,10 +112,6 @@ objects:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                - name: REGISTRATION_SERVICE_CONFIG_MAP_NAME
-                  value: ${CONFIG_MAP_NAME}
-                - name: REGISTRATION_SERVICE_SECRET_NAME
-                  value: ${SECRET_NAME}
                 - name: WATCH_NAMESPACE
                   value: ${NAMESPACE}
                 - name: REGISTRATION_AUTH_CLIENT_LIBRARY_URL
@@ -210,10 +206,6 @@ parameters:
     value: '3'
   - name: ENVIRONMENT
     value: 'prod' # prod, stage, e2e-tests, dev, etc
-  - name: CONFIG_MAP_NAME
-    value: ''
-  - name: SECRET_NAME
-    value: ''
   - name: AUTH_CLIENT_LIBRARY_URL
     value: '' #use default value from reg-service configuration
   - name: AUTH_CLIENT_PUBLIC_KEYS_URL

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -128,36 +128,6 @@ objects:
                     configMapKeyRef:
                       name: registration-service
                       key: auth_client.public_keys_url
-                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_REALM
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: auth_client.config_raw.realm
-                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_AUTH_SERVER_URL
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: auth_client.config_raw.auth_server_url
-                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_SSL_REQUIRED
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: auth_client.config_raw.ssl_required
-                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_RESOURCE
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: auth_client.config_raw.resource
-                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_CLIENT_ID
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: auth_client.config_raw.client_id
-                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_PUBLIC_CLIENT
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: auth_client.config_raw.public_client
                 - name: REGISTRATION_VERIFICATION_ENABLED
                   valueFrom:
                     configMapKeyRef:
@@ -173,6 +143,11 @@ objects:
                     configMapKeyRef:
                       name: registration-service
                       key: verification.attempts_allowed
+                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.config_raw
   - kind: Service
     apiVersion: v1
     metadata:
@@ -222,12 +197,7 @@ objects:
       environment: ${ENVIRONMENT}
       auth_client.library_url: ${AUTH_CLIENT_LIBRARY_URL}
       auth_client.public_keys_url: ${AUTH_CLIENT_PUBLIC_KEYS_URL}
-      auth_client.config_raw.realm: ${AUTH_CLIENT_CONFIG_RAW_REALM}
-      auth_client.config_raw.auth_server_url: ${AUTH_CLIENT_CONFIG_RAW_AUTH_SERVER_URL}
-      auth_client.config_raw.ssl_required: ${AUTH_CLIENT_CONFIG_RAW_SSL_REQUIRED}
-      auth_client.config_raw.resource: ${AUTH_CLIENT_CONFIG_RAW_RESOURCE}
-      auth_client.config_raw.client_id: ${AUTH_CLIENT_CONFIG_RAW_CLIENT_ID}
-      auth_client.config_raw.public_client: ${AUTH_CLIENT_CONFIG_RAW_PUBLIC_CLIENT}
+      auth_client.config_raw: ${AUTH_CLIENT_CONFIG_RAW}
       verification.enabled: ${VERIFICATION_ENABLED}
       verification.daily_limit: ${VERIFICATION_DAILY_LIMIT}
       verification.attempts_allowed: ${VERIFICATION_ATTEMPTS_ALLOWED}
@@ -248,18 +218,8 @@ parameters:
     value: '' #use default value from reg-service configuration
   - name: AUTH_CLIENT_PUBLIC_KEYS_URL
     value: '' #use default value from reg-service configuration
-  - name: AUTH_CLIENT_CONFIG_RAW_REALM
+  - name: AUTH_CLIENT_CONFIG_RAW
     value: '' #use default value from reg-service configuration
-  - name: AUTH_CLIENT_CONFIG_RAW_AUTH_SERVER_URL
-    value: ''
-  - name: AUTH_CLIENT_CONFIG_RAW_SSL_REQUIRED
-    value: ''
-  - name: AUTH_CLIENT_CONFIG_RAW_RESOURCE
-    value: ''
-  - name: AUTH_CLIENT_CONFIG_RAW_CLIENT_ID
-    value: ''
-  - name: AUTH_CLIENT_CONFIG_RAW_PUBLIC_CLIENT
-    value: ''
   - name: VERIFICATION_ENABLED
     value: ''
   - name: VERIFICATION_DAILY_LIMIT

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -41,7 +41,6 @@ objects:
       - apiGroups:
           - ""
         resources:
-          - configmaps
           - secrets
         verbs:
           - get

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -18,26 +18,34 @@ objects:
       name: registration-service
       namespace: ${NAMESPACE}
     rules:
-    - apiGroups:
-      - toolchain.dev.openshift.com
-      resources:
-      - usersignups
-      verbs:
-      - create
-      - get
-    - apiGroups:
-      - toolchain.dev.openshift.com
-      resources:
-      - masteruserrecords
-      verbs:
-      - get
-    - apiGroups:
-      - toolchain.dev.openshift.com
-      resources:
-      - bannedusers
-      verbs:
-      - get
-      - list
+      - apiGroups:
+          - toolchain.dev.openshift.com
+        resources:
+          - usersignups
+        verbs:
+          - create
+          - get
+      - apiGroups:
+          - toolchain.dev.openshift.com
+        resources:
+          - masteruserrecords
+        verbs:
+          - get
+      - apiGroups:
+          - toolchain.dev.openshift.com
+        resources:
+          - bannedusers
+        verbs:
+          - get
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - secrets
+        verbs:
+          - get
+          - list
   - kind: RoleBinding
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
@@ -46,8 +54,8 @@ objects:
       name: registration-service
       namespace: ${NAMESPACE}
     subjects:
-    - kind: ServiceAccount
-      name: registration-service
+      - kind: ServiceAccount
+        name: registration-service
     roleRef:
       kind: Role
       name: registration-service
@@ -104,26 +112,67 @@ objects:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                - name: REGISTRATION_ENVIRONMENT
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: environment
+                - name: REGISTRATION_SERVICE_CONFIG_MAP_NAME
+                  value: ${CONFIG_MAP_NAME}
+                - name: REGISTRATION_SERVICE_SECRET_NAME
+                  value: ${SECRET_NAME}
+                - name: WATCH_NAMESPACE
+                  value: ${NAMESPACE}
                 - name: REGISTRATION_AUTH_CLIENT_LIBRARY_URL
                   valueFrom:
                     configMapKeyRef:
                       name: registration-service
                       key: auth_client.library_url
-                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: auth_client.config_raw
                 - name: REGISTRATION_AUTH_CLIENT_PUBLIC_KEYS_URL
                   valueFrom:
                     configMapKeyRef:
                       name: registration-service
                       key: auth_client.public_keys_url
+                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_REALM
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.config_raw.realm
+                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_AUTH_SERVER_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.config_raw.auth_server_url
+                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_SSL_REQUIRED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.config_raw.ssl_required
+                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_RESOURCE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.config_raw.resource
+                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_CLIENT_ID
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.config_raw.client_id
+                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW_PUBLIC_CLIENT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.config_raw.public_client
+                - name: REGISTRATION_VERIFICATION_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: verification.enabled
+                - name: REGISTRATION_VERIFICATION_DAILY_LIMIT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: verification.daily_limit
+                - name: REGISTRATION_VERIFICATION_ATTEMPTS_ALLOWED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: verification.attempts_allowed
   - kind: Service
     apiVersion: v1
     metadata:
@@ -172,8 +221,16 @@ objects:
     data:
       environment: ${ENVIRONMENT}
       auth_client.library_url: ${AUTH_CLIENT_LIBRARY_URL}
-      auth_client.config_raw.realm: ${AUTH_CLIENT_CONFIG_RAW_REALM}
       auth_client.public_keys_url: ${AUTH_CLIENT_PUBLIC_KEYS_URL}
+      auth_client.config_raw.realm: ${AUTH_CLIENT_CONFIG_RAW_REALM}
+      auth_client.config_raw.auth_server_url: ${AUTH_CLIENT_CONFIG_RAW_AUTH_SERVER_URL}
+      auth_client.config_raw.ssl_required: ${AUTH_CLIENT_CONFIG_RAW_SSL_REQUIRED}
+      auth_client.config_raw.resource: ${AUTH_CLIENT_CONFIG_RAW_RESOURCE}
+      auth_client.config_raw.client_id: ${AUTH_CLIENT_CONFIG_RAW_CLIENT_ID}
+      auth_client.config_raw.public_client: ${AUTH_CLIENT_CONFIG_RAW_PUBLIC_CLIENT}
+      verification.enabled: ${VERIFICATION_ENABLED}
+      verification.daily_limit: ${VERIFICATION_DAILY_LIMIT}
+      verification.attempts_allowed: ${VERIFICATION_ATTEMPTS_ALLOWED}
 parameters:
   - name: NAMESPACE
     value: 'toolchain-host-operator'
@@ -183,9 +240,29 @@ parameters:
     value: '3'
   - name: ENVIRONMENT
     value: 'prod' # prod, stage, e2e-tests, dev, etc
+  - name: CONFIG_MAP_NAME
+    value: ''
+  - name: SECRET_NAME
+    value: ''
   - name: AUTH_CLIENT_LIBRARY_URL
-    value: '' #use default value from reg-service configuration
-  - name: AUTH_CLIENT_CONFIG_RAW
     value: '' #use default value from reg-service configuration
   - name: AUTH_CLIENT_PUBLIC_KEYS_URL
     value: '' #use default value from reg-service configuration
+  - name: AUTH_CLIENT_CONFIG_RAW_REALM
+    value: '' #use default value from reg-service configuration
+  - name: AUTH_CLIENT_CONFIG_RAW_AUTH_SERVER_URL
+    value: ''
+  - name: AUTH_CLIENT_CONFIG_RAW_SSL_REQUIRED
+    value: ''
+  - name: AUTH_CLIENT_CONFIG_RAW_RESOURCE
+    value: ''
+  - name: AUTH_CLIENT_CONFIG_RAW_CLIENT_ID
+    value: ''
+  - name: AUTH_CLIENT_CONFIG_RAW_PUBLIC_CLIENT
+    value: ''
+  - name: VERIFICATION_ENABLED
+    value: ''
+  - name: VERIFICATION_DAILY_LIMIT
+    value: ''
+  - name: VERIFICATION_ATTEMPTS_ALLOWED
+    value: ''

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -109,21 +109,21 @@ objects:
                     configMapKeyRef:
                       name: registration-service
                       key: environment
-#                - name: REGISTRATION_AUTH_CLIENT_LIBRARY_URL
-#                  valueFrom:
-#                    configMapKeyRef:
-#                      name: registration-service
-#                      key: auth_client.library_url
-#                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW
-#                  valueFrom:
-#                    configMapKeyRef:
-#                      name: registration-service
-#                      key: auth_client.config_raw
-#                - name: REGISTRATION_AUTH_CLIENT_PUBLIC_KEYS_URL
-#                  valueFrom:
-#                    configMapKeyRef:
-#                      name: registration-service
-#                      key: auth_client.public_keys_url
+                - name: REGISTRATION_AUTH_CLIENT_LIBRARY_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.library_url
+                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.config_raw
+                - name: REGISTRATION_AUTH_CLIENT_PUBLIC_KEYS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.public_keys_url
   - kind: Service
     apiVersion: v1
     metadata:
@@ -171,9 +171,9 @@ objects:
     type: Opaque
     data:
       environment: ${ENVIRONMENT}
-#      auth_client.library_url: ${AUTH_CLIENT_LIBRARY_URL}
-#      auth_client.config_raw: ${AUTH_CLIENT_CONFIG_RAW}
-#      auth_client.public_keys_url: ${AUTH_CLIENT_PUBLIC_KEYS_URL}
+      auth_client.library_url: ${AUTH_CLIENT_LIBRARY_URL}
+      auth_client.config_raw.realm: ${AUTH_CLIENT_CONFIG_RAW_REALM}
+      auth_client.public_keys_url: ${AUTH_CLIENT_PUBLIC_KEYS_URL}
 parameters:
   - name: NAMESPACE
     value: 'toolchain-host-operator'

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -109,21 +109,21 @@ objects:
                     configMapKeyRef:
                       name: registration-service
                       key: environment
-                - name: REGISTRATION_AUTH_CLIENT_LIBRARY_URL
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: auth_client.library_url
-                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: auth_client.config_raw
-                - name: REGISTRATION_AUTH_CLIENT_PUBLIC_KEYS_URL
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: auth_client.public_keys_url
+#                - name: REGISTRATION_AUTH_CLIENT_LIBRARY_URL
+#                  valueFrom:
+#                    configMapKeyRef:
+#                      name: registration-service
+#                      key: auth_client.library_url
+#                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW
+#                  valueFrom:
+#                    configMapKeyRef:
+#                      name: registration-service
+#                      key: auth_client.config_raw
+#                - name: REGISTRATION_AUTH_CLIENT_PUBLIC_KEYS_URL
+#                  valueFrom:
+#                    configMapKeyRef:
+#                      name: registration-service
+#                      key: auth_client.public_keys_url
   - kind: Service
     apiVersion: v1
     metadata:
@@ -171,9 +171,9 @@ objects:
     type: Opaque
     data:
       environment: ${ENVIRONMENT}
-      auth_client.library_url: ${AUTH_CLIENT_LIBRARY_URL}
-      auth_client.config_raw: ${AUTH_CLIENT_CONFIG_RAW}
-      auth_client.public_keys_url: ${AUTH_CLIENT_PUBLIC_KEYS_URL}
+#      auth_client.library_url: ${AUTH_CLIENT_LIBRARY_URL}
+#      auth_client.config_raw: ${AUTH_CLIENT_CONFIG_RAW}
+#      auth_client.public_keys_url: ${AUTH_CLIENT_PUBLIC_KEYS_URL}
 parameters:
   - name: NAMESPACE
     value: 'toolchain-host-operator'

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d
+	github.com/codeready-toolchain/api v0.0.0-20200805071634-c62858ce3204
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200805140615-5132f35e5270
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-contrib/gzip v0.0.1
 	github.com/gin-contrib/sse v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,10 +128,10 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd h1:G54EWvJPeJer/p07NuKKMYmXKscSnQcRMTH63AzWN+w=
-github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d h1:N9CxG2CBZk4JQsFR5lI96Km0dNBNIgxBWlCRB/UooB0=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d/go.mod h1:IC9kx4UmJCII7dEmH2ChvgGYcmZ/o9P6F/b89UvEHOw=
+github.com/codeready-toolchain/api v0.0.0-20200805071634-c62858ce3204 h1:eI4iTTEW1YF3FUNVIHxZPYeCiAyFOQL4uxh3VI5TwVY=
+github.com/codeready-toolchain/api v0.0.0-20200805071634-c62858ce3204/go.mod h1:/tMojFnmqPoMCjgq1me9lC5jF5zCgcGhtoIp6Q+sRGw=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200805140615-5132f35e5270 h1:1F3TEDIyJSu9PW8Gk7lhL1N24ArVDjxFhFtqvN4gRGk=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200805140615-5132f35e5270/go.mod h1:gGWlFDAr0VScx9t8Prhz46LiYd0bAhNclraz6lGLV0Q=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -393,7 +393,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekf
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -730,7 +729,6 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/openshift/api v0.0.0-20200414152312-3e8f22fb0b56 h1:6svnLQpAqY5w2TKjIyDKFC/JUaQcsDLSRqc8xXxxBW8=
 github.com/openshift/api v0.0.0-20200414152312-3e8f22fb0b56/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
-github.com/openshift/generic-admission-server v1.14.0/go.mod h1:GD9KN/W4KxqRQGVMbqQHpHzb2XcQVvLCaBaSciqXvfM=
 github.com/openshift/library-go v0.0.0-20191121124438-7c776f7cc17a/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
@@ -1413,15 +1411,11 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/letsencrypt v0.0.3/go.mod h1:buyQKZ6IXrRnB7TdkHP0RyEybLx18HHyOSoTyoOLqNY=
-sigs.k8s.io/controller-runtime v0.5.0 h1:CbqIy5fbUX+4E9bpnBFd204YAzRYlM9SWW77BbrcDQo=
-sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKGhb2sCtAXiT8=
 sigs.k8s.io/controller-runtime v0.5.2 h1:pyXbUfoTo+HA3jeIfr0vgi+1WtmNh0CwlcnQGLXwsSw=
 sigs.k8s.io/controller-runtime v0.5.2/go.mod h1:JZUwSMVbxDupo0lTJSSFP5pimEyxGynROImSsqIOx1A=
 sigs.k8s.io/controller-tools v0.2.4 h1:la1h46EzElvWefWLqfsXrnsO3lZjpkI0asTpX6h8PLA=
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.2.8/go.mod h1:9VKHPszmf2DHz/QmHkcfZoewO6BL7pPs9uAiBVsaJSE=
-sigs.k8s.io/kubefed v0.3.0 h1:YPFAkWeP8AehJhfeoLHLNbIm22HoF6erSM0OZq7hcyI=
-sigs.k8s.io/kubefed v0.3.0/go.mod h1:/X4yMEvaclI6CAeVwFBjtGJ1E3gwXcuVwNbGPXPz+CM=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -39,6 +39,9 @@ func (s *TestKeyManagerSuite) TestKeyManager() {
 }
 
 func (s *TestKeyManagerSuite) TestKeyFetching() {
+	restore := commontest.SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
+
 	// create test keys
 	tokengenerator := authsupport.NewTokenManager()
 	kid0 := uuid.NewV4().String()
@@ -216,6 +219,9 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 }
 
 func (s *TestKeyManagerSuite) TestE2EKeyFetching() {
+	restore := commontest.SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
+
 	s.Run("retrieve key for e2e-tests environment", func() {
 		s.Config.GetViperInstance().Set("environment", "e2e-tests")
 		keyManager, err := auth.NewKeyManager(s.Config)

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -136,17 +136,17 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		assert.EqualError(s.T(), err, "invalid character 's' looking for beginning of object key string")
 	})
 
-	s.Run("parse keys, invalid url", func() {
-		// Set the config for testing mode, the handler may use this.
-		notAnURL := "not an url"
-		s.Config.GetViperInstance().Set("auth_client.public_keys_url", notAnURL)
-		assert.Equal(s.T(), s.Config.GetAuthClientPublicKeysURL(), notAnURL, "key url not set correctly for testing")
-
-		// Create KeyManager instance.
-		_, err := auth.NewKeyManager(s.Config)
-		// this needs to fail with an error
-		assert.EqualError(s.T(), err, "Get not%20an%20url: unsupported protocol scheme \"\"")
-	})
+	//s.Run("parse keys, invalid url", func() {
+	//	// Set the config for testing mode, the handler may use this.
+	//	notAnURL := "not an url"
+	//	s.Config.GetViperInstance().Set("auth_client.public_keys_url", notAnURL)
+	//	assert.Equal(s.T(), s.Config.GetAuthClientPublicKeysURL(), notAnURL, "key url not set correctly for testing")
+	//
+	//	// Create KeyManager instance.
+	//	_, err := auth.NewKeyManager(s.Config)
+	//	// this needs to fail with an error
+	//	assert.EqualError(s.T(), err, "Get not%20an%20url: unsupported protocol scheme \"\"")
+	//})
 
 	s.Run("parse keys, server not reachable", func() {
 		// Set the config for testing mode, the handler may use this.

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -229,7 +229,7 @@ func (s *TestKeyManagerSuite) TestE2EKeyFetching() {
 		}
 	})
 
-	checkE2EKeysNotFound := func(config *configuration.Registry) {
+	checkE2EKeysNotFound := func(config *configuration.Config) {
 		keyManager, err := auth.NewKeyManager(config)
 		require.NoError(s.T(), err)
 		keys := authsupport.GetE2ETestPublicKey()

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -136,17 +136,17 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		assert.EqualError(s.T(), err, "invalid character 's' looking for beginning of object key string")
 	})
 
-	//s.Run("parse keys, invalid url", func() {
-	//	// Set the config for testing mode, the handler may use this.
-	//	notAnURL := "not an url"
-	//	s.Config.GetViperInstance().Set("auth_client.public_keys_url", notAnURL)
-	//	assert.Equal(s.T(), s.Config.GetAuthClientPublicKeysURL(), notAnURL, "key url not set correctly for testing")
-	//
-	//	// Create KeyManager instance.
-	//	_, err := auth.NewKeyManager(s.Config)
-	//	// this needs to fail with an error
-	//	assert.EqualError(s.T(), err, "Get not%20an%20url: unsupported protocol scheme \"\"")
-	//})
+	s.Run("parse keys, invalid url", func() {
+		// Set the config for testing mode, the handler may use this.
+		notAnURL := "not an url"
+		s.Config.GetViperInstance().Set("auth_client.public_keys_url", notAnURL)
+		assert.Equal(s.T(), s.Config.GetAuthClientPublicKeysURL(), notAnURL, "key url not set correctly for testing")
+
+		// Create KeyManager instance.
+		_, err := auth.NewKeyManager(s.Config)
+		// this needs to fail with an error
+		assert.EqualError(s.T(), err, "Get not%20an%20url: unsupported protocol scheme \"\"")
+	})
 
 	s.Run("parse keys, server not reachable", func() {
 		// Set the config for testing mode, the handler may use this.

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -243,7 +243,7 @@ func (s *TestKeyManagerSuite) TestE2EKeyFetching() {
 	}
 
 	s.Run("fail to retrieve e2e keys for default environment", func() {
-		config, err := configuration.New("")
+		config, err := configuration.New("", commontest.NewFakeClient(s.T()))
 		require.NoError(s.T(), err)
 
 		checkE2EKeysNotFound(config)
@@ -253,7 +253,7 @@ func (s *TestKeyManagerSuite) TestE2EKeyFetching() {
 	s.Run("fail to retrieve e2e keys for prod environment", func() {
 		resetFunc := commontest.SetEnvVarAndRestore(s.T(), key, "prod")
 		defer resetFunc()
-		config, err := configuration.New("")
+		config, err := configuration.New("", commontest.NewFakeClient(s.T()))
 		require.NoError(s.T(), err)
 
 		checkE2EKeysNotFound(config)
@@ -262,7 +262,7 @@ func (s *TestKeyManagerSuite) TestE2EKeyFetching() {
 	s.Run("fail to retrieve e2e keys if environment is not set", func() {
 		resetFunc := commontest.UnsetEnvVarAndRestore(s.T(), key)
 		defer resetFunc()
-		config, err := configuration.New("")
+		config, err := configuration.New("", commontest.NewFakeClient(s.T()))
 		require.NoError(s.T(), err)
 
 		checkE2EKeysNotFound(config)

--- a/pkg/auth/tokenparser_test.go
+++ b/pkg/auth/tokenparser_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/test"
 	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 
 	uuid "github.com/satori/go.uuid"
@@ -26,6 +27,8 @@ func TestRunTokenParserSuite(t *testing.T) {
 }
 
 func (s *TestTokenParserSuite) TestTokenParser() {
+	restore := commontest.SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 
 	configRegistry, err := configuration.CreateEmptyRegistry(NewFakeClient(s.T()))
 	require.NoError(s.T(), err)

--- a/pkg/auth/tokenparser_test.go
+++ b/pkg/auth/tokenparser_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/test"
+	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 
 	uuid "github.com/satori/go.uuid"
@@ -25,12 +26,14 @@ func TestRunTokenParserSuite(t *testing.T) {
 }
 
 func (s *TestTokenParserSuite) TestTokenParser() {
-	configRegistry := configuration.CreateEmptyRegistry()
+
+	configRegistry, err := configuration.CreateEmptyRegistry(NewFakeClient(s.T()))
+	require.NoError(s.T(), err)
 
 	// create test keys
 	tokengenerator := authsupport.NewTokenManager()
 	kid0 := uuid.NewV4().String()
-	_, err := tokengenerator.AddPrivateKey(kid0)
+	_, err = tokengenerator.AddPrivateKey(kid0)
 	require.NoError(s.T(), err)
 	kid1 := uuid.NewV4().String()
 	_, err = tokengenerator.AddPrivateKey(kid1)

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -3,6 +3,7 @@
 package configuration
 
 import (
+	"os"
 	"strings"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.Log.WithName("manager")
+var log = logf.Log.WithName("configuration")
 
 var (
 	// Commit current build commit set by build script.
@@ -136,7 +137,7 @@ const (
 	DefaultVerificationMessageTemplate = "Your verification code for Red Hat Developer Sandbox is: %s"
 )
 
-// Registry encapsulates the Viper configuration registry which stores the
+// Config encapsulates the Viper configuration registry which stores the
 // configuration data in-memory.
 type Config struct {
 	v            *viper.Viper
@@ -145,12 +146,7 @@ type Config struct {
 
 // CreateEmptyRegistry creates an initial, empty registry.
 func CreateEmptyRegistry(cl client.Client) (*Config, error) {
-
-	err := configuration.LoadFromConfigMap(EnvPrefix, "REGISTRATION_SERVICE_CONFIG_MAP_NAME", cl)
-	if err != nil {
-		return nil, err
-	}
-
+	os.Setenv("REGISTRATION_SERVICE_SECRET_NAME", "reg-service-secret")
 	secret, err := configuration.LoadFromSecret("REGISTRATION_SERVICE_SECRET_NAME", cl)
 	if err != nil {
 		return nil, err

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -79,8 +79,8 @@ const (
 	varAuthClientConfigRawRealm     = "auth_client.config_raw.realm"
 	DefaultAuthClientConfigRawRealm = "toolchain-public"
 
-	varAuthClientConfigRawServerURL     = "auth_client.config_raw.auth_server_url"
-	DefaultAuthClientConfigRawServerURL = "https://sso.prod-preview.openshift.io/auth"
+	varAuthClientConfigRawAuthServerURL     = "auth_client.config_raw.auth_server_url"
+	DefaultAuthClientConfigRawAuthServerURL = "https://sso.prod-preview.openshift.io/auth"
 
 	varAuthClientConfigRawSSLRequired = "auth_client.config_raw.ssl_required"
 	DefaultAuthClientRawSSLRequired   = "none"
@@ -92,7 +92,7 @@ const (
 	DefaultAuthClientConfigRawClientID = "crt"
 
 	varAuthClientConfigRawPublicClient     = "auth_client.config_raw.public_client"
-	DefaultAuthClientConfigRawPublicClient = "true"
+	DefaultAuthClientConfigRawPublicClient = true
 
 	varAuthClientConfigContentType = "auth_client.config.content_type"
 	// DefaultAuthClientConfigContentType specifies the auth client config content type.
@@ -204,7 +204,7 @@ func (c *Registry) setConfigDefaults() {
 	c.v.SetDefault(varAuthClientPublicKeysURL, DefaultAuthClientPublicKeysURL)
 	c.v.SetDefault(varNamespace, DefaultNamespace)
 	c.v.SetDefault(varAuthClientConfigRawRealm, DefaultAuthClientConfigRawRealm)
-	c.v.SetDefault(varAuthClientConfigRawServerURL, DefaultAuthClientConfigRawServerURL)
+	c.v.SetDefault(varAuthClientConfigRawAuthServerURL, DefaultAuthClientConfigRawAuthServerURL)
 	c.v.SetDefault(varAuthClientConfigRawSSLRequired, DefaultAuthClientRawSSLRequired)
 	c.v.SetDefault(varAuthClientConfigRawResource, DefaultAuthClientConfigRawResource)
 	c.v.SetDefault(varAuthClientConfigRawClientID, DefaultAuthClientConfigRawClientID)
@@ -281,27 +281,27 @@ func (c *Registry) GetAuthClientConfigAuthContentType() string {
 	return c.v.GetString(varAuthClientConfigContentType)
 }
 
-func (c *Registry) GetAuthClientConfigAuthRawClientID() string {
+func (c *Registry) GetAuthClientConfigRawClientID() string {
 	return c.v.GetString(varAuthClientConfigRawClientID)
 }
 
-func (c *Registry) GetAuthClientConfigAuthRawPublicClient() bool {
+func (c *Registry) GetAuthClientConfigRawPublicClient() bool {
 	return c.v.GetBool(varAuthClientConfigRawPublicClient)
 }
 
-func (c *Registry) GetAuthClientConfigAuthRawRealm() string {
+func (c *Registry) GetAuthClientConfigRawRealm() string {
 	return c.v.GetString(varAuthClientConfigRawRealm)
 }
 
-func (c *Registry) GetAuthClientConfigAuthRawResource() string {
+func (c *Registry) GetAuthClientConfigRawResource() string {
 	return c.v.GetString(varAuthClientConfigRawResource)
 }
 
-func (c *Registry) GetAuthClientConfigAuthRawServerURL() string {
-	return c.v.GetString(varAuthClientConfigRawServerURL)
+func (c *Registry) GetAuthClientConfigRawAuthServerURL() string {
+	return c.v.GetString(varAuthClientConfigRawAuthServerURL)
 }
 
-func (c *Registry) GetAuthClientConfigAuthRawSSLReuired() string {
+func (c *Registry) GetAuthClientConfigRawSSLRequired() string {
 	return c.v.GetString(varAuthClientConfigRawSSLRequired)
 }
 

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -72,16 +72,12 @@ const (
 	// DefaultAuthClientLibraryURL is the default auth library location.
 	DefaultAuthClientLibraryURL = "https://sso.prod-preview.openshift.io/auth/js/keycloak.js"
 
-	varAuthClientConfigRaw = "auth_client.config.raw"
-	// DefaultAuthClientConfigRaw specifies the auth client config.
-	DefaultAuthClientConfigRaw = `{
-  "realm": "toolchain-public",
-  "auth-server-url": "https://sso.prod-preview.openshift.io/auth",
-  "ssl-required": "none",
-  "resource": "crt",
-  "clientId": "crt",
-  "public-client": true
-}`
+	varAuthClientConfigRawRealm        = "auth_client.config_raw.realm"
+	varAuthClientConfigRawServerURL    = "auth_client.config_raw.auth_server_url"
+	varAuthClientConfigRawSSLRequired  = "auth_client.config_raw.ssl-required"
+	varAuthClientConfigRawResource     = "auth_client.config_raw.resource"
+	varAuthClientConfigRawClientID     = "auth_client.config_raw.clientId"
+	varAuthClientConfigRawPublicClient = "auth_client.config_raw.public_client"
 
 	varAuthClientConfigContentType = "auth_client.config.content_type"
 	// DefaultAuthClientConfigContentType specifies the auth client config content type.
@@ -149,10 +145,16 @@ func (c *Registry) setConfigDefaults() {
 	c.v.SetDefault(varLogJSON, DefaultLogJSON)
 	c.v.SetDefault(varGracefulTimeout, DefaultGracefulTimeout)
 	c.v.SetDefault(varAuthClientLibraryURL, DefaultAuthClientLibraryURL)
-	c.v.SetDefault(varAuthClientConfigRaw, DefaultAuthClientConfigRaw)
 	c.v.SetDefault(varAuthClientConfigContentType, DefaultAuthClientConfigContentType)
 	c.v.SetDefault(varAuthClientPublicKeysURL, DefaultAuthClientPublicKeysURL)
 	c.v.SetDefault(varNamespace, DefaultNamespace)
+
+	c.v.SetDefault(varAuthClientConfigRawRealm, "")
+	c.v.SetDefault(varAuthClientConfigRawServerURL, "")
+	c.v.SetDefault(varAuthClientConfigRawSSLRequired, "")
+	c.v.SetDefault(varAuthClientConfigRawResource, "")
+	c.v.SetDefault(varAuthClientConfigRawClientID, "")
+	c.v.SetDefault(varAuthClientConfigRawPublicClient, "")
 }
 
 // GetHTTPAddress returns the HTTP address (as set via default, config file, or
@@ -224,8 +226,28 @@ func (c *Registry) GetAuthClientConfigAuthContentType() string {
 
 // GetAuthClientConfigAuthRaw returns the auth config config (as
 // set via config file or environment variable).
-func (c *Registry) GetAuthClientConfigAuthRaw() string {
-	return c.v.GetString(varAuthClientConfigRaw)
+func (c *Registry) GetAuthClientConfigAuthRawClientID() string {
+	return c.v.GetString(varAuthClientConfigRawClientID)
+}
+
+func (c *Registry) GetAuthClientConfigAuthRawPublicClient() string {
+	return c.v.GetString(varAuthClientConfigRawPublicClient)
+}
+
+func (c *Registry) GetAuthClientConfigAuthRawRealm() string {
+	return c.v.GetString(varAuthClientConfigRawRealm)
+}
+
+func (c *Registry) GetAuthClientConfigAuthRawResource() string {
+	return c.v.GetString(varAuthClientConfigRawResource)
+}
+
+func (c *Registry) GetAuthClientConfigAuthRawServerURL() string {
+	return c.v.GetString(varAuthClientConfigRawServerURL)
+}
+
+func (c *Registry) GetAuthClientConfigAuthRawSSLReuired() string {
+	return c.v.GetString(varAuthClientConfigRawSSLRequired)
 }
 
 // GetAuthClientPublicKeysURL returns the public keys URL (as set via config file

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -76,23 +76,15 @@ const (
 	// DefaultAuthClientLibraryURL is the default auth library location.
 	DefaultAuthClientLibraryURL = "https://sso.prod-preview.openshift.io/auth/js/keycloak.js"
 
-	varAuthClientConfigRawRealm     = "auth_client.config_raw.realm"
-	DefaultAuthClientConfigRawRealm = "toolchain-public"
-
-	varAuthClientConfigRawAuthServerURL     = "auth_client.config_raw.auth_server_url"
-	DefaultAuthClientConfigRawAuthServerURL = "https://sso.prod-preview.openshift.io/auth"
-
-	varAuthClientConfigRawSSLRequired = "auth_client.config_raw.ssl_required"
-	DefaultAuthClientRawSSLRequired   = "none"
-
-	varAuthClientConfigRawResource     = "auth_client.config_raw.resource"
-	DefaultAuthClientConfigRawResource = "crt"
-
-	varAuthClientConfigRawClientID     = "auth_client.config_raw.client_id"
-	DefaultAuthClientConfigRawClientID = "crt"
-
-	varAuthClientConfigRawPublicClient     = "auth_client.config_raw.public_client"
-	DefaultAuthClientConfigRawPublicClient = true
+	varAuthClientConfigRaw     = "auth_client.config.raw"
+	DefaultAuthClientConfigRaw = `{
+		"realm": "toolchain-public",
+		"auth-server-url": "https://sso.prod-preview.openshift.io/auth",
+		"ssl-required": "none",
+		"resource": "crt",
+		"clientId": "crt",
+		"public-client": true
+	}`
 
 	varAuthClientConfigContentType = "auth_client.config.content_type"
 	// DefaultAuthClientConfigContentType specifies the auth client config content type.
@@ -203,12 +195,7 @@ func (c *Registry) setConfigDefaults() {
 	c.v.SetDefault(varAuthClientConfigContentType, DefaultAuthClientConfigContentType)
 	c.v.SetDefault(varAuthClientPublicKeysURL, DefaultAuthClientPublicKeysURL)
 	c.v.SetDefault(varNamespace, DefaultNamespace)
-	c.v.SetDefault(varAuthClientConfigRawRealm, DefaultAuthClientConfigRawRealm)
-	c.v.SetDefault(varAuthClientConfigRawAuthServerURL, DefaultAuthClientConfigRawAuthServerURL)
-	c.v.SetDefault(varAuthClientConfigRawSSLRequired, DefaultAuthClientRawSSLRequired)
-	c.v.SetDefault(varAuthClientConfigRawResource, DefaultAuthClientConfigRawResource)
-	c.v.SetDefault(varAuthClientConfigRawClientID, DefaultAuthClientConfigRawClientID)
-	c.v.SetDefault(varAuthClientConfigRawPublicClient, DefaultAuthClientConfigRawPublicClient)
+	c.v.SetDefault(varAuthClientConfigRaw, DefaultAuthClientConfigRaw)
 	c.v.SetDefault(varVerificationEnabled, DefaultVerificationEnabled)
 	c.v.SetDefault(varVerificationDailyLimit, DefaultVerificationDailyLimit)
 	c.v.SetDefault(varVerificationAttemptsAllowed, DefaultVerificationAttemptsAllowed)
@@ -281,28 +268,8 @@ func (c *Registry) GetAuthClientConfigAuthContentType() string {
 	return c.v.GetString(varAuthClientConfigContentType)
 }
 
-func (c *Registry) GetAuthClientConfigRawClientID() string {
-	return c.v.GetString(varAuthClientConfigRawClientID)
-}
-
-func (c *Registry) GetAuthClientConfigRawPublicClient() bool {
-	return c.v.GetBool(varAuthClientConfigRawPublicClient)
-}
-
-func (c *Registry) GetAuthClientConfigRawRealm() string {
-	return c.v.GetString(varAuthClientConfigRawRealm)
-}
-
-func (c *Registry) GetAuthClientConfigRawResource() string {
-	return c.v.GetString(varAuthClientConfigRawResource)
-}
-
-func (c *Registry) GetAuthClientConfigRawAuthServerURL() string {
-	return c.v.GetString(varAuthClientConfigRawAuthServerURL)
-}
-
-func (c *Registry) GetAuthClientConfigRawSSLRequired() string {
-	return c.v.GetString(varAuthClientConfigRawSSLRequired)
+func (c *Registry) GetAuthClientConfigAuthRaw() string {
+	return c.v.GetString(varAuthClientConfigRaw)
 }
 
 // GetTwilioAccountSID is the Twilio account identifier, used for sending phone verification messages

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -285,8 +285,8 @@ func (c *Registry) GetAuthClientConfigAuthRawClientID() string {
 	return c.v.GetString(varAuthClientConfigRawClientID)
 }
 
-func (c *Registry) GetAuthClientConfigAuthRawPublicClient() string {
-	return c.v.GetString(varAuthClientConfigRawPublicClient)
+func (c *Registry) GetAuthClientConfigAuthRawPublicClient() bool {
+	return c.v.GetBool(varAuthClientConfigRawPublicClient)
 }
 
 func (c *Registry) GetAuthClientConfigAuthRawRealm() string {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -338,41 +338,14 @@ func (s *TestConfigurationSuite) TestGetEnvironmentAndTestingMode() {
 	})
 }
 
-func (s *TestConfigurationSuite) TestGetAuthClientConfigRawPublicClient() {
-	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW_PUBLIC_CLIENT"
+func (s *TestConfigurationSuite) TestGetAuthClientConfigRaw() {
+	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW"
 
 	s.Run("default", func() {
 		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 		defer resetFunc()
 		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), configuration.DefaultAuthClientConfigRawPublicClient, config.GetAuthClientConfigRawPublicClient())
-	})
-
-	s.Run("file", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		newVal := "false"
-		config := s.getFileConfiguration(`auth_client.config_raw.public_client: "` + newVal + `"`)
-		assert.Equal(s.T(), false, config.GetAuthClientConfigRawPublicClient())
-	})
-
-	s.Run("env overwrite", func() {
-		newVal := "false"
-		err := os.Setenv(key, newVal)
-		require.NoError(s.T(), err)
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), false, config.GetAuthClientConfigRawPublicClient())
-	})
-}
-
-func (s *TestConfigurationSuite) TestGetAuthClientConfigRawAuthServerURL() {
-	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW_AUTH_SERVER_URL"
-
-	s.Run("default", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), configuration.DefaultAuthClientConfigRawAuthServerURL, config.GetAuthClientConfigRawAuthServerURL())
+		assert.Equal(s.T(), configuration.DefaultAuthClientConfigRaw, config.GetAuthClientConfigAuthRaw())
 	})
 
 	s.Run("file", func() {
@@ -381,8 +354,8 @@ func (s *TestConfigurationSuite) TestGetAuthClientConfigRawAuthServerURL() {
 		u, err := uuid.NewV4()
 		require.NoError(s.T(), err)
 		newVal := u.String()
-		config := s.getFileConfiguration(`auth_client.config_raw.auth_server_url: "` + newVal + `"`)
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigRawAuthServerURL())
+		config := s.getFileConfiguration(`auth_client.config.raw: "` + newVal + `"`)
+		assert.Equal(s.T(), newVal, config.GetAuthClientConfigAuthRaw())
 	})
 
 	s.Run("env overwrite", func() {
@@ -392,131 +365,7 @@ func (s *TestConfigurationSuite) TestGetAuthClientConfigRawAuthServerURL() {
 		err = os.Setenv(key, newVal)
 		require.NoError(s.T(), err)
 		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigRawAuthServerURL())
-	})
-}
-
-func (s *TestConfigurationSuite) TestGetAuthClientConfigRawSSLRequired() {
-	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW_SSL_REQUIRED"
-
-	s.Run("default", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), configuration.DefaultAuthClientRawSSLRequired, config.GetAuthClientConfigRawSSLRequired())
-	})
-
-	s.Run("file", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		newVal := u.String()
-		config := s.getFileConfiguration(`auth_client.config_raw.ssl_required: "` + newVal + `"`)
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigRawSSLRequired())
-	})
-
-	s.Run("env overwrite", func() {
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		newVal := u.String()
-		err = os.Setenv(key, newVal)
-		require.NoError(s.T(), err)
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigRawSSLRequired())
-	})
-}
-
-func (s *TestConfigurationSuite) TestGetAuthClientConfigRawRealm() {
-	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW_REALM"
-
-	s.Run("default", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), configuration.DefaultAuthClientConfigRawRealm, config.GetAuthClientConfigRawRealm())
-	})
-
-	s.Run("file", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		newVal := u.String()
-		config := s.getFileConfiguration(`auth_client.config_raw.realm: "` + newVal + `"`)
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigRawRealm())
-	})
-
-	s.Run("env overwrite", func() {
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		newVal := u.String()
-		err = os.Setenv(key, newVal)
-		require.NoError(s.T(), err)
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigRawRealm())
-	})
-}
-
-func (s *TestConfigurationSuite) TestGetAuthClientConfigRawResource() {
-	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW_RESOURCE"
-
-	s.Run("default", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), configuration.DefaultAuthClientConfigRawResource, config.GetAuthClientConfigRawResource())
-	})
-
-	s.Run("file", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		newVal := u.String()
-		config := s.getFileConfiguration(`auth_client.config_raw.resource: "` + newVal + `"`)
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigRawResource())
-	})
-
-	s.Run("env overwrite", func() {
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		newVal := u.String()
-		err = os.Setenv(key, newVal)
-		require.NoError(s.T(), err)
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigRawResource())
-	})
-}
-
-func (s *TestConfigurationSuite) TestGetAuthClientConfigRawClientID() {
-	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW_CLIENT_ID"
-
-	s.Run("default", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), configuration.DefaultAuthClientConfigRawClientID, config.GetAuthClientConfigRawClientID())
-	})
-
-	s.Run("file", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		newVal := u.String()
-		config := s.getFileConfiguration(`auth_client.config_raw.client_id: "` + newVal + `"`)
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigRawClientID())
-	})
-
-	s.Run("env overwrite", func() {
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		newVal := u.String()
-		err = os.Setenv(key, newVal)
-		require.NoError(s.T(), err)
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigRawClientID())
+		assert.Equal(s.T(), newVal, config.GetAuthClientConfigAuthRaw())
 	})
 }
 
@@ -886,15 +735,10 @@ func (s *TestConfigurationSuite) TestLoadConfigMap() {
 				Namespace: "toolchain-host-operator",
 			},
 			Data: map[string]string{
-				"auth_client.config_raw.realm":           "test-realm",
-				"auth_client.config_raw.auth_server_url": "test-auth-server-url",
-				"auth_client.config_raw.ssl_required":    "test-ssl-required",
-				"auth_client.config_raw.resource":        "test-resource",
-				"auth_client.config_raw.client_id":       "test-client-id",
-				"auth_client.config_raw.public_client":   "true",
-				"verification.enabled":                   "false",
-				"verification.daily_limit":               "20",
-				"verification.attempts_allowed":          "100",
+				"auth_client.config_raw":        "{\"realm\": \"toolchain-public\",\"auth-server-url\": \"https://sso.prod-preview.openshift.io/auth\",\"ssl-required\": \"none\",\"resource\": \"crt\",\"clientId\": \"crt\",\"public-client\": \"true\"}",
+				"verification.daily_limit":      "100",
+				"verification.enabled":          "false",
+				"verification.attempts_allowed": "120",
 			},
 		}
 
@@ -903,15 +747,10 @@ func (s *TestConfigurationSuite) TestLoadConfigMap() {
 
 		// then
 		require.NoError(t, err)
-		assert.Equal(t, "test-realm", config.GetAuthClientConfigRawRealm())
-		assert.Equal(t, "test-auth-server-url", config.GetAuthClientConfigRawAuthServerURL())
-		assert.Equal(t, "test-ssl-required", config.GetAuthClientConfigRawSSLRequired())
-		assert.Equal(t, "test-resource", config.GetAuthClientConfigRawResource())
-		assert.Equal(t, "test-client-id", config.GetAuthClientConfigRawClientID())
-		assert.Equal(t, true, config.GetAuthClientConfigRawPublicClient())
+		assert.Equal(t, "{\"realm\": \"toolchain-public\",\"auth-server-url\": \"https://sso.prod-preview.openshift.io/auth\",\"ssl-required\": \"none\",\"resource\": \"crt\",\"clientId\": \"crt\",\"public-client\": \"true\"}", config.GetAuthClientConfigAuthRaw())
 		assert.Equal(t, false, config.GetVerificationEnabled())
-		assert.Equal(t, 20, config.GetVerificationDailyLimit())
-		assert.Equal(t, 100, config.GetVerificationAttemptsAllowed())
+		assert.Equal(t, 100, config.GetVerificationDailyLimit())
+		assert.Equal(t, 120, config.GetVerificationAttemptsAllowed())
 	})
 
 	s.T().Run("secret not found", func(t *testing.T) {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -32,7 +32,7 @@ func TestRunConfigurationSuite(t *testing.T) {
 // defaults set. Remember that environment variables can overwrite defaults, so
 // please ensure to properly unset envionment variables using
 // UnsetEnvVarAndRestore().
-func (s *TestConfigurationSuite) getDefaultConfiguration() *configuration.Registry {
+func (s *TestConfigurationSuite) getDefaultConfiguration() *configuration.Config {
 	config, err := configuration.New("", NewFakeClient(s.T()))
 	require.NoError(s.T(), err)
 	return config
@@ -43,7 +43,7 @@ func (s *TestConfigurationSuite) getDefaultConfiguration() *configuration.Regist
 // getDefaultConfiguration() remember that environment variables can overwrite
 // defaults, so please ensure to properly unset envionment variables using
 // UnsetEnvVarAndRestore().
-func (s *TestConfigurationSuite) getFileConfiguration(content string) *configuration.Registry {
+func (s *TestConfigurationSuite) getFileConfiguration(content string) *configuration.Config {
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "configFile-")
 	require.NoError(s.T(), err)
 	defer func() {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -59,6 +59,9 @@ func (s *TestConfigurationSuite) getFileConfiguration(content string) *configura
 }
 
 func (s *TestConfigurationSuite) TestNew() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
+
 	s.Run("default configuration", func() {
 		reg, err := configuration.New("", NewFakeClient(s.T()))
 		require.NoError(s.T(), err)
@@ -74,6 +77,8 @@ func (s *TestConfigurationSuite) TestNew() {
 }
 
 func (s *TestConfigurationSuite) TestGetHTTPAddress() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "HTTP_ADDRESS"
 
 	s.Run("default", func() {
@@ -105,6 +110,9 @@ func (s *TestConfigurationSuite) TestGetHTTPAddress() {
 }
 
 func (s *TestConfigurationSuite) TestGetLogLevel() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
+
 	key := configuration.EnvPrefix + "_" + "LOG_LEVEL"
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()
@@ -138,6 +146,9 @@ func (s *TestConfigurationSuite) TestGetLogLevel() {
 }
 
 func (s *TestConfigurationSuite) TestIsLogJSON() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
+
 	key := configuration.EnvPrefix + "_" + "LOG_JSON"
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()
@@ -167,6 +178,9 @@ func (s *TestConfigurationSuite) TestIsLogJSON() {
 }
 
 func (s *TestConfigurationSuite) TestGetGracefulTimeout() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
+
 	key := configuration.EnvPrefix + "_" + "GRACEFUL_TIMEOUT"
 
 	s.Run("default", func() {
@@ -194,6 +208,8 @@ func (s *TestConfigurationSuite) TestGetGracefulTimeout() {
 }
 
 func (s *TestConfigurationSuite) TestGetHTTPWriteTimeout() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "HTTP_WRITE_TIMEOUT"
 
 	s.Run("default", func() {
@@ -221,6 +237,8 @@ func (s *TestConfigurationSuite) TestGetHTTPWriteTimeout() {
 }
 
 func (s *TestConfigurationSuite) TestGetHTTPReadTimeout() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "HTTP_READ_TIMEOUT"
 
 	s.Run("default", func() {
@@ -248,6 +266,8 @@ func (s *TestConfigurationSuite) TestGetHTTPReadTimeout() {
 }
 
 func (s *TestConfigurationSuite) TestGetHTTPIdleTimeout() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "HTTP_IDLE_TIMEOUT"
 
 	s.Run("default", func() {
@@ -275,6 +295,8 @@ func (s *TestConfigurationSuite) TestGetHTTPIdleTimeout() {
 }
 
 func (s *TestConfigurationSuite) TestGetHTTPCompressResponses() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "HTTP_COMPRESS"
 
 	s.Run("default", func() {
@@ -302,6 +324,8 @@ func (s *TestConfigurationSuite) TestGetHTTPCompressResponses() {
 }
 
 func (s *TestConfigurationSuite) TestGetEnvironmentAndTestingMode() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := fmt.Sprintf("%s_ENVIRONMENT", configuration.EnvPrefix)
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()
@@ -339,6 +363,8 @@ func (s *TestConfigurationSuite) TestGetEnvironmentAndTestingMode() {
 }
 
 func (s *TestConfigurationSuite) TestGetAuthClientConfigRaw() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW"
 
 	s.Run("default", func() {
@@ -370,6 +396,8 @@ func (s *TestConfigurationSuite) TestGetAuthClientConfigRaw() {
 }
 
 func (s *TestConfigurationSuite) TestGetAuthClientConfigVerificationEnabled() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "VERIFICATION_ENABLED"
 
 	s.Run("default", func() {
@@ -397,6 +425,8 @@ func (s *TestConfigurationSuite) TestGetAuthClientConfigVerificationEnabled() {
 }
 
 func (s *TestConfigurationSuite) TestGetAuthClientConfigVerificationDailyLimit() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "VERIFICATION_DAILY_LIMIT"
 
 	s.Run("default", func() {
@@ -424,6 +454,8 @@ func (s *TestConfigurationSuite) TestGetAuthClientConfigVerificationDailyLimit()
 }
 
 func (s *TestConfigurationSuite) TestGetAuthClientConfigVerificationAttemptsAllowed() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "VERIFICATION_ATTEMPTS_ALLOWED"
 
 	s.Run("default", func() {
@@ -451,6 +483,8 @@ func (s *TestConfigurationSuite) TestGetAuthClientConfigVerificationAttemptsAllo
 }
 
 func (s *TestConfigurationSuite) TestGetAuthClientConfigContentType() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_CONTENT_TYPE"
 
 	s.Run("default", func() {
@@ -482,6 +516,8 @@ func (s *TestConfigurationSuite) TestGetAuthClientConfigContentType() {
 }
 
 func (s *TestConfigurationSuite) TestGetAuthClientLibraryURL() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_LIBRARY_URL"
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()
@@ -515,6 +551,8 @@ func (s *TestConfigurationSuite) TestGetAuthClientLibraryURL() {
 }
 
 func (s *TestConfigurationSuite) TestGetAuthClientPublicKeysURL() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_PUBLIC_KEYS_URL"
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()
@@ -548,6 +586,8 @@ func (s *TestConfigurationSuite) TestGetAuthClientPublicKeysURL() {
 }
 
 func (s *TestConfigurationSuite) TestGetNamespace() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "NAMESPACE"
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()
@@ -581,6 +621,8 @@ func (s *TestConfigurationSuite) TestGetNamespace() {
 }
 
 func (s *TestConfigurationSuite) TestVerificationEnabled() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "VERIFICATION_ENABLED"
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()
@@ -608,6 +650,8 @@ func (s *TestConfigurationSuite) TestVerificationEnabled() {
 }
 
 func (s *TestConfigurationSuite) TestVerificationDailyLimit() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "VERIFICATION_DAILY_LIMIT"
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()
@@ -636,6 +680,8 @@ func (s *TestConfigurationSuite) TestVerificationDailyLimit() {
 }
 
 func (s *TestConfigurationSuite) TestVerificationAttemptsAllowed() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "VERIFICATION_ATTEMPTS_ALLOWED"
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()
@@ -672,6 +718,8 @@ func (s *TestConfigurationSuite) TestLoadSecret() {
 }
 
 func (s *TestConfigurationSuite) TestVerificationMessageTemplate() {
+	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 	key := configuration.EnvPrefix + "_" + "VERIFICATION_MESSAGE_TEMPLATE"
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()
@@ -717,12 +765,9 @@ func (s *TestConfigurationSuite) TestTwilioAccountSID() {
 	})
 	s.T().Run("env overwrite", func(t *testing.T) {
 		// given
-		restore := SetEnvVarAndRestore(t, "REGISTRATION_SERVICE_SECRET_NAME", "test-secret")
-		defer restore()
-
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-secret",
+				Name:      "reg-service-secret",
 				Namespace: "toolchain-host-operator",
 			},
 			Data: map[string][]byte{
@@ -754,61 +799,9 @@ func (s *TestConfigurationSuite) TestTwilioAccountSID() {
 	})
 }
 
-func (s *TestConfigurationSuite) TestLoadConfigMap() {
+func (s *TestConfigurationSuite) TestTwilioFromNumber() {
 	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
 	defer restore()
-	s.T().Run("default", func(t *testing.T) {
-		// when
-		config := s.getDefaultConfiguration()
-
-		// then
-		assert.Equal(t, "", config.GetTwilioAccountSID())
-		assert.Equal(t, "", config.GetTwilioAuthToken())
-	})
-	s.T().Run("env overwrite", func(t *testing.T) {
-		// given
-		restore := SetEnvVarAndRestore(t, "REGISTRATION_SERVICE_CONFIG_MAP_NAME", "test-config-map")
-		defer restore()
-
-		configMap := &v1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-config-map",
-				Namespace: "toolchain-host-operator",
-			},
-			Data: map[string]string{
-				"auth_client.config_raw":        "{\"realm\": \"toolchain-public\",\"auth-server-url\": \"https://sso.prod-preview.openshift.io/auth\",\"ssl-required\": \"none\",\"resource\": \"crt\",\"clientId\": \"crt\",\"public-client\": \"true\"}",
-				"verification.daily_limit":      "100",
-				"verification.enabled":          "false",
-				"verification.attempts_allowed": "120",
-			},
-		}
-
-		// when
-		config, err := configuration.New("", NewFakeClient(t, configMap))
-
-		// then
-		require.NoError(t, err)
-		assert.Equal(t, "{\"realm\": \"toolchain-public\",\"auth-server-url\": \"https://sso.prod-preview.openshift.io/auth\",\"ssl-required\": \"none\",\"resource\": \"crt\",\"clientId\": \"crt\",\"public-client\": \"true\"}", config.GetAuthClientConfigAuthRaw())
-		assert.Equal(t, false, config.GetVerificationEnabled())
-		assert.Equal(t, 100, config.GetVerificationDailyLimit())
-		assert.Equal(t, 120, config.GetVerificationAttemptsAllowed())
-	})
-
-	s.T().Run("secret not found", func(t *testing.T) {
-		// given
-		restore := SetEnvVarAndRestore(t, "REGISTRATION_SERVICE_CONFIG_MAP_NAME", "test-config-map")
-		defer restore()
-
-		// when
-		config, err := configuration.New("", NewFakeClient(t))
-
-		// then
-		require.NoError(t, err)
-		assert.NotNil(t, config)
-	})
-}
-
-func (s *TestConfigurationSuite) TestTwilioFromNumber() {
 	key := configuration.EnvPrefix + "_" + "TWILIO_FROM_NUMBER"
 	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
 	defer resetFunc()

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -335,36 +335,36 @@ func (s *TestConfigurationSuite) TestGetEnvironmentAndTestingMode() {
 	})
 }
 
-func (s *TestConfigurationSuite) TestGetAuthClientConfigRaw() {
-	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW"
-
-	s.Run("default", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), configuration.DefaultAuthClientConfigRaw, config.GetAuthClientConfigAuthRaw())
-	})
-
-	s.Run("file", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		newVal := u.String()
-		config := s.getFileConfiguration(`auth_client.config.raw: "` + newVal + `"`)
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigAuthRaw())
-	})
-
-	s.Run("env overwrite", func() {
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		newVal := u.String()
-		err = os.Setenv(key, newVal)
-		require.NoError(s.T(), err)
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), newVal, config.GetAuthClientConfigAuthRaw())
-	})
-}
+//func (s *TestConfigurationSuite) TestGetAuthClientConfigRaw() {
+//	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_RAW"
+//
+//	s.Run("default", func() {
+//		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
+//		defer resetFunc()
+//		config := s.getDefaultConfiguration()
+//		assert.Equal(s.T(), configuration.DefaultAuthClientConfigRaw, config.GetAuthClientConfigAuthRaw())
+//	})
+//
+//	s.Run("file", func() {
+//		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
+//		defer resetFunc()
+//		u, err := uuid.NewV4()
+//		require.NoError(s.T(), err)
+//		newVal := u.String()
+//		config := s.getFileConfiguration(`auth_client.config.raw: "` + newVal + `"`)
+//		assert.Equal(s.T(), newVal, config.GetAuthClientConfigAuthRaw())
+//	})
+//
+//	s.Run("env overwrite", func() {
+//		u, err := uuid.NewV4()
+//		require.NoError(s.T(), err)
+//		newVal := u.String()
+//		err = os.Setenv(key, newVal)
+//		require.NoError(s.T(), err)
+//		config := s.getDefaultConfiguration()
+//		assert.Equal(s.T(), newVal, config.GetAuthClientConfigAuthRaw())
+//	})
+//}
 
 func (s *TestConfigurationSuite) TestGetAuthClientConfigContentType() {
 	key := configuration.EnvPrefix + "_" + "AUTH_CLIENT_CONFIG_CONTENT_TYPE"

--- a/pkg/controller/authconfig.go
+++ b/pkg/controller/authconfig.go
@@ -17,11 +17,11 @@ type configResponse struct {
 // AuthConfig implements the auth config endpoint, which is invoked to
 // retrieve the auth config for the ui.
 type AuthConfig struct {
-	config *configuration.Registry
+	config *configuration.Config
 }
 
 // NewAuthConfig returns a new AuthConfig instance.
-func NewAuthConfig(config *configuration.Registry) *AuthConfig {
+func NewAuthConfig(config *configuration.Config) *AuthConfig {
 	return &AuthConfig{
 		config: config,
 	}

--- a/pkg/controller/authconfig.go
+++ b/pkg/controller/authconfig.go
@@ -16,7 +16,10 @@ type configResponse struct {
 	AuthClientConfigRawSSLRequired  string `json:"auth-client-config-ssl-required"`
 	AuthClientConfigRawResource     string `json:"auth-client-config-resource"`
 	AuthClientConfigRawClientID     string `json:"auth-client-config-client-id"`
-	AuthClientConfigRawPublicClient string `json:"auth-client-config-public-client"`
+	AuthClientConfigRawPublicClient bool   `json:"auth-client-config-public-client"`
+	VerificationEnabled             bool   `json:"verification-enabled"`
+	VerificationDailyLimit          int    `json:"verification-daily-limit"`
+	VerificationAttemptsAllowed     int    `json:"verification-attempts-allowed"`
 }
 
 // AuthConfig implements the auth config endpoint, which is invoked to
@@ -42,6 +45,9 @@ func (ac *AuthConfig) GetHandler(ctx *gin.Context) {
 		AuthClientConfigRawResource:     ac.config.GetAuthClientConfigAuthRawResource(),
 		AuthClientConfigRawServerURL:    ac.config.GetAuthClientConfigAuthRawServerURL(),
 		AuthClientConfigRawSSLRequired:  ac.config.GetAuthClientConfigAuthRawSSLReuired(),
+		VerificationEnabled:             ac.config.GetVerificationEnabled(),
+		VerificationDailyLimit:          ac.config.GetVerificationDailyLimit(),
+		VerificationAttemptsAllowed:     ac.config.GetVerificationAttemptsAllowed(),
 	}
 	ctx.JSON(http.StatusOK, configRespData)
 }

--- a/pkg/controller/authconfig.go
+++ b/pkg/controller/authconfig.go
@@ -11,7 +11,12 @@ type configResponse struct {
 	AuthClientLibraryURL string `json:"auth-client-library-url"`
 	// this holds the raw config. Note: this is intentionally a string
 	// not json as this field may also hold non-json configs!
-	AuthClientConfigRaw string `json:"auth-client-config"`
+	AuthClientConfigRawRealm        string `json:"auth-client-config-realm"`
+	AuthClientConfigRawServerURL    string `json:"auth-client-config-server-url"`
+	AuthClientConfigRawSSLRequired  string `json:"auth-client-config-ssl-required"`
+	AuthClientConfigRawResource     string `json:"auth-client-config-resource"`
+	AuthClientConfigRawClientID     string `json:"auth-client-config-client-id"`
+	AuthClientConfigRawPublicClient string `json:"auth-client-config-public-client"`
 }
 
 // AuthConfig implements the auth config endpoint, which is invoked to
@@ -30,8 +35,13 @@ func NewAuthConfig(config *configuration.Registry) *AuthConfig {
 // GetHandler returns raw auth config content for UI.
 func (ac *AuthConfig) GetHandler(ctx *gin.Context) {
 	configRespData := configResponse{
-		AuthClientLibraryURL: ac.config.GetAuthClientLibraryURL(),
-		AuthClientConfigRaw:  ac.config.GetAuthClientConfigAuthRaw(),
+		AuthClientLibraryURL:            ac.config.GetAuthClientLibraryURL(),
+		AuthClientConfigRawClientID:     ac.config.GetAuthClientConfigAuthRawClientID(),
+		AuthClientConfigRawPublicClient: ac.config.GetAuthClientConfigAuthRawPublicClient(),
+		AuthClientConfigRawRealm:        ac.config.GetAuthClientConfigAuthRawRealm(),
+		AuthClientConfigRawResource:     ac.config.GetAuthClientConfigAuthRawResource(),
+		AuthClientConfigRawServerURL:    ac.config.GetAuthClientConfigAuthRawServerURL(),
+		AuthClientConfigRawSSLRequired:  ac.config.GetAuthClientConfigAuthRawSSLReuired(),
 	}
 	ctx.JSON(http.StatusOK, configRespData)
 }

--- a/pkg/controller/authconfig.go
+++ b/pkg/controller/authconfig.go
@@ -11,15 +11,7 @@ type configResponse struct {
 	AuthClientLibraryURL string `json:"auth-client-library-url"`
 	// this holds the raw config. Note: this is intentionally a string
 	// not json as this field may also hold non-json configs!
-	AuthClientConfigRawRealm        string `json:"auth-client-config-realm"`
-	AuthClientConfigRawServerURL    string `json:"auth-client-config-server-url"`
-	AuthClientConfigRawSSLRequired  string `json:"auth-client-config-ssl-required"`
-	AuthClientConfigRawResource     string `json:"auth-client-config-resource"`
-	AuthClientConfigRawClientID     string `json:"auth-client-config-client-id"`
-	AuthClientConfigRawPublicClient bool   `json:"auth-client-config-public-client"`
-	VerificationEnabled             bool   `json:"verification-enabled"`
-	VerificationDailyLimit          int    `json:"verification-daily-limit"`
-	VerificationAttemptsAllowed     int    `json:"verification-attempts-allowed"`
+	AuthClientConfigRaw string `json:"auth-client-config"`
 }
 
 // AuthConfig implements the auth config endpoint, which is invoked to
@@ -38,16 +30,8 @@ func NewAuthConfig(config *configuration.Registry) *AuthConfig {
 // GetHandler returns raw auth config content for UI.
 func (ac *AuthConfig) GetHandler(ctx *gin.Context) {
 	configRespData := configResponse{
-		AuthClientLibraryURL:            ac.config.GetAuthClientLibraryURL(),
-		AuthClientConfigRawClientID:     ac.config.GetAuthClientConfigRawClientID(),
-		AuthClientConfigRawPublicClient: ac.config.GetAuthClientConfigRawPublicClient(),
-		AuthClientConfigRawRealm:        ac.config.GetAuthClientConfigRawRealm(),
-		AuthClientConfigRawResource:     ac.config.GetAuthClientConfigRawResource(),
-		AuthClientConfigRawServerURL:    ac.config.GetAuthClientConfigRawAuthServerURL(),
-		AuthClientConfigRawSSLRequired:  ac.config.GetAuthClientConfigRawSSLRequired(),
-		VerificationEnabled:             ac.config.GetVerificationEnabled(),
-		VerificationDailyLimit:          ac.config.GetVerificationDailyLimit(),
-		VerificationAttemptsAllowed:     ac.config.GetVerificationAttemptsAllowed(),
+		AuthClientLibraryURL: ac.config.GetAuthClientLibraryURL(),
+		AuthClientConfigRaw:  ac.config.GetAuthClientConfigAuthRaw(),
 	}
 	ctx.JSON(http.StatusOK, configRespData)
 }

--- a/pkg/controller/authconfig.go
+++ b/pkg/controller/authconfig.go
@@ -39,12 +39,12 @@ func NewAuthConfig(config *configuration.Registry) *AuthConfig {
 func (ac *AuthConfig) GetHandler(ctx *gin.Context) {
 	configRespData := configResponse{
 		AuthClientLibraryURL:            ac.config.GetAuthClientLibraryURL(),
-		AuthClientConfigRawClientID:     ac.config.GetAuthClientConfigAuthRawClientID(),
-		AuthClientConfigRawPublicClient: ac.config.GetAuthClientConfigAuthRawPublicClient(),
-		AuthClientConfigRawRealm:        ac.config.GetAuthClientConfigAuthRawRealm(),
-		AuthClientConfigRawResource:     ac.config.GetAuthClientConfigAuthRawResource(),
-		AuthClientConfigRawServerURL:    ac.config.GetAuthClientConfigAuthRawServerURL(),
-		AuthClientConfigRawSSLRequired:  ac.config.GetAuthClientConfigAuthRawSSLReuired(),
+		AuthClientConfigRawClientID:     ac.config.GetAuthClientConfigRawClientID(),
+		AuthClientConfigRawPublicClient: ac.config.GetAuthClientConfigRawPublicClient(),
+		AuthClientConfigRawRealm:        ac.config.GetAuthClientConfigRawRealm(),
+		AuthClientConfigRawResource:     ac.config.GetAuthClientConfigRawResource(),
+		AuthClientConfigRawServerURL:    ac.config.GetAuthClientConfigRawAuthServerURL(),
+		AuthClientConfigRawSSLRequired:  ac.config.GetAuthClientConfigRawSSLRequired(),
 		VerificationEnabled:             ac.config.GetVerificationEnabled(),
 		VerificationDailyLimit:          ac.config.GetVerificationDailyLimit(),
 		VerificationAttemptsAllowed:     ac.config.GetVerificationAttemptsAllowed(),

--- a/pkg/controller/authconfig_test.go
+++ b/pkg/controller/authconfig_test.go
@@ -63,35 +63,14 @@ func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
 
 		s.Run("envelope client config", func() {
 			assert.NotEmpty(s.T(), dataEnvelope.AuthClientLibraryURL, "no 'auth-client-config' key in authconfig response")
-
-			s.Run("realm", func() {
-				assert.Equal(s.T(), s.Config.GetAuthClientConfigRawRealm(), dataEnvelope.AuthClientConfigRawRealm, "wrong 'realm' in authconfig response")
-			})
-
-			s.Run("auth-server-url", func() {
-				assert.Equal(s.T(), s.Config.GetAuthClientConfigRawAuthServerURL(), dataEnvelope.AuthClientConfigRawServerURL, "wrong 'auth-server-url' in authconfig response")
-			})
-
-			s.Run("ssl-required", func() {
-				assert.Equal(s.T(), s.Config.GetAuthClientConfigRawSSLRequired(), dataEnvelope.AuthClientConfigRawSSLRequired, "wrong 'ssl-required' in authconfig response")
-			})
-
-			s.Run("resource", func() {
-				assert.Equal(s.T(), s.Config.GetAuthClientConfigRawResource(), dataEnvelope.AuthClientConfigRawResource, "wrong 'resource' in authconfig response")
-			})
-
-			s.Run("public-client", func() {
-				assert.Equal(s.T(), s.Config.GetAuthClientConfigRawPublicClient(), dataEnvelope.AuthClientConfigRawPublicClient, "wrong 'public-client' in authconfig response")
-			})
-			s.Run("verification-daily-limit", func() {
-				assert.Equal(s.T(), s.Config.GetVerificationDailyLimit(), dataEnvelope.VerificationDailyLimit, "wrong 'verification daily limit' in authconfig response")
-			})
-			s.Run("verification-attempts-allowed", func() {
-				assert.Equal(s.T(), s.Config.GetVerificationAttemptsAllowed(), dataEnvelope.VerificationAttemptsAllowed, "wrong 'verification attempts allowed' in authconfig response")
-			})
-			s.Run("verification-enabled", func() {
-				assert.Equal(s.T(), s.Config.GetVerificationEnabled(), dataEnvelope.VerificationEnabled, "wrong 'verification enabled' in authconfig response")
-			})
+			assert.Equal(s.T(), s.Config.GetAuthClientConfigRawRealm(), dataEnvelope.AuthClientConfigRawRealm, "wrong 'realm' in authconfig response")
+			assert.Equal(s.T(), s.Config.GetAuthClientConfigRawAuthServerURL(), dataEnvelope.AuthClientConfigRawServerURL, "wrong 'auth-server-url' in authconfig response")
+			assert.Equal(s.T(), s.Config.GetAuthClientConfigRawSSLRequired(), dataEnvelope.AuthClientConfigRawSSLRequired, "wrong 'ssl-required' in authconfig response")
+			assert.Equal(s.T(), s.Config.GetAuthClientConfigRawResource(), dataEnvelope.AuthClientConfigRawResource, "wrong 'resource' in authconfig response")
+			assert.Equal(s.T(), s.Config.GetAuthClientConfigRawPublicClient(), dataEnvelope.AuthClientConfigRawPublicClient, "wrong 'public-client' in authconfig response")
+			assert.Equal(s.T(), s.Config.GetVerificationDailyLimit(), dataEnvelope.VerificationDailyLimit, "wrong 'verification daily limit' in authconfig response")
+			assert.Equal(s.T(), s.Config.GetVerificationAttemptsAllowed(), dataEnvelope.VerificationAttemptsAllowed, "wrong 'verification attempts allowed' in authconfig response")
+			assert.Equal(s.T(), s.Config.GetVerificationEnabled(), dataEnvelope.VerificationEnabled, "wrong 'verification enabled' in authconfig response")
 		})
 	})
 }

--- a/pkg/controller/authconfig_test.go
+++ b/pkg/controller/authconfig_test.go
@@ -1,7 +1,14 @@
 package controller
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/codeready-toolchain/registration-service/test"
 
@@ -16,96 +23,75 @@ func TestRunAuthClientConfigSuite(t *testing.T) {
 	suite.Run(t, &TestAuthConfigSuite{test.UnitTestSuite{}})
 }
 
-//func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
-//	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
-//	// pass 'nil' as the third parameter.
-//	req, err := http.NewRequest(http.MethodGet, "/api/v1/authconfig", nil)
-//	require.NoError(s.T(), err)
-//
-//	// Check if the config is set to testing mode, so the handler may use this.
-//	assert.True(s.T(), s.Config.IsTestingMode(), "testing mode not set correctly to true")
-//
-//	// Create handler instance.
-//	authConfigCtrl := NewAuthConfig(s.Config)
-//	handler := gin.HandlerFunc(authConfigCtrl.GetHandler)
-//
-//	s.Run("valid json config", func() {
-//
-//		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
-//		rr := httptest.NewRecorder()
-//		ctx, _ := gin.CreateTestContext(rr)
-//		ctx.Request = req
-//
-//		handler(ctx)
-//
-//		// Check the status code is what we expect.
-//		require.Equal(s.T(), http.StatusOK, rr.Code)
-//
-//		// check response content-type.
-//		require.Equal(s.T(), s.Config.GetAuthClientConfigAuthContentType(), rr.Header().Get("Content-Type"))
-//
-//		// Check the response body is what we expect.
-//		// get config values from endpoint response
-//		var dataEnvelope *configResponse
-//		err = json.Unmarshal(rr.Body.Bytes(), &dataEnvelope)
-//		require.NoError(s.T(), err)
-//
-//		// get the configured values
-//		var config map[string]interface{}
-//		err = json.Unmarshal([]byte(s.Config.GetAuthClientConfigAuthRaw()), &config)
-//		require.NoError(s.T(), err)
-//
-//		s.Run("envelope client url", func() {
-//			assert.Equal(s.T(), s.Config.GetAuthClientLibraryURL(), dataEnvelope.AuthClientLibraryURL, "wrong 'auth-client-library-url' in authconfig response")
-//		})
-//
-//		s.Run("envelope client config", func() {
-//			assert.NotEmpty(s.T(), dataEnvelope.AuthClientLibraryURL, "no 'auth-client-config' key in authconfig response")
-//
-//			// deserialize the values in the string field
-//			var data map[string]interface{}
-//			err = json.Unmarshal([]byte(dataEnvelope.AuthClientConfigRaw), &data)
-//			require.NoError(s.T(), err)
-//
-//			s.Run("realm", func() {
-//				val, ok := data["realm"]
-//				assert.True(s.T(), ok, "no 'realm' key in authconfig response")
-//				valString, ok := val.(string)
-//				assert.True(s.T(), ok, "returned 'realm' value is not of type 'string'")
-//				assert.Equal(s.T(), config["realm"], valString, "wrong 'realm' in authconfig response")
-//			})
-//
-//			s.Run("auth-server-url", func() {
-//				val, ok := data["auth-server-url"]
-//				assert.True(s.T(), ok, "no 'auth-server-url' key in authconfig response")
-//				valString, ok := val.(string)
-//				assert.True(s.T(), ok, "returned 'auth-server-url' value is not of type 'string'")
-//				assert.Equal(s.T(), config["auth-server-url"], valString, "wrong 'auth-server-url' in authconfig response")
-//			})
-//
-//			s.Run("ssl-required", func() {
-//				val, ok := data["ssl-required"]
-//				assert.True(s.T(), ok, "no 'ssl-required' key in authconfig response")
-//				valString, ok := val.(string)
-//				assert.True(s.T(), ok, "returned 'ssl-required' value is not of type 'string'")
-//				assert.Equal(s.T(), config["ssl-required"], valString, "wrong 'ssl-required' in authconfig response")
-//			})
-//
-//			s.Run("resource", func() {
-//				val, ok := data["resource"]
-//				assert.True(s.T(), ok, "no 'resource' key in authconfig response")
-//				valString, ok := val.(string)
-//				assert.True(s.T(), ok, "returned 'resource' value is not of type 'string'")
-//				assert.Equal(s.T(), config["resource"], valString, "wrong 'resource' in authconfig response")
-//			})
-//
-//			s.Run("public-client", func() {
-//				val, ok := data["public-client"]
-//				assert.True(s.T(), ok, "no 'public-client' key in authconfig response")
-//				valBool, ok := val.(bool)
-//				assert.True(s.T(), ok, "returned 'public-client' value is not of type 'bool'")
-//				assert.Equal(s.T(), config["public-client"], valBool, "wrong 'public-client' in authconfig response")
-//			})
-//		})
-//	})
-//}
+func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req, err := http.NewRequest(http.MethodGet, "/api/v1/authconfig", nil)
+	require.NoError(s.T(), err)
+
+	// Check if the config is set to testing mode, so the handler may use this.
+	assert.True(s.T(), s.Config.IsTestingMode(), "testing mode not set correctly to true")
+
+	// Create handler instance.
+	authConfigCtrl := NewAuthConfig(s.Config)
+	handler := gin.HandlerFunc(authConfigCtrl.GetHandler)
+
+	s.Run("valid json config", func() {
+
+		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Request = req
+
+		handler(ctx)
+
+		// Check the status code is what we expect.
+		require.Equal(s.T(), http.StatusOK, rr.Code)
+
+		// check response content-type.
+		require.Equal(s.T(), s.Config.GetAuthClientConfigAuthContentType(), rr.Header().Get("Content-Type"))
+
+		// Check the response body is what we expect.
+		// get config values from endpoint response
+		var dataEnvelope *configResponse
+		err = json.Unmarshal(rr.Body.Bytes(), &dataEnvelope)
+		require.NoError(s.T(), err)
+
+		s.Run("envelope client url", func() {
+			assert.Equal(s.T(), s.Config.GetAuthClientLibraryURL(), dataEnvelope.AuthClientLibraryURL, "wrong 'auth-client-library-url' in authconfig response")
+		})
+
+		s.Run("envelope client config", func() {
+			assert.NotEmpty(s.T(), dataEnvelope.AuthClientLibraryURL, "no 'auth-client-config' key in authconfig response")
+
+			s.Run("realm", func() {
+				assert.Equal(s.T(), s.Config.GetAuthClientConfigRawRealm(), dataEnvelope.AuthClientConfigRawRealm, "wrong 'realm' in authconfig response")
+			})
+
+			s.Run("auth-server-url", func() {
+				assert.Equal(s.T(), s.Config.GetAuthClientConfigRawAuthServerURL(), dataEnvelope.AuthClientConfigRawServerURL, "wrong 'auth-server-url' in authconfig response")
+			})
+
+			s.Run("ssl-required", func() {
+				assert.Equal(s.T(), s.Config.GetAuthClientConfigRawSSLRequired(), dataEnvelope.AuthClientConfigRawSSLRequired, "wrong 'ssl-required' in authconfig response")
+			})
+
+			s.Run("resource", func() {
+				assert.Equal(s.T(), s.Config.GetAuthClientConfigRawResource(), dataEnvelope.AuthClientConfigRawResource, "wrong 'resource' in authconfig response")
+			})
+
+			s.Run("public-client", func() {
+				assert.Equal(s.T(), s.Config.GetAuthClientConfigRawPublicClient(), dataEnvelope.AuthClientConfigRawPublicClient, "wrong 'public-client' in authconfig response")
+			})
+			s.Run("verification-daily-limit", func() {
+				assert.Equal(s.T(), s.Config.GetVerificationDailyLimit(), dataEnvelope.VerificationDailyLimit, "wrong 'verification daily limit' in authconfig response")
+			})
+			s.Run("verification-attempts-allowed", func() {
+				assert.Equal(s.T(), s.Config.GetVerificationAttemptsAllowed(), dataEnvelope.VerificationAttemptsAllowed, "wrong 'verification attempts allowed' in authconfig response")
+			})
+			s.Run("verification-enabled", func() {
+				assert.Equal(s.T(), s.Config.GetVerificationEnabled(), dataEnvelope.VerificationEnabled, "wrong 'verification enabled' in authconfig response")
+			})
+		})
+	})
+}

--- a/pkg/controller/authconfig_test.go
+++ b/pkg/controller/authconfig_test.go
@@ -1,16 +1,10 @@
 package controller
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/codeready-toolchain/registration-service/test"
 
-	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -22,96 +16,96 @@ func TestRunAuthClientConfigSuite(t *testing.T) {
 	suite.Run(t, &TestAuthConfigSuite{test.UnitTestSuite{}})
 }
 
-func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
-	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
-	// pass 'nil' as the third parameter.
-	req, err := http.NewRequest(http.MethodGet, "/api/v1/authconfig", nil)
-	require.NoError(s.T(), err)
-
-	// Check if the config is set to testing mode, so the handler may use this.
-	assert.True(s.T(), s.Config.IsTestingMode(), "testing mode not set correctly to true")
-
-	// Create handler instance.
-	authConfigCtrl := NewAuthConfig(s.Config)
-	handler := gin.HandlerFunc(authConfigCtrl.GetHandler)
-
-	s.Run("valid json config", func() {
-
-		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
-		rr := httptest.NewRecorder()
-		ctx, _ := gin.CreateTestContext(rr)
-		ctx.Request = req
-
-		handler(ctx)
-
-		// Check the status code is what we expect.
-		require.Equal(s.T(), http.StatusOK, rr.Code)
-
-		// check response content-type.
-		require.Equal(s.T(), s.Config.GetAuthClientConfigAuthContentType(), rr.Header().Get("Content-Type"))
-
-		// Check the response body is what we expect.
-		// get config values from endpoint response
-		var dataEnvelope *configResponse
-		err = json.Unmarshal(rr.Body.Bytes(), &dataEnvelope)
-		require.NoError(s.T(), err)
-
-		// get the configured values
-		var config map[string]interface{}
-		err = json.Unmarshal([]byte(s.Config.GetAuthClientConfigAuthRaw()), &config)
-		require.NoError(s.T(), err)
-
-		s.Run("envelope client url", func() {
-			assert.Equal(s.T(), s.Config.GetAuthClientLibraryURL(), dataEnvelope.AuthClientLibraryURL, "wrong 'auth-client-library-url' in authconfig response")
-		})
-
-		s.Run("envelope client config", func() {
-			assert.NotEmpty(s.T(), dataEnvelope.AuthClientLibraryURL, "no 'auth-client-config' key in authconfig response")
-
-			// deserialize the values in the string field
-			var data map[string]interface{}
-			err = json.Unmarshal([]byte(dataEnvelope.AuthClientConfigRaw), &data)
-			require.NoError(s.T(), err)
-
-			s.Run("realm", func() {
-				val, ok := data["realm"]
-				assert.True(s.T(), ok, "no 'realm' key in authconfig response")
-				valString, ok := val.(string)
-				assert.True(s.T(), ok, "returned 'realm' value is not of type 'string'")
-				assert.Equal(s.T(), config["realm"], valString, "wrong 'realm' in authconfig response")
-			})
-
-			s.Run("auth-server-url", func() {
-				val, ok := data["auth-server-url"]
-				assert.True(s.T(), ok, "no 'auth-server-url' key in authconfig response")
-				valString, ok := val.(string)
-				assert.True(s.T(), ok, "returned 'auth-server-url' value is not of type 'string'")
-				assert.Equal(s.T(), config["auth-server-url"], valString, "wrong 'auth-server-url' in authconfig response")
-			})
-
-			s.Run("ssl-required", func() {
-				val, ok := data["ssl-required"]
-				assert.True(s.T(), ok, "no 'ssl-required' key in authconfig response")
-				valString, ok := val.(string)
-				assert.True(s.T(), ok, "returned 'ssl-required' value is not of type 'string'")
-				assert.Equal(s.T(), config["ssl-required"], valString, "wrong 'ssl-required' in authconfig response")
-			})
-
-			s.Run("resource", func() {
-				val, ok := data["resource"]
-				assert.True(s.T(), ok, "no 'resource' key in authconfig response")
-				valString, ok := val.(string)
-				assert.True(s.T(), ok, "returned 'resource' value is not of type 'string'")
-				assert.Equal(s.T(), config["resource"], valString, "wrong 'resource' in authconfig response")
-			})
-
-			s.Run("public-client", func() {
-				val, ok := data["public-client"]
-				assert.True(s.T(), ok, "no 'public-client' key in authconfig response")
-				valBool, ok := val.(bool)
-				assert.True(s.T(), ok, "returned 'public-client' value is not of type 'bool'")
-				assert.Equal(s.T(), config["public-client"], valBool, "wrong 'public-client' in authconfig response")
-			})
-		})
-	})
-}
+//func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
+//	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+//	// pass 'nil' as the third parameter.
+//	req, err := http.NewRequest(http.MethodGet, "/api/v1/authconfig", nil)
+//	require.NoError(s.T(), err)
+//
+//	// Check if the config is set to testing mode, so the handler may use this.
+//	assert.True(s.T(), s.Config.IsTestingMode(), "testing mode not set correctly to true")
+//
+//	// Create handler instance.
+//	authConfigCtrl := NewAuthConfig(s.Config)
+//	handler := gin.HandlerFunc(authConfigCtrl.GetHandler)
+//
+//	s.Run("valid json config", func() {
+//
+//		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+//		rr := httptest.NewRecorder()
+//		ctx, _ := gin.CreateTestContext(rr)
+//		ctx.Request = req
+//
+//		handler(ctx)
+//
+//		// Check the status code is what we expect.
+//		require.Equal(s.T(), http.StatusOK, rr.Code)
+//
+//		// check response content-type.
+//		require.Equal(s.T(), s.Config.GetAuthClientConfigAuthContentType(), rr.Header().Get("Content-Type"))
+//
+//		// Check the response body is what we expect.
+//		// get config values from endpoint response
+//		var dataEnvelope *configResponse
+//		err = json.Unmarshal(rr.Body.Bytes(), &dataEnvelope)
+//		require.NoError(s.T(), err)
+//
+//		// get the configured values
+//		var config map[string]interface{}
+//		err = json.Unmarshal([]byte(s.Config.GetAuthClientConfigAuthRaw()), &config)
+//		require.NoError(s.T(), err)
+//
+//		s.Run("envelope client url", func() {
+//			assert.Equal(s.T(), s.Config.GetAuthClientLibraryURL(), dataEnvelope.AuthClientLibraryURL, "wrong 'auth-client-library-url' in authconfig response")
+//		})
+//
+//		s.Run("envelope client config", func() {
+//			assert.NotEmpty(s.T(), dataEnvelope.AuthClientLibraryURL, "no 'auth-client-config' key in authconfig response")
+//
+//			// deserialize the values in the string field
+//			var data map[string]interface{}
+//			err = json.Unmarshal([]byte(dataEnvelope.AuthClientConfigRaw), &data)
+//			require.NoError(s.T(), err)
+//
+//			s.Run("realm", func() {
+//				val, ok := data["realm"]
+//				assert.True(s.T(), ok, "no 'realm' key in authconfig response")
+//				valString, ok := val.(string)
+//				assert.True(s.T(), ok, "returned 'realm' value is not of type 'string'")
+//				assert.Equal(s.T(), config["realm"], valString, "wrong 'realm' in authconfig response")
+//			})
+//
+//			s.Run("auth-server-url", func() {
+//				val, ok := data["auth-server-url"]
+//				assert.True(s.T(), ok, "no 'auth-server-url' key in authconfig response")
+//				valString, ok := val.(string)
+//				assert.True(s.T(), ok, "returned 'auth-server-url' value is not of type 'string'")
+//				assert.Equal(s.T(), config["auth-server-url"], valString, "wrong 'auth-server-url' in authconfig response")
+//			})
+//
+//			s.Run("ssl-required", func() {
+//				val, ok := data["ssl-required"]
+//				assert.True(s.T(), ok, "no 'ssl-required' key in authconfig response")
+//				valString, ok := val.(string)
+//				assert.True(s.T(), ok, "returned 'ssl-required' value is not of type 'string'")
+//				assert.Equal(s.T(), config["ssl-required"], valString, "wrong 'ssl-required' in authconfig response")
+//			})
+//
+//			s.Run("resource", func() {
+//				val, ok := data["resource"]
+//				assert.True(s.T(), ok, "no 'resource' key in authconfig response")
+//				valString, ok := val.(string)
+//				assert.True(s.T(), ok, "returned 'resource' value is not of type 'string'")
+//				assert.Equal(s.T(), config["resource"], valString, "wrong 'resource' in authconfig response")
+//			})
+//
+//			s.Run("public-client", func() {
+//				val, ok := data["public-client"]
+//				assert.True(s.T(), ok, "no 'public-client' key in authconfig response")
+//				valBool, ok := val.(bool)
+//				assert.True(s.T(), ok, "returned 'public-client' value is not of type 'bool'")
+//				assert.Equal(s.T(), config["public-client"], valBool, "wrong 'public-client' in authconfig response")
+//			})
+//		})
+//	})
+//}

--- a/pkg/controller/authconfig_test.go
+++ b/pkg/controller/authconfig_test.go
@@ -6,12 +6,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/codeready-toolchain/registration-service/test"
+
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/codeready-toolchain/registration-service/test"
-
 	"github.com/stretchr/testify/suite"
 )
 
@@ -57,20 +56,62 @@ func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
 		err = json.Unmarshal(rr.Body.Bytes(), &dataEnvelope)
 		require.NoError(s.T(), err)
 
+		// get the configured values
+		var config map[string]interface{}
+		err = json.Unmarshal([]byte(s.Config.GetAuthClientConfigAuthRaw()), &config)
+		require.NoError(s.T(), err)
+
 		s.Run("envelope client url", func() {
 			assert.Equal(s.T(), s.Config.GetAuthClientLibraryURL(), dataEnvelope.AuthClientLibraryURL, "wrong 'auth-client-library-url' in authconfig response")
 		})
 
 		s.Run("envelope client config", func() {
 			assert.NotEmpty(s.T(), dataEnvelope.AuthClientLibraryURL, "no 'auth-client-config' key in authconfig response")
-			assert.Equal(s.T(), s.Config.GetAuthClientConfigRawRealm(), dataEnvelope.AuthClientConfigRawRealm, "wrong 'realm' in authconfig response")
-			assert.Equal(s.T(), s.Config.GetAuthClientConfigRawAuthServerURL(), dataEnvelope.AuthClientConfigRawServerURL, "wrong 'auth-server-url' in authconfig response")
-			assert.Equal(s.T(), s.Config.GetAuthClientConfigRawSSLRequired(), dataEnvelope.AuthClientConfigRawSSLRequired, "wrong 'ssl-required' in authconfig response")
-			assert.Equal(s.T(), s.Config.GetAuthClientConfigRawResource(), dataEnvelope.AuthClientConfigRawResource, "wrong 'resource' in authconfig response")
-			assert.Equal(s.T(), s.Config.GetAuthClientConfigRawPublicClient(), dataEnvelope.AuthClientConfigRawPublicClient, "wrong 'public-client' in authconfig response")
-			assert.Equal(s.T(), s.Config.GetVerificationDailyLimit(), dataEnvelope.VerificationDailyLimit, "wrong 'verification daily limit' in authconfig response")
-			assert.Equal(s.T(), s.Config.GetVerificationAttemptsAllowed(), dataEnvelope.VerificationAttemptsAllowed, "wrong 'verification attempts allowed' in authconfig response")
-			assert.Equal(s.T(), s.Config.GetVerificationEnabled(), dataEnvelope.VerificationEnabled, "wrong 'verification enabled' in authconfig response")
+
+			// deserialize the values in the string field
+			var data map[string]interface{}
+			err = json.Unmarshal([]byte(dataEnvelope.AuthClientConfigRaw), &data)
+			require.NoError(s.T(), err)
+
+			s.Run("realm", func() {
+				val, ok := data["realm"]
+				assert.True(s.T(), ok, "no 'realm' key in authconfig response")
+				valString, ok := val.(string)
+				assert.True(s.T(), ok, "returned 'realm' value is not of type 'string'")
+				assert.Equal(s.T(), config["realm"], valString, "wrong 'realm' in authconfig response")
+			})
+
+			s.Run("auth-server-url", func() {
+				val, ok := data["auth-server-url"]
+				assert.True(s.T(), ok, "no 'auth-server-url' key in authconfig response")
+				valString, ok := val.(string)
+				assert.True(s.T(), ok, "returned 'auth-server-url' value is not of type 'string'")
+				assert.Equal(s.T(), config["auth-server-url"], valString, "wrong 'auth-server-url' in authconfig response")
+			})
+
+			s.Run("ssl-required", func() {
+				val, ok := data["ssl-required"]
+				assert.True(s.T(), ok, "no 'ssl-required' key in authconfig response")
+				valString, ok := val.(string)
+				assert.True(s.T(), ok, "returned 'ssl-required' value is not of type 'string'")
+				assert.Equal(s.T(), config["ssl-required"], valString, "wrong 'ssl-required' in authconfig response")
+			})
+
+			s.Run("resource", func() {
+				val, ok := data["resource"]
+				assert.True(s.T(), ok, "no 'resource' key in authconfig response")
+				valString, ok := val.(string)
+				assert.True(s.T(), ok, "returned 'resource' value is not of type 'string'")
+				assert.Equal(s.T(), config["resource"], valString, "wrong 'resource' in authconfig response")
+			})
+
+			s.Run("public-client", func() {
+				val, ok := data["public-client"]
+				assert.True(s.T(), ok, "no 'public-client' key in authconfig response")
+				valBool, ok := val.(bool)
+				assert.True(s.T(), ok, "returned 'public-client' value is not of type 'bool'")
+				assert.Equal(s.T(), config["public-client"], valBool, "wrong 'public-client' in authconfig response")
+			})
 		})
 	})
 }

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -14,12 +14,12 @@ import (
 
 // Signup implements the signup endpoint, which is invoked for new user registrations.
 type Signup struct {
-	config        *configuration.Registry
+	config        *configuration.Config
 	signupService signup.Service
 }
 
 // NewSignup returns a new Signup instance.
-func NewSignup(config *configuration.Registry, signupService signup.Service) *Signup {
+func NewSignup(config *configuration.Config, signupService signup.Service) *Signup {
 	return &Signup{
 		config:        config,
 		signupService: signupService,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,14 +15,14 @@ import (
 // RegistrationServer bundles configuration, and HTTP server objects in a single
 // location.
 type RegistrationServer struct {
-	config      *configuration.Registry
+	config      *configuration.Config
 	router      *gin.Engine
 	httpServer  *http.Server
 	routesSetup sync.Once
 }
 
 // New creates a new RegistrationServer object with reasonable defaults.
-func New(config *configuration.Registry) *RegistrationServer {
+func New(config *configuration.Config) *RegistrationServer {
 	srv := &RegistrationServer{
 		router: gin.Default(),
 	}
@@ -45,7 +45,7 @@ func New(config *configuration.Registry) *RegistrationServer {
 }
 
 // Config returns the app server's config object.
-func (srv *RegistrationServer) Config() *configuration.Registry {
+func (srv *RegistrationServer) Config() *configuration.Config {
 	return srv.config
 }
 

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -18,6 +18,8 @@ type UnitTestSuite struct {
 func (s *UnitTestSuite) SetupSuite() {
 	// create logger and registry
 	log.Init("registration-service-testing")
+	restore := test.SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
 
 	cfg, errs := configuration.CreateEmptyRegistry(test.NewFakeClient(s.T()))
 	if errs != nil {

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -3,6 +3,7 @@ package test
 import (
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/log"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -18,7 +19,12 @@ func (s *UnitTestSuite) SetupSuite() {
 	// create logger and registry
 	log.Init("registration-service-testing")
 
-	s.Config = configuration.CreateEmptyRegistry()
+	cfg, errs := configuration.CreateEmptyRegistry(test.NewFakeClient(s.T()))
+	if errs != nil {
+		panic(errs.Error())
+	}
+
+	s.Config = cfg
 
 	// set environment to unit-tests
 	s.Config.GetViperInstance().Set("environment", configuration.UnitTestsEnvironment)

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -11,7 +11,7 @@ import (
 // UnitTestSuite is the base test suite for unit tests.
 type UnitTestSuite struct {
 	suite.Suite
-	Config *configuration.Registry
+	Config *configuration.Config
 }
 
 // SetupSuite sets the suite up and sets testmode.


### PR DESCRIPTION
This PR adds required configuration for twilio.

This PR is also related to allowing registration-service to have it's configurations set via a configmap and set secrets (particularily for twilio).

Related PR: codeready-toolchain/host-operator#263, PR for toolchain-infra coming soon...

Related Jira: https://issues.redhat.com/browse/CRT-775