### PR TITLE
Enabled user ID encoding, added tests

### DIFF
--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -4,6 +4,8 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"hash/crc32"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -86,8 +88,7 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, err
 
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: v1.ObjectMeta{
-			//Name:      EncodeUserID(ctx.GetString(context.SubKey)),
-			Name:      ctx.GetString(context.SubKey),
+			Name:      EncodeUserID(ctx.GetString(context.SubKey)),
 			Namespace: s.Config.GetNamespace(),
 			Annotations: map[string]string{
 				v1alpha1.UserSignupUserEmailAnnotationKey:           userEmail,
@@ -119,7 +120,7 @@ func extractEmailHost(email string) string {
 
 // EncodeUserID transforms a subject value (the user's UserID) to make it DNS-1123 compliant,
 // by removing invalid characters, trimming the length and prefixing with a CRC32 checksum if required.
-/*func EncodeUserID(subject string) string {
+func EncodeUserID(subject string) string {
 	// Convert to lower case
 	encoded := strings.ToLower(subject)
 
@@ -133,7 +134,7 @@ func extractEmailHost(email string) string {
 
 	// Add a checksum prefix if the encoded value is different to the original subject value
 	if encoded != subject {
-		encoded = fmt.Sprintf("%x%s", crc32.Checksum([]byte(subject), crc32.IEEETable), encoded)
+		encoded = fmt.Sprintf("%x-%s", crc32.Checksum([]byte(subject), crc32.IEEETable), encoded)
 	}
 
 	// Trim if the length exceeds the maximum
@@ -142,7 +143,7 @@ func extractEmailHost(email string) string {
 	}
 
 	return encoded
-}*/
+}
 
 // Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username and userID
 // if doesn't exist yet.

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -148,9 +148,9 @@ func EncodeUserID(subject string) string {
 // Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username and userID
 // if doesn't exist yet.
 func (s *ServiceImpl) Signup(ctx *gin.Context) (*v1alpha1.UserSignup, error) {
-	userID := ctx.GetString(context.SubKey)
+	encodedUserID := EncodeUserID(ctx.GetString(context.SubKey))
 	// Retrieve UserSignup resource from the host cluster
-	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(userID)
+	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(encodedUserID)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// New Signup
@@ -167,7 +167,7 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*v1alpha1.UserSignup, error) {
 	}
 
 	username := ctx.GetString(context.UsernameKey)
-	return nil, errors2.Errorf("unable to create UserSignup [id: %s; username: %s] because there is already an active UserSignup with such ID", userID, username)
+	return nil, errors2.Errorf("unable to create UserSignup [id: %s; username: %s] because there is already an active UserSignup with such ID", encodedUserID, username)
 }
 
 // createUserSignup creates a new UserSignup resource with the specified username and userID

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -120,6 +120,9 @@ func extractEmailHost(email string) string {
 
 // EncodeUserID transforms a subject value (the user's UserID) to make it DNS-1123 compliant,
 // by removing invalid characters, trimming the length and prefixing with a CRC32 checksum if required.
+// ### WARNING ### changing this function will cause breakage, as it is used to lookup existing UserSignup
+// resources.  If a change is absolutely required, then all existing UserSignup instances must be migrated
+// to the new value
 func EncodeUserID(subject string) string {
 	// Convert to lower case
 	encoded := strings.ToLower(subject)
@@ -203,7 +206,7 @@ func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing v1alpha1.U
 func (s *ServiceImpl) GetSignup(userID string) (*signup.Signup, error) {
 
 	// Retrieve UserSignup resource from the host cluster
-	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(userID)
+	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(EncodeUserID(userID))
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
@@ -280,7 +283,7 @@ func (s *ServiceImpl) GetSignup(userID string) (*signup.Signup, error) {
 // GetUserSignup is used to return the actual UserSignup resource instance, rather than the Signup DTO
 func (s *ServiceImpl) GetUserSignup(userID string) (*v1alpha1.UserSignup, error) {
 	// Retrieve UserSignup resource from the host cluster
-	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(userID)
+	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(EncodeUserID(userID))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -246,6 +246,11 @@ func (s *TestSignupServiceSuite) TestEncodeUserID() {
 		encoded := service.EncodeUserID(userID)
 		require.Equal(s.T(), "e3632025-0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr", encoded)
 	})
+	s.Run("test user ID with colon separator", func() {
+		userID := "abc:xyz"
+		encoded := service.EncodeUserID(userID)
+		require.Equal(s.T(), "a05a4053-abcxyz", encoded)
+	})
 }
 
 func (s *TestSignupServiceSuite) TestUserWithExcludedDomainEmailSignsUp() {

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -3,8 +3,12 @@ package service_test
 import (
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/codeready-toolchain/registration-service/pkg/signup/service"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -178,7 +182,6 @@ func (s *TestSignupServiceSuite) TestSignup() {
 	})
 }
 
-/*
 func (s *TestSignupServiceSuite) TestUserSignupWithInvalidSubjectPrefix() {
 	s.OverrideConfig(s.ServiceConfiguration(TestNamespace, true, nil, 5))
 
@@ -217,23 +220,33 @@ func (s *TestSignupServiceSuite) TestUserSignupWithInvalidSubjectPrefix() {
 	val := userSignups.Items[0]
 
 	// Confirm that the UserSignup.Name value has been prefixed correctly
-	crc32q := crc32.MakeTable(0xEDB88320)
-	expected := fmt.Sprintf("%x%s", crc32.Checksum([]byte(subject), crc32q), subject)
+	expected := fmt.Sprintf("%x%s", crc32.Checksum([]byte(subject), crc32.IEEETable), subject)
 	require.Equal(s.T(), expected, val.Name)
 	require.False(s.T(), strings.HasPrefix(val.Name, "-"))
 }
-*/
 
-/*
 func (s *TestSignupServiceSuite) TestEncodeUserID() {
 	s.Run("test valid user ID unchanged", func() {
 		userID := "abcde-12345"
-
 		encoded := service.EncodeUserID(userID)
-
 		require.Equal(s.T(), userID, encoded)
 	})
-}*/
+	s.Run("test user ID with invalid characters", func() {
+		userID := "abcde\\*-12345"
+		encoded := service.EncodeUserID(userID)
+		require.Equal(s.T(), "c0177ca4-abcde-12345", encoded)
+	})
+	s.Run("test user ID with invalid prefix", func() {
+		userID := "-1234567"
+		encoded := service.EncodeUserID(userID)
+		require.Equal(s.T(), "ca3e1e0f-1234567", encoded)
+	})
+	s.Run("test user ID that exceeds max length", func() {
+		userID := "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-01234567890123456789"
+		encoded := service.EncodeUserID(userID)
+		require.Equal(s.T(), "e3632025-0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr", encoded)
+	})
+}
 
 func (s *TestSignupServiceSuite) TestUserWithExcludedDomainEmailSignsUp() {
 	s.OverrideConfig(s.ServiceConfiguration(TestNamespace, true, []string{"redhat.com"}, 5))


### PR DESCRIPTION
**IMPORTANT** Only to be merged after https://github.com/codeready-toolchain/host-operator/pull/362

This PR performs a one-way encoding of the user's subject claim in order to use the encoded value as the UserSignup resource name.