### PR TITLE
Refactored verification service to retry if usersignup update fails

### DIFF
--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -599,7 +599,9 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 
 		require.Equal(s.T(), "Internal Server Error", bodyParams["status"])
 		require.Equal(s.T(), float64(500), bodyParams["code"])
-		require.Equal(s.T(), "service unavailable:error updating UserSignup", bodyParams["message"])
+		require.Equal(s.T(), "there was an error while updating your account - please wait a moment before "+
+			"trying again.If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for "+
+			"assistance:error while verifying code", bodyParams["message"])
 		require.Equal(s.T(), "error while verifying code", bodyParams["details"])
 	})
 

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -600,7 +600,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 		require.Equal(s.T(), "Internal Server Error", bodyParams["status"])
 		require.Equal(s.T(), float64(500), bodyParams["code"])
 		require.Equal(s.T(), "there was an error while updating your account - please wait a moment before "+
-			"trying again.If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for "+
+			"trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for "+
 			"assistance:error while verifying code", bodyParams["message"])
 		require.Equal(s.T(), "error while verifying code", bodyParams["details"])
 	})

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -333,7 +333,7 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 
 	return
 }
-git stat
+
 func pollUpdateSignup(ctx *gin.Context, updater func() error) error {
 	// Attempt to execute an update function, retrying a number of times if the update fails
 	attempts := 0

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -366,7 +366,7 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 		// error to the user here, as we've already logged it
 		if attempts > 4 {
 			return errors.NewInternalError(errs.New("there was an error while updating your account - please wait a moment before trying again."+
-				"If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for assistance"),
+				" If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for assistance"),
 				"error while verifying code")
 		}
 	}

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -220,7 +220,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 		// error to the user here, as we've already logged it
 		if attempts > 4 {
 			return errors.NewInternalError(errs.New("there was an error while updating your account - please wait a moment before trying again."+
-				"If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for assistance"),
+				" If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for assistance"),
 				"error while initiating verification")
 		}
 	}

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"crypto/rand"
 	"encoding/hex"
+	errs "errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -78,6 +79,8 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 		log.Error(ctx, err, "error retrieving usersignup")
 		return errors.NewInternalError(err, fmt.Sprintf("error retrieving usersignup: %s", userID))
 	}
+	labelValues := map[string]string{}
+	annotationValues := map[string]string{}
 
 	// check that verification is required before proceeding
 	if !states.VerificationRequired(signup) {
@@ -106,10 +109,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 	_, _ = md5hash.Write([]byte(e164PhoneNumber))
 	phoneHash := hex.EncodeToString(md5hash.Sum(nil))
 
-	if signup.Labels == nil {
-		signup.Labels = map[string]string{}
-	}
-	signup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey] = phoneHash
+	labelValues[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey] = phoneHash
 
 	// read the current time
 	now := time.Now()
@@ -118,8 +118,8 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 	ts, parseErr := time.Parse(TimestampLayout, signup.Annotations[toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey])
 	if parseErr != nil || now.After(ts.Add(24*time.Hour)) {
 		// Set a new timestamp
-		signup.Annotations[toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey] = now.Format(TimestampLayout)
-		signup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = "0"
+		annotationValues[toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey] = now.Format(TimestampLayout)
+		annotationValues[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = "0"
 	}
 
 	// get the verification counter (i.e. the number of times the user has initiated phone verification within
@@ -135,7 +135,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 			log.Error(ctx, err, fmt.Sprintf("error converting annotation [%s] value [%s] to integer, on UserSignup: [%s]",
 				toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey,
 				signup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey], signup.Name))
-			signup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = strconv.Itoa(dailyLimit)
+			annotationValues[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = strconv.Itoa(dailyLimit)
 			counter = dailyLimit
 		}
 	}
@@ -154,10 +154,10 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 			return errors.NewInternalError(err, "error while generating verification code")
 		}
 		// set the usersignup annotations
