### PR TITLE
Refactor usage of UserSignup.Spec.Approved

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126
+	github.com/codeready-toolchain/api v0.0.0-20210527231005-3bb0f668e644
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20210525074434-b7d36013dc02
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-contrib/cors v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126 h1:ctRxZ3qcUNtaYoZqc3PUAedQChPpl0iZvyJXF5M6ySE=
 github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
+github.com/codeready-toolchain/api v0.0.0-20210527231005-3bb0f668e644 h1:A/p5oS6ACSSNEXt7BTL7OaLoaKK575+7bi0WbDG1BPw=
+github.com/codeready-toolchain/api v0.0.0-20210527231005-3bb0f668e644/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210525074434-b7d36013dc02 h1:ptdMQgbc3kCQQ0Zndb4gUwOOJv4+xGPsnlzBQ7ETXgY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210525074434-b7d36013dc02/go.mod h1:Ah8JSVbGqo58xTlghhCIFBzUZhbBdoFlmAX7P7gqIWA=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -112,7 +112,6 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 		},
 		Spec: toolchainv1alpha1.UserSignupSpec{
 			TargetCluster: "",
-			Approved:      false,
 			Userid:        ctx.GetString(context.SubKey),
 			Username:      ctx.GetString(context.UsernameKey),
 			GivenName:     ctx.GetString(context.GivenNameKey),

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -116,7 +116,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		require.Equal(s.T(), "jane", val.Spec.GivenName)
 		require.Equal(s.T(), "doe", val.Spec.FamilyName)
 		require.Equal(s.T(), "red hat", val.Spec.Company)
-		require.False(s.T(), val.Spec.Approved)
+		require.False(s.T(), states.Approved(&val))
 		require.True(s.T(), states.VerificationRequired(&val))
 		require.Equal(s.T(), "jsmith@gmail.com", val.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 		require.Equal(s.T(), "a7b1b413c1cbddbcd19a51222ef8e20a", val.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey])
@@ -524,7 +524,7 @@ func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
 	require.Equal(s.T(), "", val.Spec.GivenName)
 	require.Equal(s.T(), "", val.Spec.FamilyName)
 	require.Equal(s.T(), "", val.Spec.Company)
-	require.False(s.T(), val.Spec.Approved)
+	require.False(s.T(), states.Approved(&val))
 	require.Equal(s.T(), "jsmith@gmail.com", val.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 	require.Equal(s.T(), "a7b1b413c1cbddbcd19a51222ef8e20a", val.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey])
 }

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -423,9 +423,9 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 		},
 		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "alpha@foxtrot.com",
-			Approved: true,
 		},
 	}
+	states.SetApproved(alphaUserSignup, true)
 	states.SetVerificationRequired(alphaUserSignup, false)
 
 	err := s.FakeUserSignupClient.Tracker.Add(alphaUserSignup)
@@ -495,9 +495,9 @@ func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUs
 		},
 		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "alpha@foxtrot.com",
-			Approved: true,
 		},
 	}
+	states.SetApproved(alphaUserSignup, true)
 	states.SetVerificationRequired(alphaUserSignup, false)
 	states.SetDeactivated(alphaUserSignup, true)
 


### PR DESCRIPTION
This PR refactors the usage of the `UserSignup.Spec.Approved` property to use states instead.

Fixes https://issues.redhat.com/browse/CRT-1114