### PR TITLE
chore: add GH Actions workflow for releasing new host-operator versions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,48 @@
+name: operator-cd
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '*.*'
+env:
+  GOPATH: /tmp/go
+  GO_VERSION: 1.14.x
+
+jobs:
+  binary:
+    name: Build & push a new operator release
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles ('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Prepare tools
+      uses: codeready-toolchain/toolchain-cicd/prepare-tools-action@master
+
+    - name: Release operator
+      uses: codeready-toolchain/toolchain-cicd/release-operator-action@master
+      with:
+        quay-token: ${{ secrets.QUAY_TOKEN }}
+        quay-namespace: codeready-toolchain

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -12,19 +12,32 @@ docker-image: build
 	$(Q)docker build -f build/Dockerfile -t ${IMAGE} .
 
 .PHONY: docker-image-dev
-## Build the docker image locally that can be deployed to dev environment
+## Build the docker image
 docker-image-dev: build
 	$(Q)docker build -f build/Dockerfile -t ${IMAGE_DEV}
 
 .PHONY: docker-push
 ## Push the docker image to quay.io registry
-docker-push: docker-image
+docker-push: check-namespace docker-image
+	$(Q)docker push ${IMAGE}
+
+.PHONY: podman-image
+## Build the binary image
+podman-image: build
+	$(Q)podman build -f build/Dockerfile -t ${IMAGE} .
+
+.PHONY: podman-push
+## Push the binary image to quay.io registry
+podman-push: check-namespace podman-image
+	$(Q)podman push ${IMAGE}
+
+.PHONY: check-namespace
+check-namespace:
 ifeq ($(QUAY_NAMESPACE),${GO_PACKAGE_ORG_NAME})
 	@echo "#################################################### WARNING ####################################################"
 	@echo you are going to push to $(QUAY_NAMESPACE) namespace, make sure you have set QUAY_NAMESPACE variable appropriately
 	@echo "#################################################################################################################"
 endif
-	$(Q)docker push ${IMAGE}
 
 .PHONY: docker-push-to-local
 ## Push the docker image to the local docker.io registry


### PR DESCRIPTION
adds GH Actions workflow that releases a new version of host-operator on every commit to master

depends on codeready-toolchain/toolchain-cicd#22