-		signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = "0"
-		signup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = strconv.Itoa(counter + 1)
-		signup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey] = verificationCode
-		signup.Annotations[toolchainv1alpha1.UserVerificationExpiryAnnotationKey] = now.Add(
+		annotationValues[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = "0"
+		annotationValues[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = strconv.Itoa(counter + 1)
+		annotationValues[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey] = verificationCode
+		annotationValues[toolchainv1alpha1.UserVerificationExpiryAnnotationKey] = now.Add(
 			time.Duration(s.config.GetVerificationCodeExpiresInMin()) * time.Minute).Format(TimestampLayout)
 
 		// Generate the verification message with the new verification code
@@ -176,10 +176,53 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 		}
 	}
 
-	_, updateErr := s.Services().SignupService().UpdateUserSignup(signup)
-	if updateErr != nil {
-		log.Error(ctx, err, "error while updating UserSignup resource")
-		return errors.NewInternalError(updateErr, "error while updating UserSignup resource")
+	doUpdate := func() error {
+		signup, err := s.Services().SignupService().GetUserSignup(userID)
+		if err != nil {
+			return err
+		}
+		if signup.Labels == nil {
+			signup.Labels = map[string]string{}
+		}
+
+		for k, v := range labelValues {
+			signup.Labels[k] = v
+		}
+
+		for k, v := range annotationValues {
+			signup.Annotations[k] = v
+		}
+		_, err = s.Services().SignupService().UpdateUserSignup(signup)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Attempt to update the UserSignup, retrying a number of times if the update fails
+	attempts := 0
+	for {
+		attempts++
+
+		// Attempt the update
+		updateErr := doUpdate()
+
+		// If there was an error, then only log it for now
+		if updateErr != nil {
+			log.Error(ctx, err, fmt.Sprintf("error while updating UserSignup resource, attempt #%d", attempts))
+		} else {
+			// Otherwise if there was no error updating the UserSignup, then break here
+			break
+		}
+
+		// If we've exceeded the number of attempts, then return a useful error to the user.  We won't return the actual
+		// error to the user here, as we've already logged it
+		if attempts > 4 {
+			return errors.NewInternalError(errs.New("there was an error while updating your account - please wait a moment before trying again."+
+				"If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for assistance"),
+				"error while initiating verification")
+		}
 	}
 
 	return initError
@@ -214,6 +257,10 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 		return errors.NewInternalError(lookupErr, fmt.Sprintf("error retrieving usersignup: %s", userID))
 	}
 
+	annotationValues := map[string]string{}
+	annotationsToDelete := []string{}
+	unsetVerificationRequired := false
+
 	err := s.Services().SignupService().PhoneNumberAlreadyInUse(userID, signup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey])
 	if err != nil {
 		log.Error(ctx, err, "phone number to verify already in use")
@@ -232,7 +279,7 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 			toolchainv1alpha1.UserVerificationAttemptsAnnotationKey,
 			signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey], signup.Name))
 		attemptsMade = s.config.GetVerificationAttemptsAllowed()
-		signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = strconv.Itoa(attemptsMade)
+		annotationValues[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = strconv.Itoa(attemptsMade)
 	}
 
 	// If the user has made more attempts than is allowed per generated verification code, return an error
@@ -256,28 +303,72 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 		if code != signup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey] {
 			// The code doesn't match
 			attemptsMade++
-			signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = strconv.Itoa(attemptsMade)
+			annotationValues[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = strconv.Itoa(attemptsMade)
 			verificationErr = errors.NewForbiddenError("invalid code", "the provided code is invalid")
 		}
 	}
 
 	if verificationErr == nil {
 		// If the code matches then set VerificationRequired to false, reset other verification annotations
-		states.SetVerificationRequired(signup, false)
-		delete(signup.Annotations, toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey)
-		delete(signup.Annotations, toolchainv1alpha1.UserVerificationAttemptsAnnotationKey)
-		delete(signup.Annotations, toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey)
-		delete(signup.Annotations, toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey)
-		delete(signup.Annotations, toolchainv1alpha1.UserVerificationExpiryAnnotationKey)
+		unsetVerificationRequired = true
+		annotationsToDelete = append(annotationsToDelete, toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey)
+		annotationsToDelete = append(annotationsToDelete, toolchainv1alpha1.UserVerificationAttemptsAnnotationKey)
+		annotationsToDelete = append(annotationsToDelete, toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey)
+		annotationsToDelete = append(annotationsToDelete, toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey)
+		annotationsToDelete = append(annotationsToDelete, toolchainv1alpha1.UserVerificationExpiryAnnotationKey)
 	} else {
 		log.Error(ctx, verificationErr, "error validating verification code")
 	}
 
