### PR TITLE
feat: add publish-operators-for-e2e-tests workflow

### DIFF
--- a/.github/workflows/publish-operators-for-e2e-tests.yml
+++ b/.github/workflows/publish-operators-for-e2e-tests.yml
@@ -42,7 +42,7 @@ jobs:
       uses: MatousJobanek/toolchain-cicd/prepare-tools-action@master
 
     - name: Publish current operator bundles for host & member
-      #uses: codeready-toolchain/toolchain-cicd/publish-operator-for-e2e-tests@master
+      #uses: codeready-toolchain/toolchain-cicd/publish-operators-for-e2e-tests@master
       uses: MatousJobanek/toolchain-cicd/publish-operators-for-e2e-tests@master
       with:
         quay-token: ${{ secrets.TEST_QUAY_TOKEN }}

--- a/.github/workflows/publish-operators-for-e2e-tests.yml
+++ b/.github/workflows/publish-operators-for-e2e-tests.yml
@@ -1,0 +1,49 @@
+name: publish-operators-for-e2e-tests
+on:
+  pull_request_target
+
+env:
+  GOPATH: /tmp/go
+  GO_VERSION: 1.16.x
+
+jobs:
+  binary:
+    name: Build & push operator bundles for e2e tests
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+        fetch-depth: 0
+
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles ('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Prepare tools
+      #uses: codeready-toolchain/toolchain-cicd/prepare-tools-action@master
+      uses: MatousJobanek/toolchain-cicd/prepare-tools-action@master
+
+    - name: Publish current operator bundles for host & member
+      #uses: codeready-toolchain/toolchain-cicd/publish-operator-for-e2e-tests@master
+      uses: MatousJobanek/toolchain-cicd/publish-operators-for-e2e-tests@master
+      with:
+        quay-token: ${{ secrets.TEST_QUAY_TOKEN }}
+        quay-namespace: codeready-toolchain-test


### PR DESCRIPTION
similar as is already in host & member operator repos