### PR TITLE
Load Console and Che URLs from ToolchainStatus

### DIFF
--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -31,6 +31,7 @@ objects:
       - toolchain.dev.openshift.com
       resources:
       - masteruserrecords
+      - toolchainstatuses
       verbs:
       - get
     - apiGroups:

--- a/pkg/kubeclient/client.go
+++ b/pkg/kubeclient/client.go
@@ -16,6 +16,7 @@ type V1Alpha1 interface {
 	UserSignups() UserSignupInterface
 	MasterUserRecords() MasterUserRecordInterface
 	BannedUsers() BannedUserInterface
+	ToolchainStatuses() ToolchainStatusInterface
 }
 
 // NewCRTRESTClient creates a new REST client for managing Codeready Toolchain resources via the Kubernetes API
@@ -104,6 +105,18 @@ func (c *V1Alpha1REST) MasterUserRecords() MasterUserRecordInterface {
 // BannedUsers returns an interface which may be used to perform query operations on BannedUser resources
 func (c *V1Alpha1REST) BannedUsers() BannedUserInterface {
 	return &bannedUserClient{
+		crtClient: crtClient{
+			client: c.client.RestClient,
+			ns:     c.client.NS,
+			cfg:    c.client.Config,
+			scheme: c.client.Scheme,
+		},
+	}
+}
+
+// ToolchainStatuses returns an interface which may be used to perform query operations on ToolchainStatus resources
+func (c *V1Alpha1REST) ToolchainStatuses() ToolchainStatusInterface {
+	return &toolchainStatusClient{
 		crtClient: crtClient{
 			client: c.client.RestClient,
 			ns:     c.client.NS,

--- a/pkg/kubeclient/client.go
+++ b/pkg/kubeclient/client.go
@@ -59,6 +59,8 @@ func getRegisterObject() []runtime.Object {
 		&crtapi.MasterUserRecordList{},
 		&crtapi.BannedUser{},
 		&crtapi.BannedUserList{},
+		&crtapi.ToolchainStatus{},
+		&crtapi.ToolchainStatusList{},
 	}
 }
 

--- a/pkg/kubeclient/client_test.go
+++ b/pkg/kubeclient/client_test.go
@@ -25,4 +25,5 @@ func TestNewClient(t *testing.T) {
 	require.NotNil(t, client.V1Alpha1().UserSignups())
 	require.NotNil(t, client.V1Alpha1().MasterUserRecords())
 	require.NotNil(t, client.V1Alpha1().BannedUsers())
+	require.NotNil(t, client.V1Alpha1().ToolchainStatuses())
 }

--- a/pkg/kubeclient/toolchainstatus.go
+++ b/pkg/kubeclient/toolchainstatus.go
@@ -1,0 +1,35 @@
+package kubeclient
+
+import (
+	"context"
+
+	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+)
+
+const (
+	toolchainStatusResourcePlural = "toolchainstatuses"
+)
+
+type toolchainStatusClient struct {
+	crtClient
+}
+
+type ToolchainStatusInterface interface {
+	Get() (*crtapi.ToolchainStatus, error)
+}
+
+// Get returns the ToolchainStatus with the "toolchain-status" name, or an error if something went wrong while attempting to retrieve it
+// If not found then NotFound error returned
+func (c *toolchainStatusClient) Get() (*crtapi.ToolchainStatus, error) {
+	result := &crtapi.ToolchainStatus{}
+	err := c.client.Get().
+		Namespace(c.ns).
+		Resource(toolchainStatusResourcePlural).
+		Name("toolchain-status").
+		Do(context.TODO()).
+		Into(result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -174,7 +174,7 @@ func (s *ServiceImpl) GetSignup(userID string) (*signup.Signup, error) {
 		// Retrieve Console and Che dashboard URLs from the status of the corresponding member cluster
 		status, err := s.CRTClient().V1Alpha1().ToolchainStatuses().Get()
 		if err != nil {
-			return nil, errors2.Wrap(err, fmt.Sprintf("error when retrieving ToolchainStatus to set Che Dashboard for completed UserSignup %s", userSignup.GetName()))
+			return nil, errors2.Wrapf(err, "error when retrieving ToolchainStatus to set Che Dashboard for completed UserSignup %s", userSignup.GetName())
 		}
 		for _, member := range status.Status.Members {
 			if member.ClusterName == mur.Status.UserAccounts[0].Cluster.Name {

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -171,9 +171,18 @@ func (s *ServiceImpl) GetSignup(userID string) (*signup.Signup, error) {
 		VerificationRequired: userSignup.Spec.VerificationRequired,
 	}
 	if mur.Status.UserAccounts != nil && len(mur.Status.UserAccounts) > 0 {
-		// TODO Set ConsoleURL in UserSignup.Status. For now it's OK to get it from the first embedded UserAccount status from MUR.
-		signupResponse.ConsoleURL = mur.Status.UserAccounts[0].Cluster.ConsoleURL
-		signupResponse.CheDashboardURL = mur.Status.UserAccounts[0].Cluster.CheDashboardURL
+		// Retrieve Console and Che dashboard URLs from the status of the corresponding member cluster
+		status, err := s.CRTClient().V1Alpha1().ToolchainStatuses().Get()
+		if err != nil {
+			return nil, errors2.Wrap(err, fmt.Sprintf("error when retrieving ToolchainStatus to set Che Dashboard for completed UserSignup %s", userSignup.GetName()))
+		}
+		for _, member := range status.Status.Members {
+			if member.ClusterName == mur.Status.UserAccounts[0].Cluster.Name {
+				signupResponse.ConsoleURL = member.MemberStatus.Routes.ConsoleURL
+				signupResponse.CheDashboardURL = member.MemberStatus.Routes.CheDashboardURL
+				break
+			}
+		}
 	}
 
 	return signupResponse, nil

--- a/test/fake/banneduser_client.go
+++ b/test/fake/banneduser_client.go
@@ -3,39 +3,34 @@ package fake
 import (
 	"crypto/md5"
 	"encoding/hex"
-	"os"
+	"testing"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/testing"
+	kubetesting "k8s.io/client-go/testing"
 )
 
 type FakeBannedUserClient struct {
-	Tracker               testing.ObjectTracker
+	Tracker               kubetesting.ObjectTracker
 	Scheme                *runtime.Scheme
 	namespace             string
 	MockListByHashedLabel func(labelKey, labelValue string) (*crtapi.BannedUserList, error)
 }
 
-func NewFakeBannedUserClient(namespace string, initObjs ...runtime.Object) *FakeBannedUserClient {
+func NewFakeBannedUserClient(t *testing.T, namespace string, initObjs ...runtime.Object) *FakeBannedUserClient {
 	clientScheme := runtime.NewScheme()
 	err := crtapi.SchemeBuilder.AddToScheme(clientScheme)
-	if err != nil {
-		log.Error(err, "Error adding to scheme")
-		os.Exit(1)
-	}
+	require.NoError(t, err, "Error adding to scheme")
 	crtapi.SchemeBuilder.Register(&crtapi.BannedUser{}, &crtapi.BannedUserList{})
 
-	tracker := testing.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
+	tracker := kubetesting.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
 	for _, obj := range initObjs {
 		err := tracker.Add(obj)
-		if err != nil {
-			log.Error(err, "failed to add object to fake banned user client", "object", obj)
-			panic("could not add object to tracker: " + err.Error())
-		}
+		require.NoError(t, err, "failed to add object %v to fake banneduser client", obj)
 	}
 	return &FakeBannedUserClient{
 		Tracker:   tracker,

--- a/test/fake/fake.go
+++ b/test/fake/fake.go
@@ -1,7 +1,6 @@
 package fake
 
 import (
-	"github.com/codeready-toolchain/registration-service/pkg/kubeclient"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -12,28 +11,6 @@ import (
 var (
 	log = logf.Log.WithName("fake-usersignup-client")
 )
-
-type FakeCRTV1Alpha1Client struct {
-	NS string
-}
-
-func NewFakeCRTV1Alpha1Client(namespace string) *FakeCRTV1Alpha1Client {
-	return &FakeCRTV1Alpha1Client{
-		NS: namespace,
-	}
-}
-
-func (c *FakeCRTV1Alpha1Client) UserSignups() kubeclient.UserSignupInterface {
-	return NewFakeUserSignupClient(c.NS)
-}
-
-func (c *FakeCRTV1Alpha1Client) MasterUserRecords() kubeclient.MasterUserRecordInterface {
-	return NewFakeMasterUserRecordClient(c.NS)
-}
-
-func (c *FakeCRTV1Alpha1Client) ToolchainStatuses() kubeclient.ToolchainStatusInterface {
-	return NewFakeToolchainStatusClient(c.NS)
-}
 
 // getGVRFromObject returns the GroupVersionResource for the specified object and scheme
 func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionResource, error) {

--- a/test/fake/fake.go
+++ b/test/fake/fake.go
@@ -31,6 +31,10 @@ func (c *FakeCRTV1Alpha1Client) MasterUserRecords() kubeclient.MasterUserRecordI
 	return NewFakeMasterUserRecordClient(c.NS)
 }
 
+func (c *FakeCRTV1Alpha1Client) ToolchainStatuses() kubeclient.ToolchainStatusInterface {
+	return NewFakeToolchainStatusClient(c.NS)
+}
+
 // getGVRFromObject returns the GroupVersionResource for the specified object and scheme
 func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionResource, error) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)

--- a/test/fake/toolchainstatus_client.go
+++ b/test/fake/toolchainstatus_client.go
@@ -1,0 +1,72 @@
+package fake
+
+import (
+	"encoding/json"
+	"os"
+
+	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
+)
+
+type FakeToolchainStatusClient struct {
+	Tracker   testing.ObjectTracker
+	Scheme    *runtime.Scheme
+	namespace string
+	MockGet   func() (*crtapi.ToolchainStatus, error)
+}
+
+func NewFakeToolchainStatusClient(namespace string, initObjs ...runtime.Object) *FakeToolchainStatusClient {
+	clientScheme := runtime.NewScheme()
+	err := crtapi.SchemeBuilder.AddToScheme(clientScheme)
+	if err != nil {
+		log.Error(err, "Error adding to scheme")
+		os.Exit(1)
+	}
+	crtapi.SchemeBuilder.Register(&crtapi.ToolchainStatus{}, &crtapi.ToolchainStatusList{})
+
+	tracker := testing.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
+	for _, obj := range initObjs {
+		err := tracker.Add(obj)
+		if err != nil {
+			log.Error(err, "failed to add object to fake toolchainstatus client", "object", obj)
+			panic("could not add object to tracker: " + err.Error())
+		}
+	}
+	return &FakeToolchainStatusClient{
+		Tracker:   tracker,
+		Scheme:    clientScheme,
+		namespace: namespace,
+	}
+}
+
+func (c *FakeToolchainStatusClient) Get() (*crtapi.ToolchainStatus, error) {
+	if c.MockGet != nil {
+		return c.MockGet()
+	}
+
+	obj := &crtapi.ToolchainStatus{}
+	gvr, err := getGVRFromObject(obj, c.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := c.Tracker.Get(gvr, c.namespace, "toolchain-status")
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -22,6 +22,7 @@ type UnitTestSuite struct {
 	FakeUserSignupClient       *fake.FakeUserSignupClient
 	FakeMasterUserRecordClient *fake.FakeMasterUserRecordClient
 	FakeBannedUserClient       *fake.FakeBannedUserClient
+	FakeToolchainStatusClient  *fake.FakeToolchainStatusClient
 	factoryOptions             []factory.Option
 	configOverride             configuration.Configuration
 }
@@ -55,6 +56,7 @@ func (s *UnitTestSuite) SetupDefaultApplication() {
 	s.FakeUserSignupClient = fake.NewFakeUserSignupClient(s.config.GetNamespace())
 	s.FakeMasterUserRecordClient = fake.NewFakeMasterUserRecordClient(s.config.GetNamespace())
 	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(s.config.GetNamespace())
+	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(s.config.GetNamespace())
 	s.Application = fake.NewMockableApplication(s.config, s, s.factoryOptions...)
 }
 
@@ -73,6 +75,7 @@ func (s *UnitTestSuite) OverrideConfig(config configuration.Configuration) {
 	s.FakeUserSignupClient = fake.NewFakeUserSignupClient(config.GetNamespace())
 	s.FakeMasterUserRecordClient = fake.NewFakeMasterUserRecordClient(config.GetNamespace())
 	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(config.GetNamespace())
+	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(config.GetNamespace())
 	s.Application = fake.NewMockableApplication(config, s, s.factoryOptions...)
 }
 
@@ -88,6 +91,7 @@ func (s *UnitTestSuite) TearDownSuite() {
 	s.FakeUserSignupClient = nil
 	s.FakeMasterUserRecordClient = nil
 	s.FakeBannedUserClient = nil
+	s.FakeToolchainStatusClient = nil
 }
 
 func (s *UnitTestSuite) V1Alpha1() kubeclient.V1Alpha1 {
@@ -104,4 +108,8 @@ func (s *UnitTestSuite) MasterUserRecords() kubeclient.MasterUserRecordInterface
 
 func (s *UnitTestSuite) BannedUsers() kubeclient.BannedUserInterface {
 	return s.FakeBannedUserClient
+}
+
+func (s *UnitTestSuite) ToolchainStatuses() kubeclient.ToolchainStatusInterface {
+	return s.FakeToolchainStatusClient
 }

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -5,12 +5,11 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/kubeclient"
 	"github.com/codeready-toolchain/registration-service/pkg/log"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-
 	"github.com/codeready-toolchain/registration-service/test/fake"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	"github.com/stretchr/testify/require"
 
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -53,10 +52,10 @@ func (s *UnitTestSuite) SetupTest() {
 
 func (s *UnitTestSuite) SetupDefaultApplication() {
 	s.config = s.DefaultConfig()
-	s.FakeUserSignupClient = fake.NewFakeUserSignupClient(s.config.GetNamespace())
-	s.FakeMasterUserRecordClient = fake.NewFakeMasterUserRecordClient(s.config.GetNamespace())
-	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(s.config.GetNamespace())
-	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(s.config.GetNamespace())
+	s.FakeUserSignupClient = fake.NewFakeUserSignupClient(s.T(), s.config.GetNamespace())
+	s.FakeMasterUserRecordClient = fake.NewFakeMasterUserRecordClient(s.T(), s.config.GetNamespace())
+	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(s.T(), s.config.GetNamespace())
+	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(s.T(), s.config.GetNamespace())
 	s.Application = fake.NewMockableApplication(s.config, s, s.factoryOptions...)
 }
 
@@ -72,10 +71,10 @@ func (s *UnitTestSuite) DefaultConfig() *configuration.ViperConfig {
 
 func (s *UnitTestSuite) OverrideConfig(config configuration.Configuration) {
 	s.configOverride = config
-	s.FakeUserSignupClient = fake.NewFakeUserSignupClient(config.GetNamespace())
-	s.FakeMasterUserRecordClient = fake.NewFakeMasterUserRecordClient(config.GetNamespace())
-	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(config.GetNamespace())
-	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(config.GetNamespace())
+	s.FakeUserSignupClient = fake.NewFakeUserSignupClient(s.T(), config.GetNamespace())
+	s.FakeMasterUserRecordClient = fake.NewFakeMasterUserRecordClient(s.T(), config.GetNamespace())
+	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(s.T(), config.GetNamespace())
+	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(s.T(), config.GetNamespace())
 	s.Application = fake.NewMockableApplication(config, s, s.factoryOptions...)
 }
 


### PR DESCRIPTION
After we switched from Che to CRW in our crt-stage clusters we stuck with old Che route/URL in MUR status.
With this PR we stop using MUR status for retrieving those URLs and use ToolchainSatus instead.

There is no e2e tests to update since we do not have Che installed in our e2e tests. The toolchain-status retrieval by the reg-service is automatically covered by the existing e2e tests.