### PR TITLE
Use latest toolchain-common and add reg service configuration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,7 +46,7 @@ func main() {
 		panic(err.Error())
 	}
 
-	crtConfig, err := commonconfig.GetToolchainConfig(cl)
+	crtConfig, err := configuration.GetRegistrationServiceConfig(cl)
 	if err != nil {
 		panic(fmt.Sprintf("failed to initialize configuration: %s", err.Error()))
 	}
@@ -79,7 +79,7 @@ func main() {
 	// update cache every 10 seconds
 	go func() {
 		for {
-			if _, err := commonconfig.ForceLoadToolchainConfig(cl); err != nil {
+			if _, err := configuration.ForceLoadRegistrationServiceConfig(cl); err != nil {
 				log.Error(nil, err, "failed to update the configuration cache")
 			}
 			time.Sleep(10 * time.Second)

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/codeready-toolchain/registration-service
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20210721211719-002c2be44948
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210809234419-4a4ec2ec8202
+	github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1
 	github.com/gin-gonic/gin v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,10 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20210721211719-002c2be44948 h1:xwO422mdiCvAcbrnnU6PCEcBQ6Q/rQCvcbC/NxOKxkQ=
-github.com/codeready-toolchain/api v0.0.0-20210721211719-002c2be44948/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210809234419-4a4ec2ec8202 h1:B36xeGyA2/nAmFlckKHNDM20ZaXfzACQs8C1x/8Qpuk=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210809234419-4a4ec2ec8202/go.mod h1:O77wcE78AIKJGArGw7WZm+TcwqCOr5rfqTNrk0J88GY=
+github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584 h1:TzHWg6C8VJRdB0ALK6PARm4ACKRAguWlV3aNQHoFh0c=
+github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e h1:SuDK0YqGpQK0OxNFi59ltcwHJeJ5WvfbG+e2+ATEbH0=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e/go.mod h1:sfSHDs+ksRHzZbpbFsOXtSylQcvpQ6aaXa2TimVCCyI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/auth/keymanager.go
+++ b/pkg/auth/keymanager.go
@@ -9,8 +9,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/log"
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 
 	"gopkg.in/square/go-jose.v2"
@@ -41,14 +41,14 @@ type KeyManager struct {
 
 // NewKeyManager creates a new KeyManager and retrieves the public keys from the given URL.
 func NewKeyManager() (*KeyManager, error) {
-	cfg := commonconfig.GetCachedToolchainConfig()
-	keysEndpointURL := cfg.RegistrationService().Auth().AuthClientPublicKeysURL()
+	cfg := configuration.GetCachedRegistrationServiceConfig()
+	keysEndpointURL := cfg.Auth().AuthClientPublicKeysURL()
 	km := &KeyManager{
 		keyMap: make(map[string]*rsa.PublicKey),
 	}
 	// fetch raw keys
 	if keysEndpointURL != "" {
-		if cfg.RegistrationService().Environment() == "e2e-tests" {
+		if cfg.Environment() == "e2e-tests" {
 			log.Infof(nil, "fetching e2e public keys")
 			keys := authsupport.GetE2ETestPublicKey()
 

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -70,8 +70,8 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		Environment(configuration.DefaultEnvironment).
 		Auth().AuthClientPublicKeysURL(keysEndpointURL))
 	assert.False(s.T(), configuration.IsTestingMode(), "testing mode not set correctly to false")
-	cfg := commonconfig.GetCachedToolchainConfig()
-	assert.Equal(s.T(), keysEndpointURL, cfg.RegistrationService().Auth().AuthClientPublicKeysURL(), "key url not set correctly")
+	cfg := configuration.GetCachedRegistrationServiceConfig()
+	assert.Equal(s.T(), keysEndpointURL, cfg.Auth().AuthClientPublicKeysURL(), "key url not set correctly")
 
 	s.Run("parse keys, valid response", func() {
 		// Create KeyManager instance.
@@ -102,8 +102,8 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		// Set the config for testing mode, the handler may use this.
 		s.OverrideApplicationDefault(testconfig.RegistrationService().
 			Auth().AuthClientPublicKeysURL(ts.URL))
-		cfg := commonconfig.GetCachedToolchainConfig()
-		assert.Equal(s.T(), cfg.RegistrationService().Auth().AuthClientPublicKeysURL(), ts.URL, "key url not set correctly for testing")
+		cfg := configuration.GetCachedRegistrationServiceConfig()
+		assert.Equal(s.T(), cfg.Auth().AuthClientPublicKeysURL(), ts.URL, "key url not set correctly for testing")
 
 		// Create KeyManager instance.
 		_, err = auth.NewKeyManager()
@@ -128,8 +128,8 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		// Set the config for testing mode, the handler may use this.
 		s.OverrideApplicationDefault(testconfig.RegistrationService().
 			Auth().AuthClientPublicKeysURL(ts.URL))
-		cfg := commonconfig.GetCachedToolchainConfig()
-		assert.Equal(s.T(), cfg.RegistrationService().Auth().AuthClientPublicKeysURL(), ts.URL, "key url not set correctly for testing")
+		cfg := configuration.GetCachedRegistrationServiceConfig()
+		assert.Equal(s.T(), cfg.Auth().AuthClientPublicKeysURL(), ts.URL, "key url not set correctly for testing")
 
 		// Create KeyManager instance.
 		_, err = auth.NewKeyManager()
@@ -142,8 +142,8 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		notAnURL := "not an url"
 		s.OverrideApplicationDefault(testconfig.RegistrationService().
 			Auth().AuthClientPublicKeysURL(notAnURL))
-		cfg := commonconfig.GetCachedToolchainConfig()
-		assert.Equal(s.T(), cfg.RegistrationService().Auth().AuthClientPublicKeysURL(), notAnURL, "key url not set correctly for testing")
+		cfg := configuration.GetCachedRegistrationServiceConfig()
+		assert.Equal(s.T(), cfg.Auth().AuthClientPublicKeysURL(), notAnURL, "key url not set correctly for testing")
 
 		// Create KeyManager instance.
 		_, err := auth.NewKeyManager()
@@ -158,8 +158,8 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		anURL := "http://www.google.com/"
 		s.OverrideApplicationDefault(testconfig.RegistrationService().
 			Auth().AuthClientPublicKeysURL(anURL))
-		cfg := commonconfig.GetCachedToolchainConfig()
-		assert.Equal(s.T(), cfg.RegistrationService().Auth().AuthClientPublicKeysURL(), anURL, "key url not set correctly for testing")
+		cfg := configuration.GetCachedRegistrationServiceConfig()
+		assert.Equal(s.T(), cfg.Auth().AuthClientPublicKeysURL(), anURL, "key url not set correctly for testing")
 
 		// Create KeyManager instance.
 		_, err := auth.NewKeyManager()
@@ -171,9 +171,9 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		// Create KeyManager instance.
 		s.OverrideApplicationDefault(testconfig.RegistrationService().
 			Auth().AuthClientPublicKeysURL(keysEndpointURL))
-		cfg := commonconfig.GetCachedToolchainConfig()
+		cfg := configuration.GetCachedRegistrationServiceConfig()
 
-		assert.Equal(s.T(), cfg.RegistrationService().Auth().AuthClientPublicKeysURL(), keysEndpointURL, "key url not set correctly for testing")
+		assert.Equal(s.T(), cfg.Auth().AuthClientPublicKeysURL(), keysEndpointURL, "key url not set correctly for testing")
 		keyManager, err := auth.NewKeyManager()
 
 		// check if the keys can be used to verify a JWT
@@ -201,9 +201,9 @@ func (s *TestKeyManagerSuite) TestKeyFetching() {
 		// Create KeyManager instance.
 		s.OverrideApplicationDefault(testconfig.RegistrationService().
 			Auth().AuthClientPublicKeysURL(keysEndpointURL))
-		cfg := commonconfig.GetCachedToolchainConfig()
+		cfg := configuration.GetCachedRegistrationServiceConfig()
 
-		assert.Equal(s.T(), cfg.RegistrationService().Auth().AuthClientPublicKeysURL(), keysEndpointURL, "key url not set correctly for testing")
+		assert.Equal(s.T(), cfg.Auth().AuthClientPublicKeysURL(), keysEndpointURL, "key url not set correctly for testing")
 		keyManager, err := auth.NewKeyManager()
 
 		// check if the keys can be used to verify a JWT

--- a/pkg/auth/tokenparser_test.go
+++ b/pkg/auth/tokenparser_test.go
@@ -48,10 +48,10 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 	s.OverrideApplicationDefault(testconfig.RegistrationService().
 		Environment(configuration.UnitTestsEnvironment).
 		Auth().AuthClientPublicKeysURL(keysEndpointURL))
-	cfg := commonconfig.GetCachedToolchainConfig()
+	cfg := configuration.GetCachedRegistrationServiceConfig()
 
 	assert.True(s.T(), configuration.IsTestingMode(), "testing mode not set correctly to true")
-	assert.Equal(s.T(), keysEndpointURL, cfg.RegistrationService().Auth().AuthClientPublicKeysURL(), "key url not set correctly")
+	assert.Equal(s.T(), keysEndpointURL, cfg.Auth().AuthClientPublicKeysURL(), "key url not set correctly")
 
 	// create KeyManager instance.
 	keyManager, err := auth.NewKeyManager()

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -3,10 +3,17 @@
 package configuration
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"time"
 
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -19,6 +26,8 @@ var (
 	// StartTime in ISO 8601 (UTC) format.
 	StartTime = time.Now().UTC().Format("2006-01-02T15:04:05Z")
 )
+
+var logger = logf.Log.WithName("configuration")
 
 const (
 	GracefulTimeout       = time.Second * 15
@@ -33,10 +42,176 @@ const (
 )
 
 func IsTestingMode() bool {
-	cfg := commonconfig.GetCachedToolchainConfig()
-	return cfg.RegistrationService().Environment() == UnitTestsEnvironment
+	cfg := GetCachedRegistrationServiceConfig()
+	return cfg.Environment() == UnitTestsEnvironment
 }
 
 func Namespace() string {
 	return os.Getenv(commonconfig.WatchNamespaceEnvVar)
+}
+
+// GetRegistrationServiceConfig returns a RegistrationServiceConfig using the cache, or if the cache was not initialized
+// then retrieves the latest config using the provided client and updates the cache
+func GetRegistrationServiceConfig(cl client.Client) (RegistrationServiceConfig, error) {
+	config, secrets, err := commonconfig.GetConfig(cl, &toolchainv1alpha1.ToolchainConfig{})
+	if err != nil {
+		// return default config
+		logger.Error(err, "failed to retrieve RegistrationServiceConfig")
+		return RegistrationServiceConfig{cfg: &toolchainv1alpha1.ToolchainConfigSpec{}}, err
+	}
+	return NewRegistrationServiceConfig(config, secrets), nil
+}
+
+// GetCachedRegistrationServiceConfig returns a RegistrationServiceConfig directly from the cache
+func GetCachedRegistrationServiceConfig() RegistrationServiceConfig {
+	config, secrets := commonconfig.GetCachedConfig()
+	return NewRegistrationServiceConfig(config, secrets)
+}
+
+// ForceLoadRegistrationServiceConfig updates the cache using the provided client and returns the latest RegistrationServiceConfig
+func ForceLoadRegistrationServiceConfig(cl client.Client) (RegistrationServiceConfig, error) {
+	config, secrets, err := commonconfig.LoadLatest(cl, &toolchainv1alpha1.ToolchainConfig{})
+	if err != nil {
+		// return default config
+		logger.Error(err, "failed to force load RegistrationServiceConfig")
+		return RegistrationServiceConfig{cfg: &toolchainv1alpha1.ToolchainConfigSpec{}}, err
+	}
+	return NewRegistrationServiceConfig(config, secrets), nil
+}
+
+type RegistrationServiceConfig struct {
+	cfg     *toolchainv1alpha1.ToolchainConfigSpec
+	secrets map[string]map[string]string
+}
+
+func NewRegistrationServiceConfig(config runtime.Object, secrets map[string]map[string]string) RegistrationServiceConfig {
+	if config == nil {
+		// return default config if there's no config resource
+		return RegistrationServiceConfig{cfg: &toolchainv1alpha1.ToolchainConfigSpec{}}
+	}
+
+	toolchaincfg, ok := config.(*toolchainv1alpha1.ToolchainConfig)
+	if !ok {
+		// return default config
+		logger.Error(fmt.Errorf("cache does not contain toolchainconfig resource type"), "failed to get ToolchainConfig from resource, using default configuration")
+		return RegistrationServiceConfig{cfg: &toolchainv1alpha1.ToolchainConfigSpec{}}
+	}
+	return RegistrationServiceConfig{cfg: &toolchaincfg.Spec, secrets: secrets}
+}
+
+func (r *RegistrationServiceConfig) Print() {
+	logger.Info("Registration Service Configuration variables", "ToolchainConfigSpec", r.cfg.Host.RegistrationService)
+}
+
+func (r *RegistrationServiceConfig) Environment() string {
+	return commonconfig.GetString(r.cfg.Host.RegistrationService.Environment, "prod")
+}
+
+func (r RegistrationServiceConfig) Analytics() RegistrationServiceAnalyticsConfig {
+	return RegistrationServiceAnalyticsConfig{r.cfg.Host.RegistrationService.Analytics}
+}
+
+func (r RegistrationServiceConfig) Auth() RegistrationServiceAuthConfig {
+	return RegistrationServiceAuthConfig{r.cfg.Host.RegistrationService.Auth}
+}
+
+func (r RegistrationServiceConfig) LogLevel() string {
+	return commonconfig.GetString(r.cfg.Host.RegistrationService.LogLevel, "info")
+}
+
+func (r RegistrationServiceConfig) Namespace() string {
+	return commonconfig.GetString(r.cfg.Host.RegistrationService.Namespace, "toolchain-host-operator")
+}
+
+func (r RegistrationServiceConfig) RegistrationServiceURL() string {
+	return commonconfig.GetString(r.cfg.Host.RegistrationService.RegistrationServiceURL, "https://registration.crt-placeholder.com")
+}
+
+func (r RegistrationServiceConfig) Verification() RegistrationServiceVerificationConfig {
+	return RegistrationServiceVerificationConfig{c: r.cfg.Host.RegistrationService.Verification, secrets: r.secrets}
+}
+
+type RegistrationServiceAnalyticsConfig struct {
+	c toolchainv1alpha1.RegistrationServiceAnalyticsConfig
+}
+
+func (r RegistrationServiceAnalyticsConfig) WoopraDomain() string {
+	return commonconfig.GetString(r.c.WoopraDomain, "")
+}
+
+func (r RegistrationServiceAnalyticsConfig) SegmentWriteKey() string {
+	return commonconfig.GetString(r.c.SegmentWriteKey, "")
+}
+
+type RegistrationServiceAuthConfig struct {
+	c toolchainv1alpha1.RegistrationServiceAuthConfig
+}
+
+func (r RegistrationServiceAuthConfig) AuthClientLibraryURL() string {
+	return commonconfig.GetString(r.c.AuthClientLibraryURL, "https://sso.prod-preview.openshift.io/auth/js/keycloak.js")
+}
+
+func (r RegistrationServiceAuthConfig) AuthClientConfigContentType() string {
+	return commonconfig.GetString(r.c.AuthClientConfigContentType, "application/json; charset=utf-8")
+}
+
+func (r RegistrationServiceAuthConfig) AuthClientConfigRaw() string {
+	return commonconfig.GetString(r.c.AuthClientConfigRaw, `{"realm": "toolchain-public","auth-server-url": "https://sso.prod-preview.openshift.io/auth","ssl-required": "none","resource": "crt","clientId": "crt","public-client": true}`)
+}
+
+func (r RegistrationServiceAuthConfig) AuthClientPublicKeysURL() string {
+	return commonconfig.GetString(r.c.AuthClientPublicKeysURL, "https://sso.prod-preview.openshift.io/auth/realms/toolchain-public/protocol/openid-connect/certs")
+}
+
+type RegistrationServiceVerificationConfig struct {
+	c       toolchainv1alpha1.RegistrationServiceVerificationConfig
+	secrets map[string]map[string]string
+}
+
+func (r RegistrationServiceVerificationConfig) registrationServiceSecret(secretKey string) string {
+	secret := commonconfig.GetString(r.c.Secret.Ref, "")
+	return r.secrets[secret][secretKey]
+}
+
+func (r RegistrationServiceVerificationConfig) Enabled() bool {
+	return commonconfig.GetBool(r.c.Enabled, false)
+}
+
+func (r RegistrationServiceVerificationConfig) DailyLimit() int {
+	return commonconfig.GetInt(r.c.DailyLimit, 5)
+}
+
+func (r RegistrationServiceVerificationConfig) AttemptsAllowed() int {
+	return commonconfig.GetInt(r.c.AttemptsAllowed, 3)
+}
+
+func (r RegistrationServiceVerificationConfig) MessageTemplate() string {
+	return commonconfig.GetString(r.c.MessageTemplate, "Developer Sandbox for Red Hat OpenShift: Your verification code is %s")
+}
+
+func (r RegistrationServiceVerificationConfig) ExcludedEmailDomains() []string {
+	excluded := commonconfig.GetString(r.c.ExcludedEmailDomains, "")
+	v := strings.FieldsFunc(excluded, func(c rune) bool {
+		return c == ','
+	})
+	return v
+}
+
+func (r RegistrationServiceVerificationConfig) CodeExpiresInMin() int {
+	return commonconfig.GetInt(r.c.CodeExpiresInMin, 5)
+}
+
+func (r RegistrationServiceVerificationConfig) TwilioAccountSID() string {
+	key := commonconfig.GetString(r.c.Secret.TwilioAccountSID, "")
+	return r.registrationServiceSecret(key)
+}
+
+func (r RegistrationServiceVerificationConfig) TwilioAuthToken() string {
+	key := commonconfig.GetString(r.c.Secret.TwilioAuthToken, "")
+	return r.registrationServiceSecret(key)
+}
+
+func (r RegistrationServiceVerificationConfig) TwilioFromNumber() string {
+	key := commonconfig.GetString(r.c.Secret.TwilioFromNumber, "")
+	return r.registrationServiceSecret(key)
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/test"
+	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -26,5 +28,83 @@ func (s *TestConfigurationSuite) TestSegmentWriteKey() {
 	s.Run("prod environment", func() {
 		s.SetConfig(testconfig.RegistrationService().Environment(configuration.DefaultEnvironment))
 		require.False(s.T(), configuration.IsTestingMode())
+	})
+}
+
+func TestRegistrationService(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := commonconfig.NewToolchainConfigObjWithReset(t)
+		regServiceCfg := configuration.NewRegistrationServiceConfig(cfg, map[string]map[string]string{})
+
+		assert.Equal(t, "prod", regServiceCfg.Environment())
+		assert.Equal(t, "info", regServiceCfg.LogLevel())
+		assert.Equal(t, "toolchain-host-operator", regServiceCfg.Namespace())
+		assert.Equal(t, "https://registration.crt-placeholder.com", regServiceCfg.RegistrationServiceURL())
+		assert.Empty(t, regServiceCfg.Analytics().SegmentWriteKey())
+		assert.Empty(t, regServiceCfg.Analytics().WoopraDomain())
+		assert.Equal(t, "https://sso.prod-preview.openshift.io/auth/js/keycloak.js", regServiceCfg.Auth().AuthClientLibraryURL())
+		assert.Equal(t, "application/json; charset=utf-8", regServiceCfg.Auth().AuthClientConfigContentType())
+		assert.Equal(t, `{"realm": "toolchain-public","auth-server-url": "https://sso.prod-preview.openshift.io/auth","ssl-required": "none","resource": "crt","clientId": "crt","public-client": true}`,
+			regServiceCfg.Auth().AuthClientConfigRaw())
+		assert.Equal(t, "https://sso.prod-preview.openshift.io/auth/realms/toolchain-public/protocol/openid-connect/certs", regServiceCfg.Auth().AuthClientPublicKeysURL())
+		assert.False(t, regServiceCfg.Verification().Enabled())
+		assert.Equal(t, 5, regServiceCfg.Verification().DailyLimit())
+		assert.Equal(t, 3, regServiceCfg.Verification().AttemptsAllowed())
+		assert.Equal(t, "Developer Sandbox for Red Hat OpenShift: Your verification code is %s", regServiceCfg.Verification().MessageTemplate())
+		assert.Empty(t, regServiceCfg.Verification().ExcludedEmailDomains())
+		assert.Equal(t, 5, regServiceCfg.Verification().CodeExpiresInMin())
+		assert.Empty(t, regServiceCfg.Verification().TwilioAccountSID())
+		assert.Empty(t, regServiceCfg.Verification().TwilioAuthToken())
+		assert.Empty(t, regServiceCfg.Verification().TwilioFromNumber())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.RegistrationService().
+			Environment("e2e-tests").
+			LogLevel("debug").
+			Namespace("another-namespace").
+			RegistrationServiceURL("www.crtregservice.com").
+			Analytics().SegmentWriteKey("keyabc").
+			Analytics().WoopraDomain("woopra.com").
+			Auth().AuthClientLibraryURL("https://sso.openshift.com/auth/js/keycloak.js").
+			Auth().AuthClientConfigContentType("application/xml").
+			Auth().AuthClientConfigRaw(`{"realm": "toolchain-private"}`).
+			Auth().AuthClientPublicKeysURL("https://sso.openshift.com/certs").
+			Verification().Enabled(true).
+			Verification().DailyLimit(15).
+			Verification().AttemptsAllowed(13).
+			Verification().MessageTemplate("Developer Sandbox verification code: %s").
+			Verification().ExcludedEmailDomains("redhat.com,ibm.com").
+			Verification().CodeExpiresInMin(151).
+			Verification().Secret().Ref("verification-secrets").TwilioAccountSID("twilio.sid").TwilioAuthToken("twilio.token").TwilioFromNumber("twilio.fromnumber"))
+
+		verificationSecretValues := make(map[string]string)
+		verificationSecretValues["twilio.sid"] = "def"
+		verificationSecretValues["twilio.token"] = "ghi"
+		verificationSecretValues["twilio.fromnumber"] = "jkl"
+		secrets := make(map[string]map[string]string)
+		secrets["verification-secrets"] = verificationSecretValues
+
+		regServiceCfg := configuration.NewRegistrationServiceConfig(cfg, secrets)
+
+		assert.Equal(t, "e2e-tests", regServiceCfg.Environment())
+		assert.Equal(t, "debug", regServiceCfg.LogLevel())
+		assert.Equal(t, "another-namespace", regServiceCfg.Namespace())
+		assert.Equal(t, "www.crtregservice.com", regServiceCfg.RegistrationServiceURL())
+		assert.Equal(t, "keyabc", regServiceCfg.Analytics().SegmentWriteKey())
+		assert.Equal(t, "woopra.com", regServiceCfg.Analytics().WoopraDomain())
+		assert.Equal(t, "https://sso.openshift.com/auth/js/keycloak.js", regServiceCfg.Auth().AuthClientLibraryURL())
+		assert.Equal(t, "application/xml", regServiceCfg.Auth().AuthClientConfigContentType())
+		assert.Equal(t, `{"realm": "toolchain-private"}`, regServiceCfg.Auth().AuthClientConfigRaw())
+		assert.Equal(t, "https://sso.openshift.com/certs", regServiceCfg.Auth().AuthClientPublicKeysURL())
+
+		assert.True(t, regServiceCfg.Verification().Enabled())
+		assert.Equal(t, 15, regServiceCfg.Verification().DailyLimit())
+		assert.Equal(t, 13, regServiceCfg.Verification().AttemptsAllowed())
+		assert.Equal(t, "Developer Sandbox verification code: %s", regServiceCfg.Verification().MessageTemplate())
+		assert.Equal(t, []string{"redhat.com", "ibm.com"}, regServiceCfg.Verification().ExcludedEmailDomains())
+		assert.Equal(t, 151, regServiceCfg.Verification().CodeExpiresInMin())
+		assert.Equal(t, "def", regServiceCfg.Verification().TwilioAccountSID())
+		assert.Equal(t, "ghi", regServiceCfg.Verification().TwilioAuthToken())
+		assert.Equal(t, "jkl", regServiceCfg.Verification().TwilioFromNumber())
 	})
 }

--- a/pkg/controller/authconfig.go
+++ b/pkg/controller/authconfig.go
@@ -3,9 +3,8 @@ package controller
 import (
 	"net/http"
 
+	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/gin-gonic/gin"
-
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 )
 
 type configResponse struct {
@@ -27,10 +26,10 @@ func NewAuthConfig() *AuthConfig {
 
 // GetHandler returns raw auth config content for UI.
 func (ac *AuthConfig) GetHandler(ctx *gin.Context) {
-	cfg := commonconfig.GetCachedToolchainConfig()
+	cfg := configuration.GetCachedRegistrationServiceConfig()
 	configRespData := configResponse{
-		AuthClientLibraryURL: cfg.RegistrationService().Auth().AuthClientLibraryURL(),
-		AuthClientConfigRaw:  cfg.RegistrationService().Auth().AuthClientConfigRaw(),
+		AuthClientLibraryURL: cfg.Auth().AuthClientLibraryURL(),
+		AuthClientConfigRaw:  cfg.Auth().AuthClientConfigRaw(),
 	}
 	ctx.JSON(http.StatusOK, configRespData)
 }

--- a/pkg/controller/authconfig_test.go
+++ b/pkg/controller/authconfig_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/test"
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -32,7 +31,7 @@ func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
 
 	// Check if the config is set to testing mode, so the handler may use this.
 	assert.True(s.T(), configuration.IsTestingMode(), "testing mode not set correctly to true")
-	cfg := commonconfig.GetCachedToolchainConfig()
+	cfg := configuration.GetCachedRegistrationServiceConfig()
 
 	// Create handler instance.
 	authConfigCtrl := NewAuthConfig()
@@ -51,7 +50,7 @@ func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
 		require.Equal(s.T(), http.StatusOK, rr.Code)
 
 		// check response content-type.
-		require.Equal(s.T(), cfg.RegistrationService().Auth().AuthClientConfigContentType(), rr.Header().Get("Content-Type"))
+		require.Equal(s.T(), cfg.Auth().AuthClientConfigContentType(), rr.Header().Get("Content-Type"))
 
 		// Check the response body is what we expect.
 		// get config values from endpoint response
@@ -61,11 +60,11 @@ func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
 
 		// get the configured values
 		var config map[string]interface{}
-		err = json.Unmarshal([]byte(cfg.RegistrationService().Auth().AuthClientConfigRaw()), &config)
+		err = json.Unmarshal([]byte(cfg.Auth().AuthClientConfigRaw()), &config)
 		require.NoError(s.T(), err)
 
 		s.Run("envelope client url", func() {
-			assert.Equal(s.T(), cfg.RegistrationService().Auth().AuthClientLibraryURL(), dataEnvelope.AuthClientLibraryURL, "wrong 'auth-client-library-url' in authconfig response")
+			assert.Equal(s.T(), cfg.Auth().AuthClientLibraryURL(), dataEnvelope.AuthClientLibraryURL, "wrong 'auth-client-library-url' in authconfig response")
 		})
 
 		s.Run("envelope client config", func() {

--- a/pkg/controller/health_check.go
+++ b/pkg/controller/health_check.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/status"
 
 	"github.com/gin-gonic/gin"
@@ -28,10 +27,10 @@ func NewHealthCheck(checker HealthChecker) *HealthCheck {
 
 // getHealthInfo returns the health info.
 func (hc *HealthCheck) getHealthInfo() *status.Health {
-	cfg := commonconfig.GetCachedToolchainConfig()
+	cfg := configuration.GetCachedRegistrationServiceConfig()
 	return &status.Health{
 		Alive:       hc.checker.Alive(),
-		Environment: cfg.RegistrationService().Environment(),
+		Environment: cfg.Environment(),
 		Revision:    configuration.Commit,
 		BuildTime:   configuration.BuildTime,
 		StartTime:   configuration.StartTime,

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 
@@ -366,8 +365,8 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 	})
 
 	s.Run("init verification daily limit exceeded", func() {
-		cfg := commonconfig.GetCachedToolchainConfig()
-		originalValue := cfg.RegistrationService().Verification().DailyLimit()
+		cfg := configuration.GetCachedRegistrationServiceConfig()
+		originalValue := cfg.Verification().DailyLimit()
 		s.SetConfig(testconfig.RegistrationService().Verification().DailyLimit(0))
 		require.NoError(s.T(), err)
 		defer s.SetConfig(testconfig.RegistrationService().Verification().DailyLimit(originalValue))

--- a/pkg/controller/woopra.go
+++ b/pkg/controller/woopra.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"net/http"
 
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
+	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/gin-gonic/gin"
 )
 
@@ -19,14 +19,14 @@ func NewWoopra() *Woopra {
 
 // GetHandler returns the woopra-domain for UI.
 func (w *Woopra) GetWoopraDomain(ctx *gin.Context) {
-	cfg := commonconfig.GetCachedToolchainConfig()
-	domain := cfg.RegistrationService().Analytics().WoopraDomain()
+	cfg := configuration.GetCachedRegistrationServiceConfig()
+	domain := cfg.Analytics().WoopraDomain()
 	ctx.String(http.StatusOK, domain)
 }
 
 // GetSegmentWriteKey returns segment-write-key content for UI.
 func (w *Woopra) GetSegmentWriteKey(ctx *gin.Context) {
-	cfg := commonconfig.GetCachedToolchainConfig()
-	segmentWriteKey := cfg.RegistrationService().Analytics().SegmentWriteKey()
+	cfg := configuration.GetCachedRegistrationServiceConfig()
+	segmentWriteKey := cfg.Analytics().SegmentWriteKey()
 	ctx.String(http.StatusOK, segmentWriteKey)
 }

--- a/pkg/controller/woopra_test.go
+++ b/pkg/controller/woopra_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/test"
 
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 
 	"github.com/gin-gonic/gin"
@@ -49,9 +48,9 @@ func (s *TestWoopraSuite) TestWoopraHandler() {
 		s.OverrideApplicationDefault(testconfig.RegistrationService().
 			Analytics().WoopraDomain("testing woopra domain"))
 
-		cfg := commonconfig.GetCachedToolchainConfig()
+		cfg := configuration.GetCachedRegistrationServiceConfig()
 
-		assert.Equal(s.T(), "testing woopra domain", cfg.RegistrationService().Analytics().WoopraDomain())
+		assert.Equal(s.T(), "testing woopra domain", cfg.Analytics().WoopraDomain())
 		handler(ctx)
 
 		// Check the status code is what we expect.
@@ -63,7 +62,7 @@ func (s *TestWoopraSuite) TestWoopraHandler() {
 		require.NoError(s.T(), err)
 
 		s.Run("envelope woopra domain name", func() {
-			assert.Equal(s.T(), cfg.RegistrationService().Analytics().WoopraDomain(), dataEnvelope, "wrong 'woopra domain name' in woopra response")
+			assert.Equal(s.T(), cfg.Analytics().WoopraDomain(), dataEnvelope, "wrong 'woopra domain name' in woopra response")
 		})
 	})
 
@@ -84,9 +83,9 @@ func (s *TestWoopraSuite) TestWoopraHandler() {
 		s.OverrideApplicationDefault(testconfig.RegistrationService().
 			Analytics().SegmentWriteKey("testing segment write key"))
 
-		cfg := commonconfig.GetCachedToolchainConfig()
+		cfg := configuration.GetCachedRegistrationServiceConfig()
 
-		assert.Equal(s.T(), "testing segment write key", cfg.RegistrationService().Analytics().SegmentWriteKey())
+		assert.Equal(s.T(), "testing segment write key", cfg.Analytics().SegmentWriteKey())
 
 		handler(ctx)
 
@@ -99,7 +98,7 @@ func (s *TestWoopraSuite) TestWoopraHandler() {
 		require.NoError(s.T(), err)
 
 		s.Run("envelope segment write key", func() {
-			assert.Equal(s.T(), cfg.RegistrationService().Analytics().SegmentWriteKey(), dataEnvelope, "wrong 'segment write key' in segment response")
+			assert.Equal(s.T(), cfg.Analytics().SegmentWriteKey(), dataEnvelope, "wrong 'segment write key' in segment response")
 		})
 	})
 }

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/middleware"
 	"github.com/codeready-toolchain/registration-service/pkg/server"
 	"github.com/codeready-toolchain/registration-service/test"
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/status"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
@@ -80,8 +79,8 @@ func (s *TestAuthMiddlewareSuite) TestAuthMiddlewareService() {
 		Environment(configuration.UnitTestsEnvironment).
 		Auth().AuthClientPublicKeysURL(keysEndpointURL))
 
-	cfg := commonconfig.GetCachedToolchainConfig()
-	assert.Equal(s.T(), keysEndpointURL, cfg.RegistrationService().Auth().AuthClientPublicKeysURL(), "key url not set correctly")
+	cfg := configuration.GetCachedRegistrationServiceConfig()
+	assert.Equal(s.T(), keysEndpointURL, cfg.Auth().AuthClientPublicKeysURL(), "key url not set correctly")
 
 	// Setting up the routes.
 	err = srv.SetupRoutes()

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/log"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 	"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
 
@@ -87,13 +86,13 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 		}
 	}
 
-	cfg := commonconfig.GetCachedToolchainConfig()
+	cfg := configuration.GetCachedRegistrationServiceConfig()
 
-	verificationRequired := cfg.RegistrationService().Verification().Enabled()
+	verificationRequired := cfg.Verification().Enabled()
 
 	// Check if the user's email address is in the list of domains excluded for phone verification
 	emailHost := extractEmailHost(userEmail)
-	for _, d := range cfg.RegistrationService().Verification().ExcludedEmailDomains() {
+	for _, d := range cfg.Verification().ExcludedEmailDomains() {
 		if strings.EqualFold(d, emailHost) {
 			verificationRequired = false
 			break

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -390,7 +390,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 	defer gock.Off()
 	// call override config to ensure the factory option takes effect
 	s.OverrideApplicationDefault()
-	cfg := commonconfig.GetCachedToolchainConfig()
+	cfg := configuration.GetCachedRegistrationServiceConfig()
 
 	now := time.Now()
 
@@ -401,7 +401,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 			Namespace: configuration.Namespace(),
 			Annotations: map[string]string{
 				toolchainv1alpha1.UserSignupUserEmailAnnotationKey:                 "testuser@redhat.com",
-				toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey:       strconv.Itoa(cfg.RegistrationService().Verification().DailyLimit()),
+				toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey:       strconv.Itoa(cfg.Verification().DailyLimit()),
 				toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey: now.Format(verificationservice.TimestampLayout),
 			},
 			Labels: map[string]string{

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -66,7 +66,7 @@ func (s *UnitTestSuite) OverrideApplicationDefault(opts ...testconfig.ToolchainC
 	s.Application = fake.NewMockableApplication(s, s.factoryOptions...)
 }
 
-func (s *UnitTestSuite) SetConfig(opts ...testconfig.ToolchainConfigOption) commonconfig.ToolchainConfig {
+func (s *UnitTestSuite) SetConfig(opts ...testconfig.ToolchainConfigOption) configuration.RegistrationServiceConfig {
 
 	namespace, found := os.LookupEnv(commonconfig.WatchNamespaceEnvVar)
 	require.Truef(s.T(), found, "%s env var is not", commonconfig.WatchNamespaceEnvVar)
@@ -87,7 +87,7 @@ func (s *UnitTestSuite) SetConfig(opts ...testconfig.ToolchainConfigOption) comm
 	require.NoError(s.T(), err)
 
 	// update config cache
-	cfg, err := commonconfig.ForceLoadToolchainConfig(s.ConfigClient)
+	cfg, err := configuration.ForceLoadRegistrationServiceConfig(s.ConfigClient)
 	require.NoError(s.T(), err)
 	return cfg
 }
@@ -105,19 +105,19 @@ func (s *UnitTestSuite) SetSecret(secret *corev1.Secret) {
 	err = s.ConfigClient.Create(context.TODO(), secret)
 	require.NoError(s.T(), err)
 	// update config cache
-	cfg, err := commonconfig.ForceLoadToolchainConfig(s.ConfigClient)
+	cfg, err := configuration.ForceLoadRegistrationServiceConfig(s.ConfigClient)
 	require.NoError(s.T(), err)
 	require.NotEmpty(s.T(), cfg)
 }
 
-func (s *UnitTestSuite) DefaultConfig() commonconfig.ToolchainConfig {
+func (s *UnitTestSuite) DefaultConfig() configuration.RegistrationServiceConfig {
 	// use a new configuration client to fully reset configuration
 	s.ConfigClient = test.NewFakeClient(s.T())
-	commonconfig.Reset()
+	commonconfig.ResetCache()
 	obj := testconfig.NewToolchainConfigObj(s.T(), testconfig.RegistrationService().Environment("unit-tests"))
 	err := s.ConfigClient.Create(context.TODO(), obj)
 	require.NoError(s.T(), err)
-	cfg, err := commonconfig.GetToolchainConfig(s.ConfigClient)
+	cfg, err := configuration.GetRegistrationServiceConfig(s.ConfigClient)
 	require.NoError(s.T(), err)
 	return cfg
 }
@@ -129,7 +129,7 @@ func (s *UnitTestSuite) WithFactoryOption(opt factory.Option) {
 // TearDownSuite tears down the test suite.
 func (s *UnitTestSuite) TearDownSuite() {
 	// summon the GC!
-	commonconfig.Reset()
+	commonconfig.ResetCache()
 	s.Application = nil
 	s.FakeUserSignupClient = nil
 	s.FakeMasterUserRecordClient = nil


### PR DESCRIPTION
Related PR: https://github.com/codeready-toolchain/toolchain-common/pull/205

Updates the registration service to use the latest toolchain-common which means including the ToolchainConfig handling within the registration service and only exposing the RegistrationService configuration parts of the ToolchainConfig.