### PR TITLE
preventing usersignups for usernames that have the crtadmin suffix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20210115184740-77f08aa35c87
+	github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-contrib/cors v1.3.1
@@ -40,8 +40,8 @@ require (
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6 => github.com/tinakurian/toolchain-common v0.0.0-20210216182308-9a7445b1611e
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
-

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210219141158-8bf475892a90
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1
@@ -40,7 +40,6 @@ require (
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6 => github.com/tinakurian/toolchain-common v0.0.0-20210217164217-8325ca100257
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6 => github.com/tinakurian/toolchain-common v0.0.0-20210216182308-9a7445b1611e
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6 => github.com/tinakurian/toolchain-common v0.0.0-20210217164217-8325ca100257
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"

--- a/go.sum
+++ b/go.sum
@@ -887,8 +887,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tinakurian/toolchain-common v0.0.0-20210216182308-9a7445b1611e h1:2IokO8z9TzRUbeCKwJpZC9NiakEcj0B1DufVv63jiGg=
-github.com/tinakurian/toolchain-common v0.0.0-20210216182308-9a7445b1611e/go.mod h1:2MIk76M6c61igSzapDQr0iyNTB24jOsuCyt7MjnjeZc=
+github.com/tinakurian/toolchain-common v0.0.0-20210217164217-8325ca100257 h1:Ays0eubvxiy5C9Zo+JlRlB9WiyEWHFeS0ic7C79MbdU=
+github.com/tinakurian/toolchain-common v0.0.0-20210217164217-8325ca100257/go.mod h1:2MIk76M6c61igSzapDQr0iyNTB24jOsuCyt7MjnjeZc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 h1:5u+EJUQiosu3JFX0XS0qTf5FznsMOzTjGqavBGuCbo0=

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101 h1:oKHlw3jQXcMX8AbAlCdzn8ZS58jnGtjT7ItG5oaistM=
 github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210219141158-8bf475892a90 h1:3vATtVvGaNAjFQYDnlXj1gvx24nBfSgeYnIPeITZJvE=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210219141158-8bf475892a90/go.mod h1:2MIk76M6c61igSzapDQr0iyNTB24jOsuCyt7MjnjeZc=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -887,8 +889,6 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tinakurian/toolchain-common v0.0.0-20210217164217-8325ca100257 h1:Ays0eubvxiy5C9Zo+JlRlB9WiyEWHFeS0ic7C79MbdU=
-github.com/tinakurian/toolchain-common v0.0.0-20210217164217-8325ca100257/go.mod h1:2MIk76M6c61igSzapDQr0iyNTB24jOsuCyt7MjnjeZc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 h1:5u+EJUQiosu3JFX0XS0qTf5FznsMOzTjGqavBGuCbo0=

--- a/go.sum
+++ b/go.sum
@@ -135,15 +135,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/api v0.0.0-20201106102222-43eeb7a566e3 h1:dsr9BXua8KdmVKcFDNuXIpoDaGpYijG4RLsCIYIOl00=
-github.com/codeready-toolchain/api v0.0.0-20201106102222-43eeb7a566e3/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/api v0.0.0-20210115184740-77f08aa35c87 h1:jUqvvFYZYeD6Hcs4zEv5+oppXaxeIgGQn3YJd1DQDg0=
-github.com/codeready-toolchain/api v0.0.0-20210115184740-77f08aa35c87/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20201014231429-a44cccb4b2b5 h1:Z+oKsj4+0WWY0+Zlvc46NX7syYN1uZekjZWPhFFkfIA=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20201014231429-a44cccb4b2b5/go.mod h1:TC5Q5FtNUwzpHNMLAkJXaxkifHwPJlZtrvnTWKIY+2M=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6 h1:WyhQHwHbn1owc2kQHdujtUvUCALF1rqrWVt7s6z7rWg=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6/go.mod h1:F5agtgfX0aEhhLwQC9l3kdpUiaWovOaSouhabpeIxzo=
+github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101 h1:oKHlw3jQXcMX8AbAlCdzn8ZS58jnGtjT7ItG5oaistM=
+github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -894,6 +887,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tinakurian/toolchain-common v0.0.0-20210216182308-9a7445b1611e h1:2IokO8z9TzRUbeCKwJpZC9NiakEcj0B1DufVv63jiGg=
+github.com/tinakurian/toolchain-common v0.0.0-20210216182308-9a7445b1611e/go.mod h1:2MIk76M6c61igSzapDQr0iyNTB24jOsuCyt7MjnjeZc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 h1:5u+EJUQiosu3JFX0XS0qTf5FznsMOzTjGqavBGuCbo0=
@@ -914,8 +909,6 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
-github.com/xcoulon/toolchain-common v0.0.0-20210209111506-89a1e762b86b h1:W3ZSbKiepP+B0pylZ8abnBlbzdV3eXnyxO91JGaU0+E=
-github.com/xcoulon/toolchain-common v0.0.0-20210209111506-89a1e762b86b/go.mod h1:F5agtgfX0aEhhLwQC9l3kdpUiaWovOaSouhabpeIxzo=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -56,6 +56,11 @@ func NewSignupService(context servicecontext.ServiceContext, cfg ServiceConfigur
 // newUserSignup generates a new UserSignup resource with the specified username and userID.
 // This resource then can be used to create a new UserSignup in the host cluster or to update the existing one.
 func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, error) {
+	username := ctx.GetString(context.UsernameKey)
+	if strings.HasSuffix(username, "crtadmin") {
+		return nil, errors3.NewForbiddenError(fmt.Sprintf("Failed to create usersignup for %s", username), "Cannot create usersignup for crtadmin")
+	}
+
 	userEmail := ctx.GetString(context.EmailKey)
 	md5hash := md5.New()
 	// Ignore the error, as this implementation cannot return one

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -14,7 +14,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/application/service/base"
 	servicecontext "github.com/codeready-toolchain/registration-service/pkg/application/service/context"
 	"github.com/codeready-toolchain/registration-service/pkg/context"
-	errors3 "github.com/codeready-toolchain/registration-service/pkg/errors"
+	errs "github.com/codeready-toolchain/registration-service/pkg/errors"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
@@ -61,7 +61,7 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, err
 
 	username = usersignup.TransformUsername(username)
 	if strings.HasSuffix(username, "crtadmin") {
-		return nil, errors3.NewForbiddenError(fmt.Sprintf("failed to create usersignup for %s", username), "cannot create usersignup for crtadmin")
+		return nil, errs.NewForbiddenError(fmt.Sprintf("failed to create usersignup for %s", username), "cannot create usersignup for crtadmin")
 	}
 
 	userEmail := ctx.GetString(context.EmailKey)
@@ -315,19 +315,19 @@ func (s *ServiceImpl) UpdateUserSignup(userSignup *v1alpha1.UserSignup) (*v1alph
 func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, e164PhoneNumber string) error {
 	bannedUserList, err := s.CRTClient().V1Alpha1().BannedUsers().ListByPhone(e164PhoneNumber)
 	if err != nil {
-		return errors3.NewInternalError(err, "failed listing banned users")
+		return errs.NewInternalError(err, "failed listing banned users")
 	}
 	if len(bannedUserList.Items) > 0 {
-		return errors3.NewForbiddenError("cannot re-register with phone number", "phone number already in use")
+		return errs.NewForbiddenError("cannot re-register with phone number", "phone number already in use")
 	}
 
 	userSignupList, err := s.CRTClient().V1Alpha1().UserSignups().ListByPhone(e164PhoneNumber)
 	if err != nil {
-		return errors3.NewInternalError(err, "failed listing userSignups")
+		return errs.NewInternalError(err, "failed listing userSignups")
 	}
 	for _, signup := range userSignupList.Items {
 		if signup.Name != userID {
-			return errors3.NewForbiddenError("cannot re-register with phone number", "phone number already in use")
+			return errs.NewForbiddenError("cannot re-register with phone number", "phone number already in use")
 		}
 	}
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -57,8 +57,8 @@ func NewSignupService(context servicecontext.ServiceContext, cfg ServiceConfigur
 // This resource then can be used to create a new UserSignup in the host cluster or to update the existing one.
 func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, error) {
 	username := ctx.GetString(context.UsernameKey)
-	if strings.HasSuffix(username, "crtadmin") {
-		return nil, errors3.NewForbiddenError(fmt.Sprintf("Failed to create usersignup for %s", username), "Cannot create usersignup for crtadmin")
+	if strings.Contains(username, "crtadmin") {
+		return nil, errors3.NewForbiddenError(fmt.Sprintf("failed to create usersignup for %s", username), "cannot create usersignup for crtadmin")
 	}
 
 	userEmail := ctx.GetString(context.EmailKey)

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -60,7 +60,7 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, err
 	username := ctx.GetString(context.UsernameKey)
 
 	usersignup.TransformUsername(username)
-	if strings.Contains(username, "crtadmin") {
+	if strings.HasSuffix(username, "crtadmin") {
 		return nil, errors3.NewForbiddenError(fmt.Sprintf("failed to create usersignup for %s", username), "cannot create usersignup for crtadmin")
 	}
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -4,6 +4,8 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"hash/crc32"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -86,8 +88,7 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, err
 
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: v1.ObjectMeta{
-			//Name:      EncodeUserID(ctx.GetString(context.SubKey)),
-			Name:      ctx.GetString(context.SubKey),
+			Name:      EncodeUserID(ctx.GetString(context.SubKey)),
 			Namespace: s.Config.GetNamespace(),
 			Annotations: map[string]string{
 				v1alpha1.UserSignupUserEmailAnnotationKey:           userEmail,
@@ -119,7 +120,10 @@ func extractEmailHost(email string) string {
 
 // EncodeUserID transforms a subject value (the user's UserID) to make it DNS-1123 compliant,
 // by removing invalid characters, trimming the length and prefixing with a CRC32 checksum if required.
-/*func EncodeUserID(subject string) string {
+// ### WARNING ### changing this function will cause breakage, as it is used to lookup existing UserSignup
+// resources.  If a change is absolutely required, then all existing UserSignup instances must be migrated
+// to the new value
+func EncodeUserID(subject string) string {
 	// Convert to lower case
 	encoded := strings.ToLower(subject)
 
@@ -133,7 +137,7 @@ func extractEmailHost(email string) string {
 
 	// Add a checksum prefix if the encoded value is different to the original subject value
 	if encoded != subject {
-		encoded = fmt.Sprintf("%x%s", crc32.Checksum([]byte(subject), crc32.IEEETable), encoded)
+		encoded = fmt.Sprintf("%x-%s", crc32.Checksum([]byte(subject), crc32.IEEETable), encoded)
 	}
 
 	// Trim if the length exceeds the maximum
@@ -142,14 +146,14 @@ func extractEmailHost(email string) string {
 	}
 
 	return encoded
-}*/
+}
 
 // Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username and userID
 // if doesn't exist yet.
 func (s *ServiceImpl) Signup(ctx *gin.Context) (*v1alpha1.UserSignup, error) {
-	userID := ctx.GetString(context.SubKey)
+	encodedUserID := EncodeUserID(ctx.GetString(context.SubKey))
 	// Retrieve UserSignup resource from the host cluster
-	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(userID)
+	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(encodedUserID)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// New Signup
@@ -166,7 +170,7 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*v1alpha1.UserSignup, error) {
 	}
 
 	username := ctx.GetString(context.UsernameKey)
-	return nil, errors2.Errorf("unable to create UserSignup [id: %s; username: %s] because there is already an active UserSignup with such ID", userID, username)
+	return nil, errors2.Errorf("unable to create UserSignup [id: %s; username: %s] because there is already an active UserSignup with such ID", encodedUserID, username)
 }
 
 // createUserSignup creates a new UserSignup resource with the specified username and userID
@@ -202,7 +206,7 @@ func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing v1alpha1.U
 func (s *ServiceImpl) GetSignup(userID string) (*signup.Signup, error) {
 
 	// Retrieve UserSignup resource from the host cluster
-	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(userID)
+	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(EncodeUserID(userID))
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
@@ -279,7 +283,7 @@ func (s *ServiceImpl) GetSignup(userID string) (*signup.Signup, error) {
 // GetUserSignup is used to return the actual UserSignup resource instance, rather than the Signup DTO
 func (s *ServiceImpl) GetUserSignup(userID string) (*v1alpha1.UserSignup, error) {
 	// Retrieve UserSignup resource from the host cluster
-	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(userID)
+	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(EncodeUserID(userID))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -59,7 +59,7 @@ func NewSignupService(context servicecontext.ServiceContext, cfg ServiceConfigur
 func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, error) {
 	username := ctx.GetString(context.UsernameKey)
 
-	usersignup.TransformUsername(username)
+	username = usersignup.TransformUsername(username)
 	if strings.HasSuffix(username, "crtadmin") {
 		return nil, errors3.NewForbiddenError(fmt.Sprintf("failed to create usersignup for %s", username), "cannot create usersignup for crtadmin")
 	}

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -17,6 +17,7 @@ import (
 	errors3 "github.com/codeready-toolchain/registration-service/pkg/errors"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
 
 	"github.com/gin-gonic/gin"
 	errors2 "github.com/pkg/errors"
@@ -57,6 +58,8 @@ func NewSignupService(context servicecontext.ServiceContext, cfg ServiceConfigur
 // This resource then can be used to create a new UserSignup in the host cluster or to update the existing one.
 func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*v1alpha1.UserSignup, error) {
 	username := ctx.GetString(context.UsernameKey)
+
+	usersignup.TransformUsername(username)
 	if strings.Contains(username, "crtadmin") {
 		return nil, errors3.NewForbiddenError(fmt.Sprintf("failed to create usersignup for %s", username), "cannot create usersignup for crtadmin")
 	}

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -304,7 +304,7 @@ func (s *TestSignupServiceSuite) TestCRTAdminUserSignup() {
 
 	userSignup, err := s.Application.SignupService().Signup(ctx)
 	require.Error(s.T(), err)
-	require.Equal(s.T(), "Failed to create usersignup for jsmith-crtadmin:Cannot create usersignup for crtadmin", err.Error())
+	require.Equal(s.T(), "failed to create usersignup for jsmith-crtadmin:cannot create usersignup for crtadmin", err.Error())
 	require.Nil(s.T(), userSignup)
 }
 


### PR DESCRIPTION
Preventing the registration-service from creating signup resources for users who signup with the crtadmin suffix in their username.
 
Jira: https://issues.redhat.com/browse/CRT-913

Related PRs: https://github.com/codeready-toolchain/toolchain-common/pull/151, https://github.com/codeready-toolchain/toolchain-e2e/pull/237, https://github.com/codeready-toolchain/host-operator/pull/373
**E2E-Tests**: https://github.com/codeready-toolchain/toolchain-e2e/pull/237