### PR TITLE
Prevent users from signing up if their username has a forbidden prefix

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -144,8 +144,13 @@ const (
 	varVerificationCodeExpiresInMin     = "verification.code_expires_in_min"
 	DefaultVerificationCodeExpiresInMin = 5
 
+	// varForbiddenUsernamePrefixes defines the prefixes that a username may not have when signing up.  If a
+	// username has a forbidden prefix, then the username compliance prefix is added to the username
 	varForbiddenUsernamePrefixes     = "username.forbidden.prefixes"
 	DefaultForbiddenUsernamePrefixes = "openshift,kubernetes"
+
+	varComplianceUsernamePrefix     = "username.compliance.prefix"
+	DefaultComplianceUsernamePrefix = "crt-"
 )
 
 type Configuration interface {
@@ -175,6 +180,7 @@ type Configuration interface {
 	GetTwilioFromNumber() string
 	GetVerificationCodeExpiresInMin() int
 	GetForbiddenUsernamePrefixes() []string
+	GetComplianceUsernamePrefix() string
 }
 
 // Config encapsulates the Viper configuration registry which stores the
@@ -280,6 +286,7 @@ func (c *ViperConfig) setConfigDefaults() {
 	c.v.SetDefault(varVerificationMessageTemplate, DefaultVerificationMessageTemplate)
 	c.v.SetDefault(varVerificationCodeExpiresInMin, DefaultVerificationCodeExpiresInMin)
 	c.v.SetDefault(varForbiddenUsernamePrefixes, DefaultForbiddenUsernamePrefixes)
+	c.v.SetDefault(varComplianceUsernamePrefix, DefaultComplianceUsernamePrefix)
 }
 
 // GetHTTPAddress returns the HTTP address (as set via default, config file, or
@@ -416,4 +423,8 @@ func (c *ViperConfig) GetVerificationCodeExpiresInMin() int {
 
 func (c *ViperConfig) GetForbiddenUsernamePrefixes() []string {
 	return c.forbiddenUsernamePrefixes
+}
+
+func (c *ViperConfig) GetComplianceUsernamePrefix() string {
+	return c.v.GetString(varComplianceUsernamePrefix)
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -144,7 +144,7 @@ const (
 	varVerificationCodeExpiresInMin     = "verification.code_expires_in_min"
 	DefaultVerificationCodeExpiresInMin = 5
 
-	varForbiddenUsernamePrefixes     = "forbidden.username.prefixes"
+	varForbiddenUsernamePrefixes     = "username.forbidden.prefixes"
 	DefaultForbiddenUsernamePrefixes = "openshift,kubernetes"
 )
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -33,6 +33,7 @@ type ServiceConfiguration interface {
 	GetVerificationExcludedEmailDomains() []string
 	GetVerificationCodeExpiresInMin() int
 	GetForbiddenUsernamePrefixes() []string
+	GetComplianceUsernamePrefix() string
 }
 
 // ServiceImpl represents the implementation of the signup service.
@@ -74,7 +75,8 @@ func (s *ServiceImpl) CreateUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, 
 	username := ctx.GetString(context.UsernameKey)
 	for _, prefix := range s.Config.GetForbiddenUsernamePrefixes() {
 		if strings.HasPrefix(username, prefix) {
-			return nil, errors.NewBadRequest(fmt.Sprintf("username has forbidden prefix [%s]", prefix))
+			username = fmt.Sprintf("%s%s", s.Config.GetComplianceUsernamePrefix(), username)
+			break
 		}
 	}
 
@@ -104,7 +106,7 @@ func (s *ServiceImpl) CreateUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, 
 		Spec: v1alpha1.UserSignupSpec{
 			TargetCluster:        "",
 			Approved:             false,
-			Username:             ctx.GetString(context.UsernameKey),
+			Username:             username,
 			GivenName:            ctx.GetString(context.GivenNameKey),
 			FamilyName:           ctx.GetString(context.FamilyNameKey),
 			Company:              ctx.GetString(context.CompanyKey),

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -32,6 +32,7 @@ type ServiceConfiguration interface {
 	GetVerificationEnabled() bool
 	GetVerificationExcludedEmailDomains() []string
 	GetVerificationCodeExpiresInMin() int
+	GetForbiddenUsernamePrefixes() []string
 }
 
 // ServiceImpl represents the implementation of the signup service.
@@ -66,6 +67,14 @@ func (s *ServiceImpl) CreateUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, 
 		// If the user has been banned, return an error
 		if bu.Spec.Email == userEmail {
 			return nil, errors.NewBadRequest("user has been banned")
+		}
+	}
+
+	// Confirm that the user doesn't have a forbidden username
+	username := ctx.GetString(context.UsernameKey)
+	for _, prefix := range s.Config.GetForbiddenUsernamePrefixes() {
+		if strings.HasPrefix(username, prefix) {
+			return nil, errors.NewBadRequest(fmt.Sprintf("username has forbidden prefix [%s]", prefix))
 		}
 	}
 


### PR DESCRIPTION
This PR will prevent users from signing up if their username has a forbidden prefix.  It introduces a new configuration parameter, `username.forbidden.prefixes` which can be used to control which prefixes are forbidden.  By default, it disallows prefixes of `openshift` or `kubernetes` to be used in usernames.

Fixes https://issues.redhat.com/browse/CRT-783