### PR TITLE
Capture OriginalSub claim value during signup and store in UserSignup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/registration-service
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210928071424-2ace1784e8d2
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210930200750-f33908ee98ea
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1
 	github.com/gin-gonic/gin v1.7.2

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/registration-service
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584
+	github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20210930200750-f33908ee98ea
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,9 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584 h1:TzHWg6C8VJRdB0ALK6PARm4ACKRAguWlV3aNQHoFh0c=
 github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7 h1:143gcNMuebi/2tECJ4ReyG5KLApHcDi/z92Y3iJAhAE=
+github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210930200750-f33908ee98ea h1:MSrWePQVh1ZYSBuazXCyCztLJIZxnBM+cE4t7fRKtNM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210930200750-f33908ee98ea/go.mod h1:sfSHDs+ksRHzZbpbFsOXtSylQcvpQ6aaXa2TimVCCyI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584 h1:TzHWg6C8VJRdB0ALK6PARm4ACKRAguWlV3aNQHoFh0c=
 github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210928071424-2ace1784e8d2 h1:ah3OeK6NfT+QfWH/mz3e5Yy8zcOIGh2CtXlv9PQOoHk=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210928071424-2ace1784e8d2/go.mod h1:sfSHDs+ksRHzZbpbFsOXtSylQcvpQ6aaXa2TimVCCyI=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210930200750-f33908ee98ea h1:MSrWePQVh1ZYSBuazXCyCztLJIZxnBM+cE4t7fRKtNM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210930200750-f33908ee98ea/go.mod h1:sfSHDs+ksRHzZbpbFsOXtSylQcvpQ6aaXa2TimVCCyI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/auth/tokenparser.go
+++ b/pkg/auth/tokenparser.go
@@ -26,6 +26,7 @@ type TokenClaims struct {
 	Email         string `json:"email"`
 	EmailVerified bool   `json:"email_verified"`
 	Company       string `json:"company"`
+	OriginalSub   string `json:"original_sub"`
 	jwt.StandardClaims
 }
 

--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -13,6 +13,8 @@ const (
 	CompanyKey = "company"
 	// SubKey is the context key for the subject claim
 	SubKey = "subject"
+	// OriginalSubKey is the context key for the original subject claim
+	OriginalSubKey = "originalSub"
 	// JWTClaimsKey is the context key for the claims struct
 	JWTClaimsKey = "jwtClaims"
 )

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -71,6 +71,7 @@ func (m *JWTMiddleware) HandlerFunc() gin.HandlerFunc {
 		c.Set(context.UsernameKey, token.Username)
 		c.Set(context.EmailKey, token.Email)
 		c.Set(context.SubKey, token.Subject)
+		c.Set(context.OriginalSubKey, token.OriginalSub)
 		c.Set(context.GivenNameKey, token.GivenName)
 		c.Set(context.FamilyNameKey, token.FamilyName)
 		c.Set(context.CompanyKey, token.Company)

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -118,6 +118,7 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 			GivenName:     ctx.GetString(context.GivenNameKey),
 			FamilyName:    ctx.GetString(context.FamilyNameKey),
 			Company:       ctx.GetString(context.CompanyKey),
+			OriginalSub:   ctx.GetString(context.OriginalSubKey),
 		},
 	}
 	states.SetVerificationRequired(userSignup, verificationRequired)

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -102,6 +102,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 	ctx, _ := gin.CreateTestContext(rr)
 	ctx.Set(context.UsernameKey, "jsmith")
 	ctx.Set(context.SubKey, userID.String())
+	ctx.Set(context.OriginalSubKey, "original-sub-value")
 	ctx.Set(context.EmailKey, "jsmith@gmail.com")
 	ctx.Set(context.GivenNameKey, "jane")
 	ctx.Set(context.FamilyNameKey, "doe")
@@ -113,6 +114,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 	// then
 	require.NoError(s.T(), err)
 	assert.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey]) // at this point, the annotation is not set
+	require.Equal(s.T(), "original-sub-value", userSignup.Spec.OriginalSub)
 
 	gvr, existing := assertUserSignupExists(userSignup, userID.String())
 


### PR DESCRIPTION
This PR stores the OriginalSub claim value from the user's access token in their UserSignup resource when signing up.

Fixes https://issues.redhat.com/browse/CRT-1253