### PR TITLE
Move twilio phone number to secret

### DIFF
--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -167,11 +167,6 @@ objects:
                     configMapKeyRef:
                       name: registration-service
                       key: verification.message_template
-                - name: REGISTRATION_TWILIO_FROM_NUMBER
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: twilio.from_number
   - kind: Service
     apiVersion: v1
     metadata:
@@ -228,7 +223,6 @@ objects:
       verification.code_expires_in_min: ${VERIFICATION_CODE_EXPIRES_IN_MIN}
       verification.excluded_email_domains: ${VERIFICATION_EXCLUDED_EMAIL_DOMAINS}
       verification.message_template: ${VERIFICATION_MESSAGE_TEMPLATE}
-      twilio.from_number: ${TWILIO_FROM_NUMBER}
 parameters:
   - name: NAMESPACE
     value: 'toolchain-host-operator'
@@ -255,6 +249,4 @@ parameters:
   - name: VERIFICATION_EXCLUDED_EMAIL_DOMAINS
     value: ''
   - name: VERIFICATION_MESSAGE_TEMPLATE
-    value: ''
-  - name: TWILIO_FROM_NUMBER
     value: ''

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -411,7 +411,7 @@ func (c *ViperConfig) GetVerificationExcludedEmailDomains() []string {
 
 // GetTwilioFromNumber is the phone number or alphanumeric "Sender ID" for sending phone verification messages
 func (c *ViperConfig) GetTwilioFromNumber() string {
-	return c.v.GetString(varTwilioFromNumber)
+	return c.secretValues[varTwilioFromNumber]
 }
 
 // GetVerificationCodeExpiresInMin returns an int representing the number of minutes before a verification code should

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -789,6 +789,7 @@ func (s *TestConfigurationSuite) TestTwilioAccountSID() {
 		// then
 		assert.Equal(s.T(), "", config.GetTwilioAccountSID())
 		assert.Equal(s.T(), "", config.GetTwilioAuthToken())
+		assert.Equal(s.T(), "", config.GetTwilioFromNumber())
 	})
 	s.T().Run("env overwrite", func(t *testing.T) {
 		// given
@@ -800,6 +801,7 @@ func (s *TestConfigurationSuite) TestTwilioAccountSID() {
 			Data: map[string][]byte{
 				"twilio.account.sid": []byte("test-account-sid"),
 				"twilio.auth.token":  []byte("test-auth-token"),
+				"twilio.from_number": []byte("+1234567890"),
 			},
 		}
 
@@ -810,6 +812,7 @@ func (s *TestConfigurationSuite) TestTwilioAccountSID() {
 		require.NoError(t, err)
 		assert.Equal(t, "test-account-sid", config.GetTwilioAccountSID())
 		assert.Equal(t, "test-auth-token", config.GetTwilioAuthToken())
+		assert.Equal(t, "+1234567890", config.GetTwilioFromNumber())
 	})
 
 	s.T().Run("secret not found", func(t *testing.T) {
@@ -823,39 +826,6 @@ func (s *TestConfigurationSuite) TestTwilioAccountSID() {
 		// then
 		require.NoError(t, err)
 		assert.NotNil(t, config)
-	})
-}
-
-func (s *TestConfigurationSuite) TestTwilioFromNumber() {
-	restore := SetEnvVarAndRestore(s.T(), "WATCH_NAMESPACE", "toolchain-host-operator")
-	defer restore()
-	key := configuration.EnvPrefix + "_" + "TWILIO_FROM_NUMBER"
-	resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-	defer resetFunc()
-
-	s.Run("default", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		config := s.getDefaultConfiguration()
-		require.Equal(s.T(), "", config.GetTwilioFromNumber())
-	})
-
-	s.Run("file", func() {
-		resetFunc := UnsetEnvVarAndRestore(s.T(), key)
-		defer resetFunc()
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		config := s.getFileConfiguration(`twilio.from_number: ` + u.String())
-		assert.Equal(s.T(), u.String(), config.GetTwilioFromNumber())
-	})
-
-	s.Run("env overwrite", func() {
-		u, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		err = os.Setenv(key, u.String())
-		require.NoError(s.T(), err)
-		config := s.getDefaultConfiguration()
-		assert.Equal(s.T(), u.String(), config.GetTwilioFromNumber())
 	})
 }
 


### PR DESCRIPTION
We can't keep it in env/prod.yaml because we need to use different numbers in prod and stage. So, let's keep it in the host operator secret as we do for the rest of twilio configuration.
The secret is already setup correctly: https://github.com/codeready-toolchain/sandbox-sre/blob/7e5a36466d2b5be02b6067834d5f9eb31e5e11a1/config/sandbox.x8i5.p1.openshiftapps.com/host/operator_secret.yaml#L18
We just need to drop the reg-service env var from the deployment and start loading it from the secret.

Paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/213

Also see:
https://github.com/codeready-toolchain/host-operator/pull/342