### PR TITLE
chore: update api with new format & kubebuilder version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.14
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20210518063911-913eaf4719b7
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210504213526-a9f78c786c6f
+	github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210525074434-b7d36013dc02
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1
@@ -37,10 +37,6 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.6.0
 )
-
-replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20210520100350-fca58f9efe91
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1
 	github.com/gin-gonic/gin v1.5.0
-	github.com/go-logr/logr v0.1.0
+	github.com/go-logr/logr v0.4.0
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/inconshreveable/log15 v0.0.0-20200109203555-b30bc20e4fd1 // indirect
 	github.com/kevinburke/go-types v0.0.0-20200309064045-f2d4aea18a7a // indirect
@@ -38,9 +38,15 @@ require (
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 
+replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20210520100350-fca58f9efe91
+
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
+	github.com/go-logr/logr => github.com/go-logr/logr v0.1.0
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
+	k8s.io/klog/v2 => k8s.io/klog/v2 v2.0.0
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )

--- a/go.sum
+++ b/go.sum
@@ -135,11 +135,6 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20210413031854-81652586fd90/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/api v0.0.0-20210518063911-913eaf4719b7 h1:b1TIADY79iqmUKJEVlxX64r3yfvr8YtQxO9aXe6TYik=
-github.com/codeready-toolchain/api v0.0.0-20210518063911-913eaf4719b7/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210504213526-a9f78c786c6f h1:akecB3GR6c1cyON3ASxCJw50Kg4ouYboflofPkwb/ss=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210504213526-a9f78c786c6f/go.mod h1:174YTzyQ21yeNsnnG08RR5VExGBsoH9KDBRRNiy/ahM=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -602,6 +597,10 @@ github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043 h1:FrCL5fGboLnw/8pzb+2tl5rOGmocaQnlVw+ZVbXirgY=
+github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
+github.com/matousjobanek/toolchain-common v0.0.0-20210520100350-fca58f9efe91 h1:ErTmzG5H1oa/Eas5PAwCJZzPTzqUZn+9B6JEcf5SLXI=
+github.com/matousjobanek/toolchain-common v0.0.0-20210520100350-fca58f9efe91/go.mod h1:QjU7LhHgonkPxMQMgXmoyR9o7//i8caVIFrMaO9qKvM=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215 h1:hDa3vAq/Zo5gjfJ46XMsGFbH+hTizpR4fUzQCk2nxgk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215/go.mod h1:LH+NgPY9AJpDfqAFtzyer01N9MYNsAKUf3DC9DV1xIY=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -1186,6 +1185,7 @@ golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200115044656-831fdb1e1868/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0 h1:SQvH+DjrwqD1hyyQU+K7JegHz1KEZgEwt17p9d6R2eg=
 golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1370,6 +1370,7 @@ k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120 h1:RPscN6KhmG54S33L+lr3GS+oD1jmchIU0ll519K6FA4=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -1407,6 +1408,7 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
+sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,10 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126 h1:ctRxZ3qcUNtaYoZqc3PUAedQChPpl0iZvyJXF5M6ySE=
+github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210525074434-b7d36013dc02 h1:ptdMQgbc3kCQQ0Zndb4gUwOOJv4+xGPsnlzBQ7ETXgY=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210525074434-b7d36013dc02/go.mod h1:Ah8JSVbGqo58xTlghhCIFBzUZhbBdoFlmAX7P7gqIWA=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -597,10 +601,6 @@ github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
-github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043 h1:FrCL5fGboLnw/8pzb+2tl5rOGmocaQnlVw+ZVbXirgY=
-github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
-github.com/matousjobanek/toolchain-common v0.0.0-20210520100350-fca58f9efe91 h1:ErTmzG5H1oa/Eas5PAwCJZzPTzqUZn+9B6JEcf5SLXI=
-github.com/matousjobanek/toolchain-common v0.0.0-20210520100350-fca58f9efe91/go.mod h1:QjU7LhHgonkPxMQMgXmoyR9o7//i8caVIFrMaO9qKvM=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215 h1:hDa3vAq/Zo5gjfJ46XMsGFbH+hTizpR4fUzQCk2nxgk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215/go.mod h1:LH+NgPY9AJpDfqAFtzyer01N9MYNsAKUf3DC9DV1xIY=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -1370,6 +1370,7 @@ k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120 h1:RPscN6KhmG54S33L+lr3GS+oD1jmchIU0ll519K6FA4=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac h1:sAvhNk5RRuc6FNYGqe7Ygz3PSo/2wGWbulskmzRX8Vs=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -1408,6 +1409,7 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
+sigs.k8s.io/controller-tools v0.4.1 h1:VkuV0MxlRPmRu5iTgBZU4UxUX2LiR99n3sdQGRxZF4w=
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/gin-gonic/gin"
 )

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -1,16 +1,16 @@
 package service
 
 import (
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/gin-gonic/gin"
 )
 
 type SignupService interface {
-	Signup(ctx *gin.Context) (*v1alpha1.UserSignup, error)
+	Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error)
 	GetSignup(userID string) (*signup.Signup, error)
-	GetUserSignup(userID string) (*v1alpha1.UserSignup, error)
-	UpdateUserSignup(userSignup *v1alpha1.UserSignup) (*v1alpha1.UserSignup, error)
+	GetUserSignup(userID string) (*toolchainv1alpha1.UserSignup, error)
+	UpdateUserSignup(userSignup *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error)
 	PhoneNumberAlreadyInUse(userID, phoneNumberOrHash string) error
 }
 

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/codeready-toolchain/registration-service/pkg/verification/service"
 
-	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/context"
 	"github.com/codeready-toolchain/registration-service/pkg/controller"

--- a/pkg/kubeclient/banneduser.go
+++ b/pkg/kubeclient/banneduser.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"

--- a/pkg/kubeclient/client.go
+++ b/pkg/kubeclient/client.go
@@ -1,7 +1,7 @@
 package kubeclient
 
 import (
-	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -29,7 +29,7 @@ func NewCRTRESTClient(cfg *rest.Config, namespace string) (CRTClient, error) {
 	crtapi.SchemeBuilder.Register(getRegisterObject()...)
 
 	config := *cfg
-	config.GroupVersion = &crtapi.SchemeGroupVersion
+	config.GroupVersion = &crtapi.GroupVersion
 	config.APIPath = "/apis"
 	config.ContentType = runtime.ContentTypeJSON
 	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)}