-	// Update changes made to the UserSignup
-	_, updateErr := s.Services().SignupService().UpdateUserSignup(signup)
-	if updateErr != nil {
-		log.Error(ctx, updateErr, "error updating UserSignup")
-		verificationErr = errors.NewInternalError(updateErr, "error updating UserSignup")
+	doUpdate := func() error {
+		signup, err := s.Services().SignupService().GetUserSignup(userID)
+		if err != nil {
+			return err
+		}
+
+		if unsetVerificationRequired {
+			states.SetVerificationRequired(signup, false)
+		}
+
+		for k, v := range annotationValues {
+			signup.Annotations[k] = v
+		}
+
+		for _, annotationName := range annotationsToDelete {
+			delete(signup.Annotations, annotationName)
+		}
+
+		_, err = s.Services().SignupService().UpdateUserSignup(signup)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Attempt to update the UserSignup, retrying a number of times if the update fails
+	attempts := 0
+	for {
+		attempts++
+
+		// Attempt the update
+		updateErr := doUpdate()
+
+		// If there was an error, then only log it for now
+		if updateErr != nil {
+			log.Error(ctx, err, fmt.Sprintf("error while updating UserSignup resource, attempt #%d", attempts))
+		} else {
+			// Otherwise if there was no error updating the UserSignup, then break here
+			break
+		}
+
+		// If we've exceeded the number of attempts, then return a useful error to the user.  We won't return the actual
+		// error to the user here, as we've already logged it
+		if attempts > 4 {
+			return errors.NewInternalError(errs.New("there was an error while updating your account - please wait a moment before trying again."+
+				"If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for assistance"),
+				"error while verifying code")
+		}
 	}
 
 	return

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -257,7 +257,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 
 		failCount := 0
 
-		// Cause the client UPDATE call to fail always
+		// Cause the client UPDATE call to fail just twice
 		s.FakeUserSignupClient.MockUpdate = func(userSignup *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
 			if failCount < 2 {
 				failCount++

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/hex"
+	errs "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -181,7 +182,7 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 	require.Equal(s.T(), "+1NUMBER", params.Get("To"))
 }
 
-func (s *TestVerificationServiceSuite) TestInitVerificationClientUpdateFails() {
+func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 	// Setup gock to intercept calls made to the Twilio API
 	s.SetHTTPClientFactoryOption()
 	s.OverrideConfig(s.ServiceConfiguration("xxx", "yyy", "CodeReady"))
@@ -189,6 +190,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientUpdateFails() {
 	defer gock.Off()
 
 	gock.New("https://api.twilio.com").
+		Times(2).
 		Reply(http.StatusNoContent).
 		BodyString("")
 
@@ -221,27 +223,73 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientUpdateFails() {
 	err := s.FakeUserSignupClient.Tracker.Add(userSignup)
 	require.NoError(s.T(), err)
 
-	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
-	require.NoError(s.T(), err)
+	s.T().Run("when client GET call fails should return error", func(t *testing.T) {
 
-	userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
-	require.NoError(s.T(), err)
+		// Cause the client GET call to fail
+		s.FakeUserSignupClient.MockGet = func(s string) (*toolchainv1alpha1.UserSignup, error) {
+			return nil, errs.New("get failed")
+		}
+		defer func() { s.FakeUserSignupClient.MockGet = nil }()
 
-	require.NotEmpty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
+		require.Error(s.T(), err)
+		require.Equal(s.T(), "get failed:error retrieving usersignup: 123", err.Error())
+	})
 
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(reqBody)
-	require.NoError(s.T(), err)
-	reqValue := buf.String()
+	s.T().Run("when client UPDATE call fails indefinitely should return error", func(t *testing.T) {
 
-	params, err := url.ParseQuery(reqValue)
-	require.NoError(s.T(), err)
-	require.Equal(s.T(), fmt.Sprintf("Developer Sandbox for Red Hat OpenShift: Your verification code is %s",
-		userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]),
-		params.Get("Body"))
-	require.Equal(s.T(), "CodeReady", params.Get("From"))
-	require.Equal(s.T(), "+1NUMBER", params.Get("To"))
+		// Cause the client UPDATE call to fail always
+		s.FakeUserSignupClient.MockUpdate = func(userSignup *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
+			return nil, errs.New("update failed")
+		}
+		defer func() { s.FakeUserSignupClient.MockUpdate = nil }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
+		require.Error(s.T(), err)
+		require.Equal(s.T(), "there was an error while updating your account - please wait a moment before "+
+			"trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com "+
+			"for assistance:error while verifying code", err.Error())
+	})
+
+	s.T().Run("when client UPDATE call fails twice should return ok", func(t *testing.T) {
+
+		failCount := 0
+
+		// Cause the client UPDATE call to fail always
+		s.FakeUserSignupClient.MockUpdate = func(userSignup *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
+			if failCount < 2 {
+				failCount++
+				return nil, errs.New("update failed")
+			}
+			s.FakeUserSignupClient.MockUpdate = nil
+			return s.FakeUserSignupClient.Update(userSignup)
+		}
+		defer func() { s.FakeUserSignupClient.MockUpdate = nil }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
+		require.NoError(s.T(), err)
+
+		userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
+		require.NoError(s.T(), err)
+
+		require.NotEmpty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+
+		buf := new(bytes.Buffer)
+		_, err = buf.ReadFrom(reqBody)
+		require.NoError(s.T(), err)
+		reqValue := buf.String()
+
+		params, err := url.ParseQuery(reqValue)
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), fmt.Sprintf("Developer Sandbox for Red Hat OpenShift: Your verification code is %s",
+			userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]),
+			params.Get("Body"))
+		require.Equal(s.T(), "CodeReady", params.Get("From"))
+		require.Equal(s.T(), "+1NUMBER", params.Get("To"))
+	})
 }
 
 func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountReachedAndTimestampElapsed() {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CRT-1147

This PR also takes the opportunity to remove some old pre-migration tests which are no longer required.
