### PR TITLE
changing woopra-domain and segment-write-key to return strings

### DIFF
--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -167,6 +167,10 @@ objects:
                     configMapKeyRef:
                       name: registration-service
                       key: verification.message_template
+              resources:
+                requests:
+                  cpu: "50m"
+                  memory: "100M"
   - kind: Service
     apiVersion: v1
     metadata:

--- a/pkg/controller/woopra.go
+++ b/pkg/controller/woopra.go
@@ -6,14 +6,6 @@ import (
 	"net/http"
 )
 
-type woopraResponse struct {
-	WoopraDomain string `json:"woopra-domain"`
-}
-
-type segmentResponse struct {
-	SegmentWriteKey string `json:"segment-write-key"`
-}
-
 // Woopra implements the segment endpoint, which is invoked to
 // retrieve the woopra domain for the ui.
 type Woopra struct {
@@ -30,11 +22,11 @@ func NewWoopra(config configuration.Configuration) *Woopra {
 // GetHandler returns the woopra-domain for UI.
 func (w *Woopra) GetWoopraDomain(ctx *gin.Context) {
 	domain := w.config.GetWoopraDomain()
-	ctx.JSON(http.StatusOK, woopraResponse{WoopraDomain: domain})
+	ctx.String(http.StatusOK, domain)
 }
 
 // GetSegmentWriteKey returns segment-write-key content for UI.
 func (s *Woopra) GetSegmentWriteKey(ctx *gin.Context) {
 	segmentWriteKey := s.config.GetSegmentWriteKey()
-	ctx.JSON(http.StatusOK, segmentResponse{SegmentWriteKey: segmentWriteKey})
+	ctx.String(http.StatusOK, segmentWriteKey)
 }

--- a/pkg/controller/woopra_test.go
+++ b/pkg/controller/woopra_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -52,12 +51,11 @@ func (s *TestWoopraSuite) TestWoopraHandler() {
 
 		// Check the response body is what we expect.
 		// get config values from endpoint response
-		var dataEnvelope *woopraResponse
-		err = json.Unmarshal(rr.Body.Bytes(), &dataEnvelope)
+		dataEnvelope := string(rr.Body.Bytes())
 		require.NoError(s.T(), err)
 
 		s.Run("envelope woopra domain name", func() {
-			assert.Equal(s.T(), s.Config().GetWoopraDomain(), dataEnvelope.WoopraDomain, "wrong 'woopra domain name' in woopra response")
+			assert.Equal(s.T(), s.Config().GetWoopraDomain(), dataEnvelope, "wrong 'woopra domain name' in woopra response")
 		})
 	})
 
@@ -84,12 +82,11 @@ func (s *TestWoopraSuite) TestWoopraHandler() {
 
 		// Check the response body is what we expect.
 		// get config values from endpoint response
-		var dataEnvelope *segmentResponse
-		err = json.Unmarshal(rr.Body.Bytes(), &dataEnvelope)
+		dataEnvelope := string(rr.Body.Bytes())
 		require.NoError(s.T(), err)
 
 		s.Run("envelope segment write key", func() {
-			assert.Equal(s.T(), s.Config().GetSegmentWriteKey(), dataEnvelope.SegmentWriteKey, "wrong 'segment write key' in segment response")
+			assert.Equal(s.T(), s.Config().GetSegmentWriteKey(), dataEnvelope, "wrong 'segment write key' in segment response")
 		})
 	})
 }


### PR DESCRIPTION
The format expected from the woopra-domain and segment-write-key should be string instead of JSON. 

See the discussion: https://issues.redhat.com/browse/CRT-753
Related PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/225

This PR updates the endpoints to return string format instead of JSON. 