--- a/pkg/kubeclient/mur.go
+++ b/pkg/kubeclient/mur.go
@@ -3,7 +3,7 @@ package kubeclient
 import (
 	"context"
 
-	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 )
 
 const (

--- a/pkg/kubeclient/signup.go
+++ b/pkg/kubeclient/signup.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
-	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 )
 
 const (

--- a/pkg/kubeclient/toolchainstatus.go
+++ b/pkg/kubeclient/toolchainstatus.go
@@ -3,7 +3,7 @@ package kubeclient
 import (
 	"context"
 
-	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 )
 
 const (

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/application/service/base"
 	servicecontext "github.com/codeready-toolchain/registration-service/pkg/application/service/context"

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -25,7 +25,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/context"
 	"github.com/codeready-toolchain/registration-service/test"
 

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -25,7 +25,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/context"
 	"github.com/codeready-toolchain/registration-service/test"
 
@@ -94,7 +94,7 @@ func (c *mockSignupServiceConfiguration) GetVerificationCodeExpiresInMin() int {
 func (s *TestSignupServiceSuite) TestSignup() {
 	s.OverrideConfig(s.ServiceConfiguration(TestNamespace, true, nil, 5))
 
-	assertUserSignupExists := func(userSignup *v1alpha1.UserSignup, userID string) (schema.GroupVersionResource, v1alpha1.UserSignup) {
+	assertUserSignupExists := func(userSignup *toolchainv1alpha1.UserSignup, userID string) (schema.GroupVersionResource, toolchainv1alpha1.UserSignup) {
 		require.NotNil(s.T(), userSignup)
 
 		gvk, err := apiutil.GVKForObject(userSignup, s.FakeUserSignupClient.Scheme)
@@ -104,7 +104,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		values, err := s.FakeUserSignupClient.Tracker.List(gvr, gvk, s.Config().GetNamespace())
 		require.NoError(s.T(), err)
 
-		userSignups := values.(*v1alpha1.UserSignupList)
+		userSignups := values.(*toolchainv1alpha1.UserSignupList)
 		require.NotEmpty(s.T(), userSignups.Items)
 		require.Len(s.T(), userSignups.Items, 1)
 
@@ -118,8 +118,8 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		require.Equal(s.T(), "red hat", val.Spec.Company)
 		require.False(s.T(), val.Spec.Approved)
 		require.True(s.T(), states.VerificationRequired(&val))
-		require.Equal(s.T(), "jsmith@gmail.com", val.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
-		require.Equal(s.T(), "a7b1b413c1cbddbcd19a51222ef8e20a", val.Labels[v1alpha1.UserSignupUserEmailHashLabelKey])
+		require.Equal(s.T(), "jsmith@gmail.com", val.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
+		require.Equal(s.T(), "a7b1b413c1cbddbcd19a51222ef8e20a", val.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey])
 
 		return gvr, val
 	}
@@ -142,14 +142,14 @@ func (s *TestSignupServiceSuite) TestSignup() {
 
 	// then
 	require.NoError(s.T(), err)
-	assert.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]) // at this point, the annotation is not set
+	assert.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey]) // at this point, the annotation is not set
 
 	gvr, existing := assertUserSignupExists(userSignup, userID.String())
 
 	s.Run("deactivate and reactivate again", func() {
 		// given
 		deactivatedUS := existing.DeepCopy()
-		deactivatedUS.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey] = "2" // assume the user was activated 2 times already
+		deactivatedUS.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey] = "2" // assume the user was activated 2 times already
 		states.SetDeactivated(deactivatedUS, true)
 		deactivatedUS.Status.Conditions = deactivated()
 		err := s.FakeUserSignupClient.Tracker.Update(gvr, deactivatedUS, s.Config().GetNamespace())
@@ -162,7 +162,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		require.NoError(s.T(), err)
 		assertUserSignupExists(deactivatedUS, userID.String())
 		assert.NotEmpty(s.T(), deactivatedUS.ResourceVersion)
-		assert.Equal(s.T(), "2", deactivatedUS.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]) // value was preserved
+		assert.Equal(s.T(), "2", deactivatedUS.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey]) // value was preserved
 	})
 
 	s.Run("deactivate and reactivate with missing annotation", func() {
@@ -171,7 +171,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		states.SetDeactivated(deactivatedUS, true)
 		deactivatedUS.Status.Conditions = deactivated()
 		// also, alter the activation counter annotation
-		delete(deactivatedUS.Annotations, v1alpha1.UserSignupActivationCounterAnnotationKey)
+		delete(deactivatedUS.Annotations, toolchainv1alpha1.UserSignupActivationCounterAnnotationKey)
 		err := s.FakeUserSignupClient.Tracker.Update(gvr, deactivatedUS, s.Config().GetNamespace())
 		require.NoError(s.T(), err)
 
@@ -182,7 +182,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		require.NoError(s.T(), err)
 		assertUserSignupExists(userSignup, userID.String())
 		assert.NotEmpty(s.T(), userSignup.ResourceVersion)
-		assert.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupActivationCounterAnnotationKey]) // was initially missing, and was not set
+		assert.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey]) // was initially missing, and was not set
 	})
 
 	s.Run("deactivate and try to reactivate but reactivation fails", func() {
@@ -192,11 +192,11 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		deactivatedUS.Status.Conditions = deactivated()
 		err := s.FakeUserSignupClient.Tracker.Update(gvr, deactivatedUS, s.Config().GetNamespace())
 		require.NoError(s.T(), err)
-		s.FakeUserSignupClient.MockUpdate = func(signup *v1alpha1.UserSignup) (*v1alpha1.UserSignup, error) {
+		s.FakeUserSignupClient.MockUpdate = func(signup *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
 			if signup.Name == userID.String() {
 				return nil, errors.New("an error occurred")
 			}
-			return &v1alpha1.UserSignup{}, nil
+			return &toolchainv1alpha1.UserSignup{}, nil
 		}
 
 		// when
@@ -238,7 +238,7 @@ func (s *TestSignupServiceSuite) TestUserSignupWithInvalidSubjectPrefix() {
 	values, err := s.FakeUserSignupClient.Tracker.List(gvr, gvk, s.Config().GetNamespace())
 	require.NoError(s.T(), err)
 
-	userSignups := values.(*v1alpha1.UserSignupList)
+	userSignups := values.(*toolchainv1alpha1.UserSignupList)
 	require.NotEmpty(s.T(), userSignups.Items)
 	require.Len(s.T(), userSignups.Items, 1)
 
@@ -304,7 +304,7 @@ func (s *TestSignupServiceSuite) TestUserWithExcludedDomainEmailSignsUp() {
 	values, err := s.FakeUserSignupClient.Tracker.List(gvr, gvk, TestNamespace)
 	require.NoError(s.T(), err)
 
-	userSignups := values.(*v1alpha1.UserSignupList)
+	userSignups := values.(*toolchainv1alpha1.UserSignupList)
 	require.NotEmpty(s.T(), userSignups.Items)
 	require.Len(s.T(), userSignups.Items, 1)
 
@@ -338,16 +338,16 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
-	err = s.FakeUserSignupClient.Tracker.Add(&v1alpha1.UserSignup{
+	err = s.FakeUserSignupClient.Tracker.Add(&toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey: "john@gmail.com",
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "john@gmail.com",
 			},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "john@gmail.com",
 		},
 	})
@@ -373,16 +373,16 @@ func (s *TestSignupServiceSuite) TestFailsIfUserBanned() {
 	bannedUserID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 
-	err = s.FakeBannedUserClient.Tracker.Add(&v1alpha1.BannedUser{
+	err = s.FakeBannedUserClient.Tracker.Add(&toolchainv1alpha1.BannedUser{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      bannedUserID.String(),
 			Namespace: TestNamespace,
 			Labels: map[string]string{
-				v1alpha1.BannedUserEmailHashLabelKey: "a7b1b413c1cbddbcd19a51222ef8e20a",
+				toolchainv1alpha1.BannedUserEmailHashLabelKey: "a7b1b413c1cbddbcd19a51222ef8e20a",
 			},
 		},
-		Spec: v1alpha1.BannedUserSpec{
+		Spec: toolchainv1alpha1.BannedUserSpec{
 			Email: "jsmith@gmail.com",
 		},
 	})
@@ -415,17 +415,17 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseBannedUser() {
 	bannedUserID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 
-	err = s.FakeBannedUserClient.Tracker.Add(&v1alpha1.BannedUser{
+	err = s.FakeBannedUserClient.Tracker.Add(&toolchainv1alpha1.BannedUser{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      bannedUserID.String(),
 			Namespace: TestNamespace,
 			Labels: map[string]string{
-				v1alpha1.BannedUserEmailHashLabelKey:       "a7b1b413c1cbddbcd19a51222ef8e20a",
-				v1alpha1.BannedUserPhoneNumberHashLabelKey: "fd276563a8232d16620da8ec85d0575f",
+				toolchainv1alpha1.BannedUserEmailHashLabelKey:       "a7b1b413c1cbddbcd19a51222ef8e20a",
+				toolchainv1alpha1.BannedUserPhoneNumberHashLabelKey: "fd276563a8232d16620da8ec85d0575f",
 			},
 		},
-		Spec: v1alpha1.BannedUserSpec{
+		Spec: toolchainv1alpha1.BannedUserSpec{
 			Email: "jane.doe@gmail.com",
 		},
 	})
@@ -447,14 +447,14 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseUserSignup() {
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 
-	err = s.FakeUserSignupClient.Tracker.Add(&v1alpha1.UserSignup{
+	err = s.FakeUserSignupClient.Tracker.Add(&toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Labels: map[string]string{
-				v1alpha1.UserSignupUserEmailHashLabelKey: "a7b1b413c1cbddbcd19a51222ef8e20a",
-				v1alpha1.UserSignupUserPhoneHashLabelKey: "fd276563a8232d16620da8ec85d0575f",
+				toolchainv1alpha1.UserSignupUserEmailHashLabelKey: "a7b1b413c1cbddbcd19a51222ef8e20a",
+				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "fd276563a8232d16620da8ec85d0575f",
 			},
 		},
 	})
@@ -482,16 +482,16 @@ func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
 	bannedUserID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 
-	err = s.FakeBannedUserClient.Tracker.Add(&v1alpha1.BannedUser{
+	err = s.FakeBannedUserClient.Tracker.Add(&toolchainv1alpha1.BannedUser{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      bannedUserID.String(),
 			Namespace: TestNamespace,
 			Labels: map[string]string{
-				v1alpha1.BannedUserEmailHashLabelKey: "1df66fbb427ff7e64ac46af29cc74b71",
+				toolchainv1alpha1.BannedUserEmailHashLabelKey: "1df66fbb427ff7e64ac46af29cc74b71",
 			},
 		},
-		Spec: v1alpha1.BannedUserSpec{
+		Spec: toolchainv1alpha1.BannedUserSpec{
 			Email: "jane.doe@gmail.com",
 		},
 	})
@@ -513,7 +513,7 @@ func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
 	values, err := s.FakeUserSignupClient.Tracker.List(gvr, gvk, TestNamespace)
 	require.NoError(s.T(), err)
 
-	userSignups := values.(*v1alpha1.UserSignupList)
+	userSignups := values.(*toolchainv1alpha1.UserSignupList)
 	require.NotEmpty(s.T(), userSignups.Items)
 	require.Len(s.T(), userSignups.Items, 1)
 
@@ -525,19 +525,19 @@ func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
 	require.Equal(s.T(), "", val.Spec.FamilyName)
 	require.Equal(s.T(), "", val.Spec.Company)
 	require.False(s.T(), val.Spec.Approved)
-	require.Equal(s.T(), "jsmith@gmail.com", val.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
-	require.Equal(s.T(), "a7b1b413c1cbddbcd19a51222ef8e20a", val.Labels[v1alpha1.UserSignupUserEmailHashLabelKey])
+	require.Equal(s.T(), "jsmith@gmail.com", val.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
+	require.Equal(s.T(), "a7b1b413c1cbddbcd19a51222ef8e20a", val.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey])
 }
 
 func (s *TestSignupServiceSuite) TestGetUserSignupFails() {
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 
-	s.FakeUserSignupClient.MockGet = func(name string) (*v1alpha1.UserSignup, error) {
+	s.FakeUserSignupClient.MockGet = func(name string) (*toolchainv1alpha1.UserSignup, error) {
 		if name == userID.String() {
 			return nil, errors.New("an error occurred")
 		}
-		return &v1alpha1.UserSignup{}, nil
+		return &toolchainv1alpha1.UserSignup{}, nil
 	}
 
 	_, err = s.Application.SignupService().GetSignup(userID.String())
@@ -559,27 +559,27 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 
-	userSignup := v1alpha1.UserSignup{
+	userSignup := toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "bill",
 		},
-		Status: v1alpha1.UserSignupStatus{
-			Conditions: []v1alpha1.Condition{
+		Status: toolchainv1alpha1.UserSignupStatus{
+			Conditions: []toolchainv1alpha1.Condition{
 				{
-					Type:    v1alpha1.UserSignupComplete,
+					Type:    toolchainv1alpha1.UserSignupComplete,
 					Status:  apiv1.ConditionFalse,
 					Reason:  "test_reason",
 					Message: "test_message",
 				},
 				{
-					Type:   v1alpha1.UserSignupApproved,
+					Type:   toolchainv1alpha1.UserSignupApproved,
 					Status: apiv1.ConditionTrue,
-					Reason: v1alpha1.UserSignupApprovedAutomaticallyReason,
+					Reason: toolchainv1alpha1.UserSignupApprovedAutomaticallyReason,
 				},
 			},
 		},
@@ -607,42 +607,42 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 	s.OverrideConfig(s.ServiceConfiguration(TestNamespace, true, nil, 5))
 
-	noCondition := v1alpha1.UserSignupStatus{}
-	pendingApproval := v1alpha1.UserSignupStatus{
-		Conditions: []v1alpha1.Condition{
+	noCondition := toolchainv1alpha1.UserSignupStatus{}
+	pendingApproval := toolchainv1alpha1.UserSignupStatus{
+		Conditions: []toolchainv1alpha1.Condition{
 			{
-				Type:   v1alpha1.UserSignupApproved,
+				Type:   toolchainv1alpha1.UserSignupApproved,
 				Status: apiv1.ConditionFalse,
-				Reason: v1alpha1.UserSignupPendingApprovalReason,
+				Reason: toolchainv1alpha1.UserSignupPendingApprovalReason,
 			},
 		},
 	}
-	noClusterApproval := v1alpha1.UserSignupStatus{
-		Conditions: []v1alpha1.Condition{
+	noClusterApproval := toolchainv1alpha1.UserSignupStatus{
+		Conditions: []toolchainv1alpha1.Condition{
 			{
-				Type:   v1alpha1.UserSignupApproved,
+				Type:   toolchainv1alpha1.UserSignupApproved,
 				Status: apiv1.ConditionFalse,
-				Reason: v1alpha1.UserSignupPendingApprovalReason,
+				Reason: toolchainv1alpha1.UserSignupPendingApprovalReason,
 			},
 			{
-				Type:   v1alpha1.UserSignupComplete,
+				Type:   toolchainv1alpha1.UserSignupComplete,
 				Status: apiv1.ConditionFalse,
-				Reason: v1alpha1.UserSignupNoClusterAvailableReason,
+				Reason: toolchainv1alpha1.UserSignupNoClusterAvailableReason,
 			},
 		},
 	}
 
-	for _, status := range []v1alpha1.UserSignupStatus{noCondition, pendingApproval, noClusterApproval} {
+	for _, status := range []toolchainv1alpha1.UserSignupStatus{noCondition, pendingApproval, noClusterApproval} {
 		userID, err := uuid.NewV4()
 		require.NoError(s.T(), err)
 
-		userSignup := v1alpha1.UserSignup{
+		userSignup := toolchainv1alpha1.UserSignup{
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      userID.String(),
 				Namespace: TestNamespace,
 			},
-			Spec: v1alpha1.UserSignupSpec{
+			Spec: toolchainv1alpha1.UserSignupSpec{
 				Username: "bill",
 			},
 			Status: status,
@@ -691,19 +691,19 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 	err = s.FakeMasterUserRecordClient.Tracker.Add(s.newProvisionedMUR())
 	require.NoError(s.T(), err)
 
-	err = s.FakeToolchainStatusClient.Tracker.Add(&v1alpha1.ToolchainStatus{
+	err = s.FakeToolchainStatusClient.Tracker.Add(&toolchainv1alpha1.ToolchainStatus{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "toolchain-status",
 			Namespace: TestNamespace,
 		},
-		Status: v1alpha1.ToolchainStatusStatus{
-			Members: []v1alpha1.Member{
+		Status: toolchainv1alpha1.ToolchainStatusStatus{
+			Members: []toolchainv1alpha1.Member{
 				{
 					ClusterName: "member-1",
 					ApiEndpoint: "http://api.devcluster.openshift.com",
-					MemberStatus: v1alpha1.MemberStatusStatus{
-						Routes: &v1alpha1.Routes{
+					MemberStatus: toolchainv1alpha1.MemberStatusStatus{
+						Routes: &toolchainv1alpha1.Routes{
 							ConsoleURL:      "https://console.member-1.com",
 							CheDashboardURL: "http://che-toolchain-che.member-1.com",
 						},
@@ -712,8 +712,8 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 				{
 					ClusterName: "member-123",
 					ApiEndpoint: "http://api.devcluster.openshift.com",
-					MemberStatus: v1alpha1.MemberStatusStatus{
-						Routes: &v1alpha1.Routes{
+					MemberStatus: toolchainv1alpha1.MemberStatusStatus{
+						Routes: &toolchainv1alpha1.Routes{
 							ConsoleURL:      "https://console.member-123.com",
 							CheDashboardURL: "http://che-toolchain-che.member-123.com",
 						},
@@ -761,11 +761,11 @@ func (s *TestSignupServiceSuite) TestGetSignupMURGetFails() {
 	require.NoError(s.T(), err)
 
 	returnedErr := errors.New("an error occurred")
-	s.FakeMasterUserRecordClient.MockGet = func(name string) (*v1alpha1.MasterUserRecord, error) {
+	s.FakeMasterUserRecordClient.MockGet = func(name string) (*toolchainv1alpha1.MasterUserRecord, error) {
 		if name == us.Status.CompliantUsername {
 			return nil, returnedErr
 		}
-		return &v1alpha1.MasterUserRecord{}, nil
+		return &toolchainv1alpha1.MasterUserRecord{}, nil
 	}
 
 	_, err = s.Application.SignupService().GetSignup(us.Name)
@@ -779,19 +779,19 @@ func (s *TestSignupServiceSuite) TestGetSignupUnknownStatus() {
 	err := s.FakeUserSignupClient.Tracker.Add(us)
 	require.NoError(s.T(), err)
 
-	err = s.FakeMasterUserRecordClient.Tracker.Add(&v1alpha1.MasterUserRecord{
+	err = s.FakeMasterUserRecordClient.Tracker.Add(&toolchainv1alpha1.MasterUserRecord{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "ted",
 			Namespace: TestNamespace,
 		},
-		Spec: v1alpha1.MasterUserRecordSpec{
-			UserAccounts: []v1alpha1.UserAccountEmbedded{{TargetCluster: "member-123"}},
+		Spec: toolchainv1alpha1.MasterUserRecordSpec{
+			UserAccounts: []toolchainv1alpha1.UserAccountEmbedded{{TargetCluster: "member-123"}},
 		},
-		Status: v1alpha1.MasterUserRecordStatus{
-			Conditions: []v1alpha1.Condition{
+		Status: toolchainv1alpha1.MasterUserRecordStatus{
+			Conditions: []toolchainv1alpha1.Condition{
 				{
-					Type:   v1alpha1.MasterUserRecordReady,
+					Type:   toolchainv1alpha1.MasterUserRecordReady,
 					Status: "blah-blah-blah",
 				},
 			},
@@ -817,7 +817,7 @@ func (s *TestSignupServiceSuite) TestGetUserSignup() {
 	})
 
 	s.Run("getusersignup returns error", func() {
-		s.FakeUserSignupClient.MockGet = func(s string) (userSignup *v1alpha1.UserSignup, e error) {
+		s.FakeUserSignupClient.MockGet = func(s string) (userSignup *toolchainv1alpha1.UserSignup, e error) {
 			return nil, errors.New("get failed")
 		}
 
@@ -856,7 +856,7 @@ func (s *TestSignupServiceSuite) TestUpdateUserSignup() {
 	})
 
 	s.Run("updateusersignup returns error", func() {
-		s.FakeUserSignupClient.MockUpdate = func(userSignup2 *v1alpha1.UserSignup) (userSignup *v1alpha1.UserSignup, e error) {
+		s.FakeUserSignupClient.MockUpdate = func(userSignup2 *toolchainv1alpha1.UserSignup) (userSignup *toolchainv1alpha1.UserSignup, e error) {
 			return nil, errors.New("update failed")
 		}
 
@@ -870,36 +870,36 @@ func (s *TestSignupServiceSuite) TestUpdateUserSignup() {
 	})
 }
 
-func (s *TestSignupServiceSuite) newUserSignupComplete() *v1alpha1.UserSignup {
+func (s *TestSignupServiceSuite) newUserSignupComplete() *toolchainv1alpha1.UserSignup {
 	return s.newUserSignupCompleteWithReason("")
 }
 
-func (s *TestSignupServiceSuite) newUserSignupCompleteWithReason(reason string) *v1alpha1.UserSignup {
+func (s *TestSignupServiceSuite) newUserSignupCompleteWithReason(reason string) *toolchainv1alpha1.UserSignup {
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
-	return &v1alpha1.UserSignup{
+	return &toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
 			Namespace: TestNamespace,
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey: "ted@domain.com",
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "ted@domain.com",
 			},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "ted@domain.com",
 		},
-		Status: v1alpha1.UserSignupStatus{
-			Conditions: []v1alpha1.Condition{
+		Status: toolchainv1alpha1.UserSignupStatus{
+			Conditions: []toolchainv1alpha1.Condition{
 				{
-					Type:   v1alpha1.UserSignupComplete,
+					Type:   toolchainv1alpha1.UserSignupComplete,
 					Status: apiv1.ConditionTrue,
 					Reason: reason,
 				},
 				{
-					Type:   v1alpha1.UserSignupApproved,
+					Type:   toolchainv1alpha1.UserSignupApproved,
 					Status: apiv1.ConditionTrue,
-					Reason: v1alpha1.UserSignupApprovedAutomaticallyReason,
+					Reason: toolchainv1alpha1.UserSignupApprovedAutomaticallyReason,
 				},
 			},
 			CompliantUsername: "ted",
@@ -907,36 +907,36 @@ func (s *TestSignupServiceSuite) newUserSignupCompleteWithReason(reason string) 
 	}
 }
 
-func (s *TestSignupServiceSuite) newProvisionedMUR() *v1alpha1.MasterUserRecord {
-	return &v1alpha1.MasterUserRecord{
+func (s *TestSignupServiceSuite) newProvisionedMUR() *toolchainv1alpha1.MasterUserRecord {
+	return &toolchainv1alpha1.MasterUserRecord{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "ted",
 			Namespace: TestNamespace,
 		},
-		Spec: v1alpha1.MasterUserRecordSpec{
-			UserAccounts: []v1alpha1.UserAccountEmbedded{{TargetCluster: "member-123"}},
+		Spec: toolchainv1alpha1.MasterUserRecordSpec{
+			UserAccounts: []toolchainv1alpha1.UserAccountEmbedded{{TargetCluster: "member-123"}},
 		},
-		Status: v1alpha1.MasterUserRecordStatus{
-			Conditions: []v1alpha1.Condition{
+		Status: toolchainv1alpha1.MasterUserRecordStatus{
+			Conditions: []toolchainv1alpha1.Condition{
 				{
-					Type:    v1alpha1.MasterUserRecordReady,
+					Type:    toolchainv1alpha1.MasterUserRecordReady,
 					Status:  apiv1.ConditionTrue,
 					Reason:  "mur_ready_reason",
 					Message: "mur_ready_message",
 				},
 			},
-			UserAccounts: []v1alpha1.UserAccountStatusEmbedded{{Cluster: v1alpha1.Cluster{
+			UserAccounts: []toolchainv1alpha1.UserAccountStatusEmbedded{{Cluster: toolchainv1alpha1.Cluster{
 				Name: "member-123",
 			}}},
 		},
 	}
 }
 
-func deactivated() []v1alpha1.Condition {
-	return []v1alpha1.Condition{
+func deactivated() []toolchainv1alpha1.Condition {
+	return []toolchainv1alpha1.Condition{
 		{
-			Type:   v1alpha1.UserSignupComplete,
+			Type:   toolchainv1alpha1.UserSignupComplete,
 			Status: apiv1.ConditionTrue,
 			Reason: "Deactivated",
 		},

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/codeready-toolchain/registration-service/pkg/errors"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/log"
 	"github.com/gin-gonic/gin"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -109,22 +109,22 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 	if signup.Labels == nil {
 		signup.Labels = map[string]string{}
 	}
-	signup.Labels[v1alpha1.UserSignupUserPhoneHashLabelKey] = phoneHash
+	signup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey] = phoneHash
 
 	// read the current time
 	now := time.Now()
 
 	// If 24 hours has passed since the verification timestamp, then reset the timestamp and verification attempts
-	ts, parseErr := time.Parse(TimestampLayout, signup.Annotations[v1alpha1.UserSignupVerificationInitTimestampAnnotationKey])
+	ts, parseErr := time.Parse(TimestampLayout, signup.Annotations[toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey])
 	if parseErr != nil || now.After(ts.Add(24*time.Hour)) {
 		// Set a new timestamp
-		signup.Annotations[v1alpha1.UserSignupVerificationInitTimestampAnnotationKey] = now.Format(TimestampLayout)
-		signup.Annotations[v1alpha1.UserSignupVerificationCounterAnnotationKey] = "0"
+		signup.Annotations[toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey] = now.Format(TimestampLayout)
+		signup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = "0"
 	}
 
 	// get the verification counter (i.e. the number of times the user has initiated phone verification within
 	// the last 24 hours)
-	verificationCounter := signup.Annotations[v1alpha1.UserSignupVerificationCounterAnnotationKey]
+	verificationCounter := signup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey]
 	var counter int
 	dailyLimit := s.config.GetVerificationDailyLimit()
 	if verificationCounter != "" {
@@ -133,9 +133,9 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 			// We shouldn't get an error here, but if we do, we should probably set verification counter to the daily
 			// limit so that we at least now have a valid value
 			log.Error(ctx, err, fmt.Sprintf("error converting annotation [%s] value [%s] to integer, on UserSignup: [%s]",
-				v1alpha1.UserSignupVerificationCounterAnnotationKey,
-				signup.Annotations[v1alpha1.UserSignupVerificationCounterAnnotationKey], signup.Name))
-			signup.Annotations[v1alpha1.UserSignupVerificationCounterAnnotationKey] = strconv.Itoa(dailyLimit)
+				toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey,
+				signup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey], signup.Name))
+			signup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = strconv.Itoa(dailyLimit)
 			counter = dailyLimit
 		}
 	}
@@ -154,10 +154,10 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 			return errors.NewInternalError(err, "error while generating verification code")
 		}
 		// set the usersignup annotations
-		signup.Annotations[v1alpha1.UserVerificationAttemptsAnnotationKey] = "0"
-		signup.Annotations[v1alpha1.UserSignupVerificationCounterAnnotationKey] = strconv.Itoa(counter + 1)
-		signup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey] = verificationCode
-		signup.Annotations[v1alpha1.UserVerificationExpiryAnnotationKey] = now.Add(
+		signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = "0"
+		signup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = strconv.Itoa(counter + 1)
+		signup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey] = verificationCode
+		signup.Annotations[toolchainv1alpha1.UserVerificationExpiryAnnotationKey] = now.Add(
 			time.Duration(s.config.GetVerificationCodeExpiresInMin()) * time.Minute).Format(TimestampLayout)
 
 		// Generate the verification message with the new verification code
@@ -214,7 +214,7 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 		return errors.NewInternalError(lookupErr, fmt.Sprintf("error retrieving usersignup: %s", userID))
 	}
 
-	err := s.Services().SignupService().PhoneNumberAlreadyInUse(userID, signup.Labels[v1alpha1.UserSignupUserPhoneHashLabelKey])
+	err := s.Services().SignupService().PhoneNumberAlreadyInUse(userID, signup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey])
 	if err != nil {
 		log.Error(ctx, err, "phone number to verify already in use")
 		return errors.NewBadRequest("phone number already in use",
@@ -223,16 +223,16 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 
 	now := time.Now()
 
-	attemptsMade, convErr := strconv.Atoi(signup.Annotations[v1alpha1.UserVerificationAttemptsAnnotationKey])
+	attemptsMade, convErr := strconv.Atoi(signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey])
 	if convErr != nil {
 		// We shouldn't get an error here, but if we do, we will set verification attempts to max allowed
 		// so that we at least now have a valid value, and let the workflow continue to the
 		// subsequent attempts check
 		log.Error(ctx, convErr, fmt.Sprintf("error converting annotation [%s] value [%s] to integer, on UserSignup: [%s]",
-			v1alpha1.UserVerificationAttemptsAnnotationKey,
-			signup.Annotations[v1alpha1.UserVerificationAttemptsAnnotationKey], signup.Name))
+			toolchainv1alpha1.UserVerificationAttemptsAnnotationKey,
+			signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey], signup.Name))
 		attemptsMade = s.config.GetVerificationAttemptsAllowed()
-		signup.Annotations[v1alpha1.UserVerificationAttemptsAnnotationKey] = strconv.Itoa(attemptsMade)
+		signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = strconv.Itoa(attemptsMade)
 	}
 
 	// If the user has made more attempts than is allowed per generated verification code, return an error
@@ -242,7 +242,7 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 
 	if verificationErr == nil {
 		// Parse the verification expiry timestamp
-		exp, parseErr := time.Parse(TimestampLayout, signup.Annotations[v1alpha1.UserVerificationExpiryAnnotationKey])
+		exp, parseErr := time.Parse(TimestampLayout, signup.Annotations[toolchainv1alpha1.UserVerificationExpiryAnnotationKey])
 		if parseErr != nil {
 			// If the verification expiry timestamp is corrupt or missing, then return an error
 			verificationErr = errors.NewInternalError(parseErr, "error parsing expiry timestamp")
@@ -253,10 +253,10 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 	}
 
 	if verificationErr == nil {
-		if code != signup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey] {
+		if code != signup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey] {
 			// The code doesn't match
 			attemptsMade++
-			signup.Annotations[v1alpha1.UserVerificationAttemptsAnnotationKey] = strconv.Itoa(attemptsMade)
+			signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = strconv.Itoa(attemptsMade)
 			verificationErr = errors.NewForbiddenError("invalid code", "the provided code is invalid")
 		}
 	}
@@ -264,11 +264,11 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 	if verificationErr == nil {
 		// If the code matches then set VerificationRequired to false, reset other verification annotations
 		states.SetVerificationRequired(signup, false)
-		delete(signup.Annotations, v1alpha1.UserSignupVerificationCodeAnnotationKey)
-		delete(signup.Annotations, v1alpha1.UserVerificationAttemptsAnnotationKey)
-		delete(signup.Annotations, v1alpha1.UserSignupVerificationCounterAnnotationKey)
-		delete(signup.Annotations, v1alpha1.UserSignupVerificationInitTimestampAnnotationKey)
-		delete(signup.Annotations, v1alpha1.UserVerificationExpiryAnnotationKey)
+		delete(signup.Annotations, toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey)
+		delete(signup.Annotations, toolchainv1alpha1.UserVerificationAttemptsAnnotationKey)
+		delete(signup.Annotations, toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey)
+		delete(signup.Annotations, toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey)
+		delete(signup.Annotations, toolchainv1alpha1.UserVerificationExpiryAnnotationKey)
 	} else {
 		log.Error(ctx, verificationErr, "error validating verification code")
 	}

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/codeready-toolchain/registration-service/pkg/errors"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/log"
 	"github.com/gin-gonic/gin"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/errors"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -136,19 +136,19 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 
 	gock.Observe(obs)
 
-	userSignup := &v1alpha1.UserSignup{
+	userSignup := &toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "123",
 			Namespace: s.Config().GetNamespace(),
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey: "sbryzak@redhat.com",
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "sbryzak@redhat.com",
 			},
 			Labels: map[string]string{
-				v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 			},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "sbryzak@redhat.com",
 		},
 	}
@@ -165,7 +165,7 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 	userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
 	require.NoError(s.T(), err)
 
-	require.NotEmpty(s.T(), userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.NotEmpty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(reqBody)
@@ -175,7 +175,7 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 	params, err := url.ParseQuery(reqValue)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), fmt.Sprintf("Developer Sandbox for Red Hat OpenShift: Your verification code is %s",
-		userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey]),
+		userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]),
 		params.Get("Body"))
 	require.Equal(s.T(), "CodeReady", params.Get("From"))
 	require.Equal(s.T(), "+1NUMBER", params.Get("To"))
@@ -200,19 +200,19 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPreMigration() {
 
 	gock.Observe(obs)
 
-	userSignup := &v1alpha1.UserSignup{
+	userSignup := &toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "123",
 			Namespace: s.Config().GetNamespace(),
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey: "sbryzak@redhat.com",
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "sbryzak@redhat.com",
 			},
 			Labels: map[string]string{
-				v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 			},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "sbryzak@redhat.com",
 		},
 	}
@@ -228,7 +228,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPreMigration() {
 	userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
 	require.NoError(s.T(), err)
 
-	require.NotEmpty(s.T(), userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.NotEmpty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(reqBody)
@@ -238,7 +238,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPreMigration() {
 	params, err := url.ParseQuery(reqValue)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), fmt.Sprintf("Developer Sandbox for Red Hat OpenShift: Your verification code is %s",
-		userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey]),
+		userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]),
 		params.Get("Body"))
 	require.Equal(s.T(), "CodeReady", params.Get("From"))
 	require.Equal(s.T(), "+1NUMBER", params.Get("To"))
@@ -262,22 +262,22 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 
 	gock.Observe(obs)
 
-	userSignup := &v1alpha1.UserSignup{
+	userSignup := &toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "123",
 			Namespace: s.Config().GetNamespace(),
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey:                 "testuser@redhat.com",
-				v1alpha1.UserSignupVerificationInitTimestampAnnotationKey: now.Add(-25 * time.Hour).Format(verificationservice.TimestampLayout),
-				v1alpha1.UserVerificationAttemptsAnnotationKey:            "3",
-				v1alpha1.UserSignupVerificationCodeAnnotationKey:          "123456",
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey:                 "testuser@redhat.com",
+				toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey: now.Add(-25 * time.Hour).Format(verificationservice.TimestampLayout),
+				toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:            "3",
+				toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:          "123456",
 			},
 			Labels: map[string]string{
-				v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 			},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "sbryzak@redhat.com",
 		},
 	}
@@ -293,7 +293,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 	userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
 	require.NoError(s.T(), err)
 
-	require.NotEmpty(s.T(), userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.NotEmpty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(reqBody)
@@ -303,11 +303,11 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 	params, err := url.ParseQuery(reqValue)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), fmt.Sprintf("Developer Sandbox for Red Hat OpenShift: Your verification code is %s",
-		userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey]),
+		userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]),
 		params.Get("Body"))
 	require.Equal(s.T(), "CodeReady", params.Get("From"))
 	require.Equal(s.T(), "+1NUMBER", params.Get("To"))
-	require.Equal(s.T(), "1", userSignup.Annotations[v1alpha1.UserSignupVerificationCounterAnnotationKey])
+	require.Equal(s.T(), "1", userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey])
 }
 
 func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenCountContainsInvalidValue() {
@@ -319,21 +319,21 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenCountContain
 
 	now := time.Now()
 
-	userSignup := &v1alpha1.UserSignup{
+	userSignup := &toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "123",
 			Namespace: s.Config().GetNamespace(),
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey:                 "testuser@redhat.com",
-				v1alpha1.UserSignupVerificationCounterAnnotationKey:       "abc",
-				v1alpha1.UserSignupVerificationInitTimestampAnnotationKey: now.Format(verificationservice.TimestampLayout),
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey:                 "testuser@redhat.com",
+				toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey:       "abc",
+				toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey: now.Format(verificationservice.TimestampLayout),
 			},
 			Labels: map[string]string{
-				v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 			},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "sbryzak@redhat.com",
 		},
 	}
@@ -360,21 +360,21 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 
 	now := time.Now()
 
-	userSignup := &v1alpha1.UserSignup{
+	userSignup := &toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "123",
 			Namespace: s.Config().GetNamespace(),
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey:                 "testuser@redhat.com",
-				v1alpha1.UserSignupVerificationCounterAnnotationKey:       strconv.Itoa(s.Config().GetVerificationDailyLimit()),
-				v1alpha1.UserSignupVerificationInitTimestampAnnotationKey: now.Format(verificationservice.TimestampLayout),
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey:                 "testuser@redhat.com",
+				toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey:       strconv.Itoa(s.Config().GetVerificationDailyLimit()),
+				toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey: now.Format(verificationservice.TimestampLayout),
 			},
 			Labels: map[string]string{
-				v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 			},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "sbryzak@redhat.com",
 		},
 	}
@@ -388,7 +388,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 	require.Error(s.T(), err)
 	require.Equal(s.T(), "daily limit exceeded:cannot generate new verification code", err.Error())
 
-	require.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 }
 
 func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberInUse() {
@@ -409,19 +409,19 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 	_, _ = md5hash.Write([]byte(e164PhoneNumber))
 	phoneHash := hex.EncodeToString(md5hash.Sum(nil))
 
-	alphaUserSignup := &v1alpha1.UserSignup{
+	alphaUserSignup := &toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "alpha",
 			Namespace: s.Config().GetNamespace(),
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey: "alpha@foxtrot.com",
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "alpha@foxtrot.com",
 			},
 			Labels: map[string]string{
-				v1alpha1.UserSignupUserPhoneHashLabelKey: phoneHash,
+				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: phoneHash,
 			},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "alpha@foxtrot.com",
 			Approved: true,
 		},
@@ -431,17 +431,17 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 	err := s.FakeUserSignupClient.Tracker.Add(alphaUserSignup)
 	require.NoError(s.T(), err)
 
-	bravoUserSignup := &v1alpha1.UserSignup{
+	bravoUserSignup := &toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "bravo",
 			Namespace: s.Config().GetNamespace(),
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey: "bravo@foxtrot.com",
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "bravo@foxtrot.com",
 			},
 			Labels: map[string]string{},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "bravo@foxtrot.com",
 		},
 	}
@@ -459,7 +459,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 	bravoUserSignup, err = s.FakeUserSignupClient.Get(bravoUserSignup.Name)
 	require.NoError(s.T(), err)
 
-	require.Empty(s.T(), bravoUserSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.Empty(s.T(), bravoUserSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 }
 
 func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUseByDeactivatedUserSignup() {
@@ -480,20 +480,20 @@ func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUs
 	_, _ = md5hash.Write([]byte(e164PhoneNumber))
 	phoneHash := hex.EncodeToString(md5hash.Sum(nil))
 
-	alphaUserSignup := &v1alpha1.UserSignup{
+	alphaUserSignup := &toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "alpha",
 			Namespace: s.Config().GetNamespace(),
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey: "alpha@foxtrot.com",
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "alpha@foxtrot.com",
 			},
 			Labels: map[string]string{
-				v1alpha1.UserSignupUserPhoneHashLabelKey: phoneHash,
-				v1alpha1.UserSignupStateLabelKey:         v1alpha1.UserSignupStateLabelValueDeactivated,
+				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: phoneHash,
+				toolchainv1alpha1.UserSignupStateLabelKey:         toolchainv1alpha1.UserSignupStateLabelValueDeactivated,
 			},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "alpha@foxtrot.com",
 			Approved: true,
 		},
@@ -504,17 +504,17 @@ func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUs
 	err := s.FakeUserSignupClient.Tracker.Add(alphaUserSignup)
 	require.NoError(s.T(), err)
 
-	bravoUserSignup := &v1alpha1.UserSignup{
+	bravoUserSignup := &toolchainv1alpha1.UserSignup{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "bravo",
 			Namespace: s.Config().GetNamespace(),
 			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailAnnotationKey: "bravo@foxtrot.com",
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "bravo@foxtrot.com",
 			},
 			Labels: map[string]string{},
 		},
-		Spec: v1alpha1.UserSignupSpec{
+		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "bravo@foxtrot.com",
 		},
 	}
@@ -532,7 +532,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUs
 	require.NoError(s.T(), err)
 
 	// Just confirm that verification has been initialized by testing whether a verification code has been set
-	require.NotEmpty(s.T(), bravoUserSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.NotEmpty(s.T(), bravoUserSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 }
 
 func (s *TestVerificationServiceSuite) TestVerifyCode() {
@@ -541,22 +541,22 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 
 	s.T().Run("verification ok", func(t *testing.T) {
 
-		userSignup := &v1alpha1.UserSignup{
+		userSignup := &toolchainv1alpha1.UserSignup{
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "123",
 				Namespace: s.Config().GetNamespace(),
 				Annotations: map[string]string{
-					v1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
-					v1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					v1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					v1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					toolchainv1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
+					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
+					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
+					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
 				},
 				Labels: map[string]string{
-					v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 				},
 			},
-			Spec: v1alpha1.UserSignupSpec{
+			Spec: toolchainv1alpha1.UserSignupSpec{
 				Username: "sbryzak@redhat.com",
 			},
 		}
@@ -578,22 +578,22 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 	// TODO remove this test after migration complete
 	s.T().Run("verification ok for pre-migrated user signup", func(t *testing.T) {
 
-		userSignup := &v1alpha1.UserSignup{
+		userSignup := &toolchainv1alpha1.UserSignup{
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "999",
 				Namespace: s.Config().GetNamespace(),
 				Annotations: map[string]string{
-					v1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
-					v1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					v1alpha1.UserSignupVerificationCodeAnnotationKey: "999333",
-					v1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					toolchainv1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
+					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
+					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "999333",
+					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
 				},
 				Labels: map[string]string{
-					v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 				},
 			},
-			Spec: v1alpha1.UserSignupSpec{
+			Spec: toolchainv1alpha1.UserSignupSpec{
 				Username: "sbryzak@redhat.com",
 			},
 		}
@@ -614,22 +614,22 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 
 	s.T().Run("when verification code is invalid", func(t *testing.T) {
 
-		userSignup := &v1alpha1.UserSignup{
+		userSignup := &toolchainv1alpha1.UserSignup{
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "123",
 				Namespace: s.Config().GetNamespace(),
 				Annotations: map[string]string{
-					v1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
-					v1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					v1alpha1.UserSignupVerificationCodeAnnotationKey: "000000",
-					v1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					toolchainv1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
+					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
+					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "000000",
+					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
 				},
 				Labels: map[string]string{
-					v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 				},
 			},
-			Spec: v1alpha1.UserSignupSpec{
+			Spec: toolchainv1alpha1.UserSignupSpec{
 				Username: "sbryzak@redhat.com",
 			},
 		}
@@ -650,22 +650,22 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 
 	s.T().Run("when verification code has expired", func(t *testing.T) {
 
-		userSignup := &v1alpha1.UserSignup{
+		userSignup := &toolchainv1alpha1.UserSignup{
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "123",
 				Namespace: s.Config().GetNamespace(),
 				Annotations: map[string]string{
-					v1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
-					v1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					v1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					v1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(-10 * time.Second).Format(verificationservice.TimestampLayout),
+					toolchainv1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
+					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
+					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
+					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(-10 * time.Second).Format(verificationservice.TimestampLayout),
 				},
 				Labels: map[string]string{
-					v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 				},
 			},
-			Spec: v1alpha1.UserSignupSpec{
+			Spec: toolchainv1alpha1.UserSignupSpec{
 				Username: "sbryzak@redhat.com",
 			},
 		}
@@ -685,22 +685,22 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 
 	s.T().Run("when verifications exceeded maximum attempts", func(t *testing.T) {
 
-		userSignup := &v1alpha1.UserSignup{
+		userSignup := &toolchainv1alpha1.UserSignup{
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "123",
 				Namespace: s.Config().GetNamespace(),
 				Annotations: map[string]string{
-					v1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
-					v1alpha1.UserVerificationAttemptsAnnotationKey:   "3",
-					v1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					v1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					toolchainv1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
+					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "3",
+					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
+					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
 				},
 				Labels: map[string]string{
-					v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 				},
 			},
-			Spec: v1alpha1.UserSignupSpec{
+			Spec: toolchainv1alpha1.UserSignupSpec{
 				Username: "sbryzak@redhat.com",
 			},
 		}
@@ -718,22 +718,22 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 
 	s.T().Run("when verifications attempts has invalid value", func(t *testing.T) {
 
-		userSignup := &v1alpha1.UserSignup{
+		userSignup := &toolchainv1alpha1.UserSignup{
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "123",
 				Namespace: s.Config().GetNamespace(),
 				Annotations: map[string]string{
-					v1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
-					v1alpha1.UserVerificationAttemptsAnnotationKey:   "ABC",
-					v1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					v1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					toolchainv1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
+					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "ABC",
+					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
+					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
 				},
 				Labels: map[string]string{
-					v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 				},
 			},
-			Spec: v1alpha1.UserSignupSpec{
+			Spec: toolchainv1alpha1.UserSignupSpec{
 				Username: "sbryzak@redhat.com",
 			},
 		}
@@ -751,27 +751,27 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 		userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
 		require.NoError(s.T(), err)
 
-		require.Equal(s.T(), "3", userSignup.Annotations[v1alpha1.UserVerificationAttemptsAnnotationKey])
+		require.Equal(s.T(), "3", userSignup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey])
 	})
 
 	s.T().Run("when verifications expiry is corrupt", func(t *testing.T) {
 
-		userSignup := &v1alpha1.UserSignup{
+		userSignup := &toolchainv1alpha1.UserSignup{
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "123",
 				Namespace: s.Config().GetNamespace(),
 				Annotations: map[string]string{
-					v1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
-					v1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					v1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					v1alpha1.UserVerificationExpiryAnnotationKey:     "ABC",
+					toolchainv1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
+					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
+					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
+					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     "ABC",
 				},
 				Labels: map[string]string{
-					v1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
 				},
 			},
-			Spec: v1alpha1.UserSignupSpec{
+			Spec: toolchainv1alpha1.UserSignupSpec{
 				Username: "sbryzak@redhat.com",
 			},
 		}

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/errors"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/test/fake/banneduser_client.go
+++ b/test/fake/banneduser_client.go
@@ -7,7 +7,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
-	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/test/fake/masteruserrecord_client.go
+++ b/test/fake/masteruserrecord_client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/test/fake/signup_client.go
+++ b/test/fake/signup_client.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"

--- a/test/fake/toolchainstatus_client.go
+++ b/test/fake/toolchainstatus_client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	crtapi "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
result of codeready-toolchain/api#237

* small changes in go.mod so we can use the new controller-tools 0.4.1 together with client-go 0.18.3
* update all imports to api repo/types
