### PR TITLE
Added email address check also when PhoneNumberAlreadyInUse verification

### DIFF
--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -11,7 +11,7 @@ type SignupService interface {
 	GetSignup(userID string) (*signup.Signup, error)
 	GetUserSignup(userID string) (*v1alpha1.UserSignup, error)
 	UpdateUserSignup(userSignup *v1alpha1.UserSignup) (*v1alpha1.UserSignup, error)
-	PhoneNumberAlreadyInUse(userID, e164PhoneNumber, email string) error
+	PhoneNumberAlreadyInUse(userID, value string) error
 }
 
 type VerificationService interface {

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -11,7 +11,7 @@ type SignupService interface {
 	GetSignup(userID string) (*signup.Signup, error)
 	GetUserSignup(userID string) (*v1alpha1.UserSignup, error)
 	UpdateUserSignup(userSignup *v1alpha1.UserSignup) (*v1alpha1.UserSignup, error)
-	PhoneNumberAlreadyInUse(userID, e164PhoneNumber string) error
+	PhoneNumberAlreadyInUse(userID, e164PhoneNumber, email string) error
 }
 
 type VerificationService interface {

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -11,7 +11,7 @@ type SignupService interface {
 	GetSignup(userID string) (*signup.Signup, error)
 	GetUserSignup(userID string) (*v1alpha1.UserSignup, error)
 	UpdateUserSignup(userSignup *v1alpha1.UserSignup) (*v1alpha1.UserSignup, error)
-	PhoneNumberAlreadyInUse(userID, value string) error
+	PhoneNumberAlreadyInUse(userID, phoneNumberOrHash string) error
 }
 
 type VerificationService interface {

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -88,10 +88,10 @@ func (s *Signup) InitVerificationHandler(ctx *gin.Context) {
 	if err != nil {
 		log.Errorf(ctx, nil, "Verification for %s could not be sent", userID)
 		switch t := err.(type) {
-		default:
-			errors.AbortWithError(ctx, http.StatusInternalServerError, err, "error while initiating verification")
 		case *errors.Error:
 			errors.AbortWithError(ctx, int(t.Code), err, t.Message)
+		default:
+			errors.AbortWithError(ctx, http.StatusInternalServerError, err, "error while initiating verification")
 		}
 		return
 	}

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -290,7 +290,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 	ctrl := controller.NewSignup(s.Application, s.Config())
 	handler := gin.HandlerFunc(ctrl.InitVerificationHandler)
 
-	assertInitVerificationSuccess := func(phone_number string, expectedCounter int) {
+	assertInitVerificationSuccess := func(phone_number, expectedHash string, expectedCounter int) {
 		gock.New("https://api.twilio.com").
 			Reply(http.StatusNoContent).
 			BodyString("")
@@ -306,22 +306,22 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 		require.NotEmpty(s.T(), updatedUserSignup.Annotations[crtapi.UserSignupVerificationInitTimestampAnnotationKey])
 		require.NotEmpty(s.T(), updatedUserSignup.Annotations[crtapi.UserVerificationExpiryAnnotationKey])
 		require.Equal(s.T(), strconv.Itoa(expectedCounter), updatedUserSignup.Annotations[crtapi.UserSignupVerificationCounterAnnotationKey])
-		require.Equal(s.T(), "fd276563a8232d16620da8ec85d0575f", updatedUserSignup.Labels[crtapi.UserSignupUserPhoneHashLabelKey])
+		require.Equal(s.T(), expectedHash, updatedUserSignup.Labels[crtapi.UserSignupUserPhoneHashLabelKey])
 	}
 
 	s.Run("init verification success", func() {
-		assertInitVerificationSuccess("2268213044", 1)
+		assertInitVerificationSuccess("2268213044", "fd276563a8232d16620da8ec85d0575f", 1)
 	})
 
 	s.Run("init verification success phone number with parenthesis and spaces", func() {
-		assertInitVerificationSuccess("(226) 821 3044", 2)
+		assertInitVerificationSuccess("(226) 821 3045", "9691252ac0ea2cb55295ac9b98df1c51", 2)
 	})
 
 	s.Run("init verification success phone number with dashes", func() {
-		assertInitVerificationSuccess("226-821-3044", 3)
+		assertInitVerificationSuccess("226-821-3044", "fd276563a8232d16620da8ec85d0575f", 3)
 	})
 	s.Run("init verification success phone number with spaces", func() {
-		assertInitVerificationSuccess("2 2 6 8 2 1 3 0 4 4", 4)
+		assertInitVerificationSuccess("2 2 6 8 2 1 3 0 4 7", "ce3e697125f35efb76357ed8e3b768b7", 4)
 	})
 	s.Run("init verification fails with invalid country code", func() {
 		gock.New("https://api.twilio.com").
@@ -681,7 +681,7 @@ type FakeSignupService struct {
 	MockSignup                  func(ctx *gin.Context) (*crtapi.UserSignup, error)
 	MockGetUserSignup           func(userID string) (*crtapi.UserSignup, error)
 	MockUpdateUserSignup        func(userSignup *crtapi.UserSignup) (*crtapi.UserSignup, error)
-	MockPhoneNumberAlreadyInUse func(userID, e164phoneNumber string) error
+	MockPhoneNumberAlreadyInUse func(userID, value string) error
 }
 
 func (m *FakeSignupService) GetSignup(userID string) (*signup.Signup, error) {

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -290,12 +290,12 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 	ctrl := controller.NewSignup(s.Application, s.Config())
 	handler := gin.HandlerFunc(ctrl.InitVerificationHandler)
 
-	assertInitVerificationSuccess := func(phone_number, expectedHash string, expectedCounter int) {
+	assertInitVerificationSuccess := func(phoneNumber, expectedHash string, expectedCounter int) {
 		gock.New("https://api.twilio.com").
 			Reply(http.StatusNoContent).
 			BodyString("")
 
-		data := []byte(fmt.Sprintf(`{"phone_number": "%s", "country_code": "1"}`, phone_number))
+		data := []byte(fmt.Sprintf(`{"phone_number": "%s", "country_code": "1"}`, phoneNumber))
 		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, http.MethodPut, "/api/v1/signup/verification")
 		require.Equal(s.T(), http.StatusNoContent, rr.Code)
 

--- a/pkg/kubeclient/banneduser.go
+++ b/pkg/kubeclient/banneduser.go
@@ -22,23 +22,44 @@ type bannedUserClient struct {
 
 type BannedUserInterface interface {
 	ListByEmail(email string) (*crtapi.BannedUserList, error)
-	ListByPhone(phoneNumber string) (*crtapi.BannedUserList, error)
+	ListByPhoneNumberOrHash(phoneNumberOrHash string) (*crtapi.BannedUserList, error)
 }
 
 func (c *bannedUserClient) ListByEmail(email string) (*crtapi.BannedUserList, error) {
-	return c.listByHashedLabel(crtapi.BannedUserEmailHashLabelKey, email)
-}
-func (c *bannedUserClient) ListByPhone(phone string) (*crtapi.BannedUserList, error) {
-	return c.listByHashedLabel(crtapi.BannedUserPhoneNumberHashLabelKey, phone)
+	return c.listByLabelForHashedValue(crtapi.BannedUserEmailHashLabelKey, email)
 }
 
-// ListByHashedLabel returns a BannedUserList containing any BannedUser resources that have a label matching the specified label
-func (c *bannedUserClient) listByHashedLabel(labelKey, labelValue string) (*crtapi.BannedUserList, error) {
+// ListByPhoneNumberOrHash will return a list of BannedUsers that have a phone number hash label value matching
+// the provided value.  If the value provided is an actual phone number, then the hash will be calculated and then
+// used to query the BannedUsers, otherwise if the hash value has been provided, then that value will be used
+// directly for the query.
+func (c *bannedUserClient) ListByPhoneNumberOrHash(phoneNumberOrHash string) (*crtapi.BannedUserList, error) {
+	if e164Matcher.Match([]byte(phoneNumberOrHash)) {
+		return c.listByLabelForHashedValue(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
+	}
+
+	if md5Matcher.Match([]byte(phoneNumberOrHash)) {
+		return c.listByLabel(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
+	}
+
+	// Default to searching for a hash of the specified value
+	return c.listByLabelForHashedValue(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
+}
+
+// listByLabelForHashedValue returns a BannedUserList containing any BannedUser resources that have a label matching
+// the hash of the specified value
+func (c *bannedUserClient) listByLabelForHashedValue(labelKey, valueToHash string) (*crtapi.BannedUserList, error) {
 	// Calculate the md5 hash for the phoneNumber
 	md5hash := md5.New()
 	// Ignore the error, as this implementation cannot return one
-	_, _ = md5hash.Write([]byte(labelValue))
+	_, _ = md5hash.Write([]byte(valueToHash))
 	hash := hex.EncodeToString(md5hash.Sum(nil))
+
+	return c.listByLabel(labelKey, hash)
+}
+
+// listByLabel returns a BannedUserList containing any BannedUser resources that have a label matching the specified label
+func (c *bannedUserClient) listByLabel(labelKey, labelValue string) (*crtapi.BannedUserList, error) {
 
 	intf, err := dynamic.NewForConfig(&c.cfg)
 	if err != nil {
@@ -47,7 +68,7 @@ func (c *bannedUserClient) listByHashedLabel(labelKey, labelValue string) (*crta
 
 	r := schema.GroupVersionResource{Group: "toolchain.dev.openshift.com", Version: "v1alpha1", Resource: bannedUserResourcePlural}
 	listOptions := v1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", labelKey, hash),
+		LabelSelector: fmt.Sprintf("%s=%s", labelKey, labelValue),
 	}
 
 	list, err := intf.Resource(r).Namespace(c.ns).List(context.TODO(), listOptions)

--- a/pkg/kubeclient/banneduser.go
+++ b/pkg/kubeclient/banneduser.go
@@ -34,10 +34,6 @@ func (c *bannedUserClient) ListByEmail(email string) (*crtapi.BannedUserList, er
 // used to query the BannedUsers, otherwise if the hash value has been provided, then that value will be used
 // directly for the query.
 func (c *bannedUserClient) ListByPhoneNumberOrHash(phoneNumberOrHash string) (*crtapi.BannedUserList, error) {
-	if e164Matcher.Match([]byte(phoneNumberOrHash)) {
-		return c.listByLabelForHashedValue(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
-	}
-
 	if md5Matcher.Match([]byte(phoneNumberOrHash)) {
 		return c.listByLabel(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
 	}

--- a/pkg/kubeclient/signup.go
+++ b/pkg/kubeclient/signup.go
@@ -88,10 +88,6 @@ func (c *userSignupClient) Update(obj *crtapi.UserSignup) (*crtapi.UserSignup, e
 // used to query the UserSignups, otherwise if the hash value has been provided, then that value will be used
 // directly for the query.
 func (c *userSignupClient) ListByPhoneNumberOrHash(phoneNumberOrHash string) (*crtapi.UserSignupList, error) {
-	if e164Matcher.Match([]byte(phoneNumberOrHash)) {
-		return c.listByLabelForHashedValue(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
-	}
-
 	if md5Matcher.Match([]byte(phoneNumberOrHash)) {
 		return c.listByLabel(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
 	}

--- a/pkg/kubeclient/signup.go
+++ b/pkg/kubeclient/signup.go
@@ -118,7 +118,7 @@ func (c *userSignupClient) listByLabel(labelKey, labelValue string) (*crtapi.Use
 
 	r := schema.GroupVersionResource{Group: "toolchain.dev.openshift.com", Version: "v1alpha1", Resource: userSignupResourcePlural}
 	listOptions := v1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", labelKey, labelValue),
+		LabelSelector: fmt.Sprintf("%s!=%s,%s=%s", crtapi.UserSignupStateLabelKey, crtapi.UserSignupStateLabelValueDeactivated,labelKey, labelValue),
 	}
 
 	list, err := intf.Resource(r).Namespace(c.ns).List(context.TODO(), listOptions)

--- a/pkg/kubeclient/signup.go
+++ b/pkg/kubeclient/signup.go
@@ -32,7 +32,7 @@ type UserSignupInterface interface {
 	Get(name string) (*crtapi.UserSignup, error)
 	Create(obj *crtapi.UserSignup) (*crtapi.UserSignup, error)
 	Update(obj *crtapi.UserSignup) (*crtapi.UserSignup, error)
-	ListByPhoneNumberOrHash(phoneNumberOrHash string) (*crtapi.UserSignupList, error)
+	ListActiveSignupsByPhoneNumberOrHash(phoneNumberOrHash string) (*crtapi.UserSignupList, error)
 }
 
 // Get returns the UserSignup with the specified name, or an error if something went wrong while attempting to retrieve it
@@ -83,33 +83,34 @@ func (c *userSignupClient) Update(obj *crtapi.UserSignup) (*crtapi.UserSignup, e
 	return result, nil
 }
 
-// ListByPhoneNumberOrHash will return a list of UserSignups that have a phone number hash label value matching
-// the provided value.  If the value provided is an actual phone number, then the hash will be calculated and then
-// used to query the UserSignups, otherwise if the hash value has been provided, then that value will be used
-// directly for the query.
-func (c *userSignupClient) ListByPhoneNumberOrHash(phoneNumberOrHash string) (*crtapi.UserSignupList, error) {
+// ListActiveSignupsByPhoneNumberOrHash will return a list of non-deactivated UserSignups that have a phone number hash
+// label value matching the provided value.  If the value provided is an actual phone number, then the hash will be
+// calculated and then used to query the UserSignups, otherwise if the hash value has been provided, then that value
+// will be used directly for the query.
+func (c *userSignupClient) ListActiveSignupsByPhoneNumberOrHash(phoneNumberOrHash string) (*crtapi.UserSignupList, error) {
 	if md5Matcher.Match([]byte(phoneNumberOrHash)) {
-		return c.listByLabel(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
+		return c.listActiveSignupsByLabel(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
 	}
 
 	// Default to searching for a hash of the specified value
-	return c.listByLabelForHashedValue(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
+	return c.listActiveSignupsByLabelForHashedValue(crtapi.BannedUserPhoneNumberHashLabelKey, phoneNumberOrHash)
 }
 
-// listByLabelForHashedValue returns a UserSignupList containing any UserSignup resources that have a label matching the
-// md5 hash of the specified value
-func (c *userSignupClient) listByLabelForHashedValue(labelKey, value string) (*crtapi.UserSignupList, error) {
+// listActiveSignupsByLabelForHashedValue returns a UserSignupList containing any non-deactivated UserSignup resources
+// that have a label matching the md5 hash of the specified value
+func (c *userSignupClient) listActiveSignupsByLabelForHashedValue(labelKey, value string) (*crtapi.UserSignupList, error) {
 	// Calculate the md5 hash for the label value
 	md5hash := md5.New()
 	// Ignore the error, as this implementation cannot return one
 	_, _ = md5hash.Write([]byte(value))
 	hash := hex.EncodeToString(md5hash.Sum(nil))
 
-	return c.listByLabel(labelKey, hash)
+	return c.listActiveSignupsByLabel(labelKey, hash)
 }
 
-// listByLabel returns a UserSignupList containing any UserSignup resources that have a label matching the specified label
-func (c *userSignupClient) listByLabel(labelKey, labelValue string) (*crtapi.UserSignupList, error) {
+// listActiveSignupsByLabel returns a UserSignupList containing any non-deactivated UserSignup resources that have a
+// label matching the specified label
+func (c *userSignupClient) listActiveSignupsByLabel(labelKey, labelValue string) (*crtapi.UserSignupList, error) {
 
 	intf, err := dynamic.NewForConfig(&c.cfg)
 	if err != nil {
@@ -118,7 +119,7 @@ func (c *userSignupClient) listByLabel(labelKey, labelValue string) (*crtapi.Use
 
 	r := schema.GroupVersionResource{Group: "toolchain.dev.openshift.com", Version: "v1alpha1", Resource: userSignupResourcePlural}
 	listOptions := v1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s!=%s,%s=%s", crtapi.UserSignupStateLabelKey, crtapi.UserSignupStateLabelValueDeactivated,labelKey, labelValue),
+		LabelSelector: fmt.Sprintf("%s!=%s,%s=%s", crtapi.UserSignupStateLabelKey, crtapi.UserSignupStateLabelValueDeactivated, labelKey, labelValue),
 	}
 
 	list, err := intf.Resource(r).Namespace(c.ns).List(context.TODO(), listOptions)

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -313,8 +313,8 @@ func (s *ServiceImpl) UpdateUserSignup(userSignup *v1alpha1.UserSignup) (*v1alph
 
 // PhoneNumberAlreadyInUse checks if the phone number has been banned. If so, return
 // an internal server error. If not, check if a signup with a different userID
-// exists. If so, return an internal server error. Otherwise, return without error.
-func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, e164PhoneNumber string) error {
+// and email address exists. If so, return an internal server error. Otherwise, return without error.
+func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, e164PhoneNumber, email string) error {
 	bannedUserList, err := s.CRTClient().V1Alpha1().BannedUsers().ListByPhone(e164PhoneNumber)
 	if err != nil {
 		return errs.NewInternalError(err, "failed listing banned users")
@@ -328,7 +328,8 @@ func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, e164PhoneNumber string) er
 		return errs.NewInternalError(err, "failed listing userSignups")
 	}
 	for _, signup := range userSignupList.Items {
-		if signup.Name != userID {
+
+		if signup.Spec.UserID != userID && signup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey] != email {
 			return errs.NewForbiddenError("cannot re-register with phone number", "phone number already in use")
 		}
 	}

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -329,15 +329,10 @@ func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, phoneNumberOrHash string) 
 		return errs.NewInternalError(err, "failed listing userSignups")
 	}
 	for _, signup := range userSignupList.Items {
-<<<<<<< HEAD
 
-		if signup.Spec.UserID != userID && signup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey] != email {
-			return errs.NewForbiddenError("cannot re-register with phone number", "phone number already in use")
-=======
 		if signup.Spec.UserID != userID && !signup.Spec.Deactivated {
-			return errors3.NewForbiddenError("cannot re-register with phone number",
+			return errs.NewForbiddenError("cannot re-register with phone number",
 				"phone number already in use")
->>>>>>> 8257211 (CRT-883 modify phone number check logic, fix existing tests)
 		}
 	}
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -332,7 +332,7 @@ func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, phoneNumberOrHash string) 
 	}
 	for _, signup := range userSignupList.Items {
 
-		if signup.Spec.UserID != userID && !signup.Spec.Deactivated {
+		if signup.Spec.UserID != userID {
 			return errs.NewForbiddenError("cannot re-register with phone number",
 				"phone number already in use")
 		}

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -314,8 +314,8 @@ func (s *ServiceImpl) UpdateUserSignup(userSignup *v1alpha1.UserSignup) (*v1alph
 // PhoneNumberAlreadyInUse checks if the phone number has been banned. If so, return
 // an internal server error. If not, check if a signup with a different userID
 // and email address exists. If so, return an internal server error. Otherwise, return without error.
-func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, e164PhoneNumber, email string) error {
-	bannedUserList, err := s.CRTClient().V1Alpha1().BannedUsers().ListByPhone(e164PhoneNumber)
+func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, value string) error {
+	bannedUserList, err := s.CRTClient().V1Alpha1().BannedUsers().ListByPhone(value)
 	if err != nil {
 		return errs.NewInternalError(err, "failed listing banned users")
 	}
@@ -323,14 +323,20 @@ func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, e164PhoneNumber, email str
 		return errs.NewForbiddenError("cannot re-register with phone number", "phone number already in use")
 	}
 
-	userSignupList, err := s.CRTClient().V1Alpha1().UserSignups().ListByPhone(e164PhoneNumber)
+	userSignupList, err := s.CRTClient().V1Alpha1().UserSignups().ListByPhone(value)
 	if err != nil {
 		return errs.NewInternalError(err, "failed listing userSignups")
 	}
 	for _, signup := range userSignupList.Items {
+<<<<<<< HEAD
 
 		if signup.Spec.UserID != userID && signup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey] != email {
 			return errs.NewForbiddenError("cannot re-register with phone number", "phone number already in use")
+=======
+		if signup.Spec.UserID != userID && !signup.Spec.Deactivated {
+			return errors3.NewForbiddenError("cannot re-register with phone number",
+				"phone number already in use")
+>>>>>>> 8257211 (CRT-883 modify phone number check logic, fix existing tests)
 		}
 	}
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -314,8 +314,9 @@ func (s *ServiceImpl) UpdateUserSignup(userSignup *v1alpha1.UserSignup) (*v1alph
 // PhoneNumberAlreadyInUse checks if the phone number has been banned. If so, return
 // an internal server error. If not, check if a signup with a different userID
 // and email address exists. If so, return an internal server error. Otherwise, return without error.
-func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, value string) error {
-	bannedUserList, err := s.CRTClient().V1Alpha1().BannedUsers().ListByPhone(value)
+// Either the actual phone number, or the md5 hash of the phone number may be provided here.
+func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, phoneNumberOrHash string) error {
+	bannedUserList, err := s.CRTClient().V1Alpha1().BannedUsers().ListByPhoneNumberOrHash(phoneNumberOrHash)
 	if err != nil {
 		return errs.NewInternalError(err, "failed listing banned users")
 	}
@@ -323,7 +324,7 @@ func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, value string) error {
 		return errs.NewForbiddenError("cannot re-register with phone number", "phone number already in use")
 	}
 
-	userSignupList, err := s.CRTClient().V1Alpha1().UserSignups().ListByPhone(value)
+	userSignupList, err := s.CRTClient().V1Alpha1().UserSignups().ListByPhoneNumberOrHash(phoneNumberOrHash)
 	if err != nil {
 		return errs.NewInternalError(err, "failed listing userSignups")
 	}

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -83,7 +83,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 		return errors.NewBadRequest("forbidden request", "verification code will not be sent")
 	}
 
-	// Check if the provided phone number is already being used by another user with a different email address
+	// Check if the provided phone number is already being used by another user
 	err = s.Services().SignupService().PhoneNumberAlreadyInUse(userID, e164PhoneNumber)
 	if err != nil {
 		switch t := err.(type) {

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -84,8 +84,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 	}
 
 	// Check if the provided phone number is already being used by another user with a different email address
-	err = s.Services().SignupService().PhoneNumberAlreadyInUse(userID, e164PhoneNumber,
-		signup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
+	err = s.Services().SignupService().PhoneNumberAlreadyInUse(userID, e164PhoneNumber)
 	if err != nil {
 		if apierrors.IsForbidden(err) {
 			log.Errorf(ctx, err, "phone number already in use, cannot register using phone number: %s", e164PhoneNumber)
@@ -203,6 +202,13 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 		}
 		log.Error(ctx, lookupErr, "error retrieving usersignup")
 		return errors.NewInternalError(lookupErr, fmt.Sprintf("error retrieving usersignup: %s", userID))
+	}
+
+	err := s.Services().SignupService().PhoneNumberAlreadyInUse(userID, signup.Labels[v1alpha1.UserSignupUserPhoneHashLabelKey])
+	if err != nil {
+		log.Error(ctx, err, "phone number to verify already in use")
+		return errors.NewBadRequest("phone number already in use",
+			"the phone number provided for this signup is already in use by an active account")
 	}
 
 	now := time.Now()

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -83,8 +83,9 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 		return errors.NewBadRequest("forbidden request", "verification code will not be sent")
 	}
 
-	// Check if the provided phone number is already being used by another user
-	err = s.Services().SignupService().PhoneNumberAlreadyInUse(userID, e164PhoneNumber)
+	// Check if the provided phone number is already being used by another user with a different email address
+	err = s.Services().SignupService().PhoneNumberAlreadyInUse(userID, e164PhoneNumber,
+		signup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
 	if err != nil {
 		if apierrors.IsForbidden(err) {
 			log.Errorf(ctx, err, "phone number already in use, cannot register using phone number: %s", e164PhoneNumber)

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -522,4 +522,5 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 		require.Error(s.T(), err)
 		require.Equal(s.T(), "parsing time \"ABC\" as \"2006-01-02T15:04:05.000Z07:00\": cannot parse \"ABC\" as \"2006\":error parsing expiry timestamp", err.Error())
 	})
+
 }

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -382,7 +382,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	err := s.Application.VerificationService().InitVerification(ctx, bravoUserSignup.Name, e164PhoneNumber)
 	require.Error(s.T(), err)
-	require.Equal(s.T(), "daily limit exceeded:cannot generate new verification code", err.Error())
+	require.Equal(s.T(), "phone number already in use:cannot register using phone number: +19875551122", err.Error())
 
 	require.Empty(s.T(), bravoUserSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
 }

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -384,7 +384,82 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 	require.Error(s.T(), err)
 	require.Equal(s.T(), "phone number already in use:cannot register using phone number: +19875551122", err.Error())
 
+	// Reload bravoUserSignup
+	bravoUserSignup, err = s.FakeUserSignupClient.Get(bravoUserSignup.Name)
+	require.NoError(s.T(), err)
+
 	require.Empty(s.T(), bravoUserSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+}
+
+func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUseByDeactivatedUserSignup() {
+	// Setup gock to intercept calls made to the Twilio API
+	s.SetHttpClientFactoryOption()
+
+	gock.New("https://api.twilio.com").
+		Reply(http.StatusNoContent).
+		BodyString("")
+	defer gock.Off()
+	s.OverrideConfig(s.DefaultConfig())
+
+	e164PhoneNumber := "+19875553344"
+
+	// calculate the phone number hash
+	md5hash := md5.New()
+	// Ignore the error, as this implementation cannot return one
+	_, _ = md5hash.Write([]byte(e164PhoneNumber))
+	phoneHash := hex.EncodeToString(md5hash.Sum(nil))
+
+	alphaUserSignup := &v1alpha1.UserSignup{
+		TypeMeta: v1.TypeMeta{},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "alpha",
+			Namespace: s.Config().GetNamespace(),
+			Annotations: map[string]string{
+				v1alpha1.UserSignupUserEmailAnnotationKey: "alpha@foxtrot.com",
+			},
+			Labels: map[string]string{
+				v1alpha1.UserSignupUserPhoneHashLabelKey: phoneHash,
+				v1alpha1.UserSignupStateLabelKey:         v1alpha1.UserSignupStateLabelValueDeactivated,
+			},
+		},
+		Spec: v1alpha1.UserSignupSpec{
+			Username:             "alpha@foxtrot.com",
+			VerificationRequired: false,
+			Deactivated:          true,
+			Approved:             true,
+		},
+	}
+
+	s.FakeUserSignupClient.Tracker.Add(alphaUserSignup)
+
+	bravoUserSignup := &v1alpha1.UserSignup{
+		TypeMeta: v1.TypeMeta{},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "bravo",
+			Namespace: s.Config().GetNamespace(),
+			Annotations: map[string]string{
+				v1alpha1.UserSignupUserEmailAnnotationKey: "bravo@foxtrot.com",
+			},
+			Labels: map[string]string{},
+		},
+		Spec: v1alpha1.UserSignupSpec{
+			Username:             "bravo@foxtrot.com",
+			VerificationRequired: true,
+		},
+	}
+
+	s.FakeUserSignupClient.Tracker.Add(bravoUserSignup)
+
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	err := s.Application.VerificationService().InitVerification(ctx, bravoUserSignup.Name, e164PhoneNumber)
+	require.NoError(s.T(), err)
+
+	// Reload bravoUserSignup
+	bravoUserSignup, err = s.FakeUserSignupClient.Get(bravoUserSignup.Name)
+	require.NoError(s.T(), err)
+
+	// Just confirm that verification has been initialized by testing whether a verification code has been set
+	require.NotEmpty(s.T(), bravoUserSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
 }
 
 func (s *TestVerificationServiceSuite) TestVerifyCode() {

--- a/test/fake/banneduser_client.go
+++ b/test/fake/banneduser_client.go
@@ -42,7 +42,7 @@ func NewFakeBannedUserClient(t *testing.T, namespace string, initObjs ...runtime
 func (c *FakeBannedUserClient) ListByEmail(email string) (*crtapi.BannedUserList, error) {
 	return c.listByHashedLabel(crtapi.BannedUserEmailHashLabelKey, email)
 }
-func (c *FakeBannedUserClient) ListByPhone(phone string) (*crtapi.BannedUserList, error) {
+func (c *FakeBannedUserClient) ListByPhoneNumberOrHash(phone string) (*crtapi.BannedUserList, error) {
 	return c.listByHashedLabel(crtapi.BannedUserPhoneNumberHashLabelKey, phone)
 }
 

--- a/test/fake/signup_client.go
+++ b/test/fake/signup_client.go
@@ -134,7 +134,7 @@ func (c *FakeUserSignupClient) Delete(name string, options *v1.DeleteOptions) er
 	return c.Tracker.Delete(gvr, c.namespace, name)
 }
 
-func (c *FakeUserSignupClient) ListByPhoneNumberOrHash(phone string) (*crtapi.UserSignupList, error) {
+func (c *FakeUserSignupClient) ListActiveSignupsByPhoneNumberOrHash(phone string) (*crtapi.UserSignupList, error) {
 	return c.listByHashedLabel(crtapi.UserSignupUserPhoneHashLabelKey, phone)
 }
 

--- a/test/fake/signup_client.go
+++ b/test/fake/signup_client.go
@@ -134,7 +134,7 @@ func (c *FakeUserSignupClient) Delete(name string, options *v1.DeleteOptions) er
 	return c.Tracker.Delete(gvr, c.namespace, name)
 }
 
-func (c *FakeUserSignupClient) ListByPhone(phone string) (*crtapi.UserSignupList, error) {
+func (c *FakeUserSignupClient) ListByPhoneNumberOrHash(phone string) (*crtapi.UserSignupList, error) {
 	return c.listByHashedLabel(crtapi.UserSignupUserPhoneHashLabelKey, phone)
 }
 


### PR DESCRIPTION
When doing phone verification and checking if a phone number is already in use, also check whether the email address is the same for the UserSignup which has the duplicate phone number.  If the email address is the same, then don't return an error when doing the check.

Fixes https://issues.redhat.com/browse/CRT-883