### PR TITLE
feat: add metric for returning users

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,3 +44,5 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
+
+replace github.com/codeready-toolchain/api => ../api

--- a/go.mod
+++ b/go.mod
@@ -45,4 +45,4 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
-replace github.com/codeready-toolchain/api => ../api
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210408113742-bf6728155343

--- a/go.sum
+++ b/go.sum
@@ -909,6 +909,7 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
+github.com/xcoulon/api v0.0.0-20210408113742-bf6728155343/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/go.sum
+++ b/go.sum
@@ -909,6 +909,7 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
+github.com/xcoulon/api v0.0.0-20210408113742-bf6728155343 h1:uqpBJ+rF1DFWYO3cxhNtpP2qg8juKBR0VgAuhNyn1xc=
 github.com/xcoulon/api v0.0.0-20210408113742-bf6728155343/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -205,7 +205,7 @@ func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing *v1alpha1.
 	if err != nil {
 		return nil, err
 	}
-	log.WithValues(map[string]interface{}{"toolchain.dev.openshift.com/activation-counter": existing.Annotations["toolchain.dev.openshift.com/activation-counter"]}).
+	log.WithValues(map[string]interface{}{v1alpha1.UserSignupActivationCounterAnnotationKey: existing.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]}).
 		Info(ctx, "reactivating user")
 
 	// override annotations from the `newUserSignup`, but preserve others (eg: toolchain.dev.openshift.com/activation-counter)

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -141,14 +141,14 @@ func (s *TestSignupServiceSuite) TestSignup() {
 
 	// then
 	require.NoError(s.T(), err)
-	assert.Equal(s.T(), "1", userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey])
+	assert.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]) // at this point, the annotation is not set
 
 	gvr, existing := assertUserSignupExists(userSignup, userID.String())
 
 	s.Run("deactivate and reactivate again", func() {
 		// given
 		deactivatedUS := existing.DeepCopy()
-		deactivatedUS.Annotations["v1alpha1.UserSignupActivationCounterAnnotationKey"] = "2" // assume the user was activated 2 times already
+		deactivatedUS.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey] = "2" // assume the user was activated 2 times already
 		deactivatedUS.Spec.Deactivated = true
 		deactivatedUS.Status.Conditions = deactivated()
 		err := s.FakeUserSignupClient.Tracker.Update(gvr, deactivatedUS, s.Config().GetNamespace())
@@ -170,7 +170,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		deactivatedUS.Spec.Deactivated = true
 		deactivatedUS.Status.Conditions = deactivated()
 		// also, alter the activation counter annotation
-		delete(userSignup.Annotations, v1alpha1.UserSignupActivationCounterAnnotationKey)
+		delete(deactivatedUS.Annotations, v1alpha1.UserSignupActivationCounterAnnotationKey)
 		err := s.FakeUserSignupClient.Tracker.Update(gvr, deactivatedUS, s.Config().GetNamespace())
 		require.NoError(s.T(), err)
 
@@ -181,7 +181,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		require.NoError(s.T(), err)
 		assertUserSignupExists(userSignup, userID.String())
 		assert.NotEmpty(s.T(), userSignup.ResourceVersion)
-		assert.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]) // was missing, and is not set
+		assert.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]) // was initially missing, and was not set
 	})
 
 	s.Run("deactivate and try to reactivate but reactivation fails", func() {

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -141,6 +141,8 @@ func (s *TestSignupServiceSuite) TestSignup() {
 
 	// then
 	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "1", userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey])
+
 	gvr, existing := assertUserSignupExists(userSignup, userID.String())
 
 	s.Run("deactivate and reactivate again", func() {
@@ -152,12 +154,70 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		require.NoError(s.T(), err)
 
 		// when
+		deactivatedUS, err = s.Application.SignupService().Signup(ctx)
+
+		// then
+		require.NoError(s.T(), err)
+		assertUserSignupExists(deactivatedUS, userID.String())
+		assert.NotEmpty(s.T(), deactivatedUS.ResourceVersion)
+		assert.Equal(s.T(), "2", deactivatedUS.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]) // incremented
+
+		s.Run("deactivate and reactivate once more", func() {
+			// given
+			deactivatedUS.Spec.Deactivated = true
+			deactivatedUS.Status.Conditions = deactivated()
+			err := s.FakeUserSignupClient.Tracker.Update(gvr, deactivatedUS, s.Config().GetNamespace())
+			require.NoError(s.T(), err)
+
+			// when
+			userSignup, err := s.Application.SignupService().Signup(ctx)
+
+			// then
+			require.NoError(s.T(), err)
+			assertUserSignupExists(userSignup, userID.String())
+			assert.NotEmpty(s.T(), userSignup.ResourceVersion)
+			assert.Equal(s.T(), "3", userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]) // incremented
+		})
+	})
+
+	s.Run("deactivate and reactivate with invalid annotation", func() {
+		// given
+		deactivatedUS := existing.DeepCopy()
+		deactivatedUS.Spec.Deactivated = true
+		deactivatedUS.Status.Conditions = deactivated()
+		// also, alter the activation counter annotation
+		userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey] = "invalid"
+		err := s.FakeUserSignupClient.Tracker.Update(gvr, deactivatedUS, s.Config().GetNamespace())
+		require.NoError(s.T(), err)
+
+		// when
 		userSignup, err := s.Application.SignupService().Signup(ctx)
 
 		// then
 		require.NoError(s.T(), err)
 		assertUserSignupExists(userSignup, userID.String())
 		assert.NotEmpty(s.T(), userSignup.ResourceVersion)
+		assert.Equal(s.T(), "2", userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]) // incremented
+	})
+
+	s.Run("deactivate and reactivate with missing annotation", func() {
+		// given
+		deactivatedUS := existing.DeepCopy()
+		deactivatedUS.Spec.Deactivated = true
+		deactivatedUS.Status.Conditions = deactivated()
+		// also, alter the activation counter annotation
+		delete(userSignup.Annotations, v1alpha1.UserSignupActivationCounterAnnotationKey)
+		err := s.FakeUserSignupClient.Tracker.Update(gvr, deactivatedUS, s.Config().GetNamespace())
+		require.NoError(s.T(), err)
+
+		// when
+		userSignup, err := s.Application.SignupService().Signup(ctx)
+
+		// then
+		require.NoError(s.T(), err)
+		assertUserSignupExists(userSignup, userID.String())
+		assert.NotEmpty(s.T(), userSignup.ResourceVersion)
+		assert.Equal(s.T(), "2", userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]) // incremented
 	})
 
 	s.Run("deactivate and try to reactivate but reactivation fails", func() {


### PR DESCRIPTION
when reactivating a user, increment the value of the
`UserSignupActivationCounterAnnotationKey` annotation on the corresponding
UserSignup resource.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
