### PR TITLE
Update to latest toolchain-common and uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.14
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20210528134715-13373a2ab54a
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210528140854-e36fca9e7edf
+	github.com/codeready-toolchain/api v0.0.0-20210614133722-31dc79a71878
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210615160410-5fc6a59ad950
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1
@@ -23,7 +23,6 @@ require (
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.9.1
-	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -135,11 +135,10 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20210527231005-3bb0f668e644/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
-github.com/codeready-toolchain/api v0.0.0-20210528134715-13373a2ab54a h1:vgAmn8t5F0+9PIeYpooMLwj9rjPqFDw4RNUhGZFP1S4=
-github.com/codeready-toolchain/api v0.0.0-20210528134715-13373a2ab54a/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210528140854-e36fca9e7edf h1:sQhalyiXRkQbcN9kY2OF1ytDfueDOd0DYkG3dZPjf/s=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210528140854-e36fca9e7edf/go.mod h1:xYj5K9tJRqoYP/+TPaUXELd81hK9XTdlk9A6kCIFWCg=
+github.com/codeready-toolchain/api v0.0.0-20210614133722-31dc79a71878 h1:i68EEb0tuzXiwpksbkA1G6W06kjYV7CFRILGR3wISN4=
+github.com/codeready-toolchain/api v0.0.0-20210614133722-31dc79a71878/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210615160410-5fc6a59ad950 h1:s6u/XIOmrY2W0Bue6Ft0FTdmk4O1tn7XhtSgVsQa6t4=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210615160410-5fc6a59ad950/go.mod h1:bnpg/I9j7Ala/QiJ3YR238Dtddp6BhK4IRmjLCKjmYw=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -13,7 +13,7 @@ import (
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 
 	"github.com/dgrijalva/jwt-go"
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -46,25 +46,25 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 
 	// create test keys
 	tokengenerator := authsupport.NewTokenManager()
-	kid0 := uuid.NewV4().String()
+	kid0 := uuid.Must(uuid.NewV4()).String()
 	_, err := tokengenerator.AddPrivateKey(kid0)
 	require.NoError(s.T(), err)
-	kid1 := uuid.NewV4().String()
+	kid1 := uuid.Must(uuid.NewV4()).String()
 	_, err = tokengenerator.AddPrivateKey(kid1)
 	require.NoError(s.T(), err)
 
 	// create two test tokens, both valid
-	username0 := uuid.NewV4().String()
+	username0 := uuid.Must(uuid.NewV4()).String()
 	identity0 := &authsupport.Identity{
-		ID:       uuid.NewV4(),
+		ID:       uuid.Must(uuid.NewV4()),
 		Username: username0,
 	}
 	email0 := identity0.Username + "@email.tld"
 	jwt0, err := tokengenerator.GenerateSignedToken(*identity0, kid0, authsupport.WithEmailClaim(email0))
 	require.NoError(s.T(), err)
-	username1 := uuid.NewV4().String()
+	username1 := uuid.Must(uuid.NewV4()).String()
 	identity1 := &authsupport.Identity{
-		ID:       uuid.NewV4(),
+		ID:       uuid.Must(uuid.NewV4()),
 		Username: username1,
 	}
 	email1 := identity1.Username + "@email.tld"

--- a/pkg/auth/tokenparser_test.go
+++ b/pkg/auth/tokenparser_test.go
@@ -12,7 +12,7 @@ import (
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -35,10 +35,10 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 
 	// create test keys
 	tokengenerator := authsupport.NewTokenManager()
-	kid0 := uuid.NewV4().String()
+	kid0 := uuid.Must(uuid.NewV4()).String()
 	_, err = tokengenerator.AddPrivateKey(kid0)
 	require.NoError(s.T(), err)
-	kid1 := uuid.NewV4().String()
+	kid1 := uuid.Must(uuid.NewV4()).String()
 	_, err = tokengenerator.AddPrivateKey(kid1)
 	require.NoError(s.T(), err)
 
@@ -68,17 +68,17 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 
 	s.Run("parse valid tokens", func() {
 		// create two test tokens, both valid
-		username0 := uuid.NewV4().String()
+		username0 := uuid.Must(uuid.NewV4()).String()
 		identity0 := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
 		jwt0, err := tokengenerator.GenerateSignedToken(*identity0, kid0, authsupport.WithEmailClaim(email0))
 		require.NoError(s.T(), err)
-		username1 := uuid.NewV4().String()
+		username1 := uuid.Must(uuid.NewV4()).String()
 		identity1 := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: username1,
 		}
 		email1 := identity1.Username + "@email.tld"
@@ -107,9 +107,9 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 
 	s.Run("parse invalid token", func() {
 		// create invalid test token (wrong set of claims, no email), signed with key1
-		invalidUsername := uuid.NewV4().String()
+		invalidUsername := uuid.Must(uuid.NewV4()).String()
 		invalidIdentity := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: invalidUsername,
 		}
 		invalidJWT, err := tokengenerator.GenerateSignedToken(*invalidIdentity, kid1)
@@ -122,13 +122,13 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 
 	s.Run("token signed by unknown key", func() {
 		// new key
-		kidX := uuid.NewV4().String()
+		kidX := uuid.Must(uuid.NewV4()).String()
 		_, err := tokengenerator.AddPrivateKey(kidX)
 		require.NoError(s.T(), err)
 		// generate valid token
-		usernameX := uuid.NewV4().String()
+		usernameX := uuid.Must(uuid.NewV4()).String()
 		identityX := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: usernameX,
 		}
 		emailX := identityX.Username + "@email.tld"
@@ -143,9 +143,9 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 	})
 
 	s.Run("no KID header in token", func() {
-		username0 := uuid.NewV4().String()
+		username0 := uuid.Must(uuid.NewV4()).String()
 		identity0 := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
@@ -162,9 +162,9 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 	})
 
 	s.Run("missing claim: preferred_username", func() {
-		username0 := uuid.NewV4().String()
+		username0 := uuid.Must(uuid.NewV4()).String()
 		identity0 := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
@@ -182,9 +182,9 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 	})
 
 	s.Run("missing claim: email", func() {
-		username0 := uuid.NewV4().String()
+		username0 := uuid.Must(uuid.NewV4()).String()
 		identity0 := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: username0,
 		}
 		// generate non-serialized token
@@ -199,9 +199,9 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 	})
 
 	s.Run("missing claim: sub", func() {
-		username0 := uuid.NewV4().String()
+		username0 := uuid.Must(uuid.NewV4()).String()
 		identity0 := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
@@ -218,9 +218,9 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 	})
 
 	s.Run("signature is good but token expired", func() {
-		username0 := uuid.NewV4().String()
+		username0 := uuid.Must(uuid.NewV4()).String()
 		identity0 := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
@@ -239,9 +239,9 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 	})
 
 	s.Run("signature is good but token not valid yet", func() {
-		username0 := uuid.NewV4().String()
+		username0 := uuid.Must(uuid.NewV4()).String()
 		identity0 := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
@@ -260,9 +260,9 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 	})
 
 	s.Run("token signed by known key but the signature is invalid", func() {
-		username0 := uuid.NewV4().String()
+		username0 := uuid.Must(uuid.NewV4()).String()
 		identity0 := &authsupport.Identity{
-			ID:       uuid.NewV4(),
+			ID:       uuid.Must(uuid.NewV4()),
 			Username: username0,
 		}
 		email0 := identity0.Username + "@email.tld"
@@ -274,7 +274,7 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 		// replace signature with garbage
 		str := strings.Split(jwt0string, ".")
 		require.Len(s.T(), str, 3)
-		str[2] = uuid.NewV4().String()
+		str[2] = uuid.Must(uuid.NewV4()).String()
 		jwt0string = strings.Join(str, ".")
 		// validate token
 		_, err = tokenParser.FromString(jwt0string)

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/status"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -43,16 +43,16 @@ func (s *TestAuthMiddlewareSuite) TestAuthMiddleware() {
 func (s *TestAuthMiddlewareSuite) TestAuthMiddlewareService() {
 	// create a TokenGenerator and a key
 	tokengenerator := authsupport.NewTokenManager()
-	kid0 := uuid.NewV4().String()
+	kid0 := uuid.Must(uuid.NewV4()).String()
 	_, err := tokengenerator.AddPrivateKey(kid0)
 	require.NoError(s.T(), err)
 
 	// create some test tokens
 	identity0 := authsupport.Identity{
-		ID:       uuid.NewV4(),
-		Username: uuid.NewV4().String(),
+		ID:       uuid.Must(uuid.NewV4()),
+		Username: uuid.Must(uuid.NewV4()).String(),
 	}
-	emailClaim0 := authsupport.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
+	emailClaim0 := authsupport.WithEmailClaim(uuid.Must(uuid.NewV4()).String() + "@email.tld")
 	// valid token
 	tokenValid, err := tokengenerator.GenerateSignedToken(identity0, kid0, emailClaim0)
 	require.NoError(s.T(), err)
@@ -60,7 +60,7 @@ func (s *TestAuthMiddlewareSuite) TestAuthMiddlewareService() {
 	tokenInvalidNoEmail, err := tokengenerator.GenerateSignedToken(identity0, kid0)
 	require.NoError(s.T(), err)
 	// invalid token - garbage
-	tokenInvalidGarbage := uuid.NewV4().String()
+	tokenInvalidGarbage := uuid.Must(uuid.NewV4()).String()
 	// invalid token - expired
 	expTime := time.Now().Add(-60 * time.Second)
 	expClaim := authsupport.WithExpClaim(expTime)

--- a/test/fake/signup_client.go
+++ b/test/fake/signup_client.go
@@ -8,7 +8,7 @@ import (
 
 	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,7 +78,7 @@ func (c *FakeUserSignupClient) Get(name string) (*crtapi.UserSignup, error) {
 
 func (c *FakeUserSignupClient) Create(obj *crtapi.UserSignup) (*crtapi.UserSignup, error) {
 	if obj != nil {
-		obj.ResourceVersion = uuid.NewV4().String()
+		obj.ResourceVersion = uuid.Must(uuid.NewV4()).String()
 	}
 	if c.MockCreate != nil {
 		return c.MockCreate(obj)


### PR DESCRIPTION
Updates to the latest toolchain-common and switches from using github.com/satori/go.uuid to github.com/gofrs/uuid