### PR TITLE
configure logger to output in JSON format

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,17 +9,19 @@ import (
 	"syscall"
 	"time"
 
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/log"
 	"github.com/codeready-toolchain/registration-service/pkg/server"
-
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
+
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	// this is needed to be able to generate assets
 	_ "github.com/shurcooL/vfsgen"
@@ -27,7 +29,22 @@ import (
 
 func main() {
 	// create logger and registry
-	log.Init("registration-service")
+	log.Init("registration-service",
+		zap.UseDevMode(true),
+		zap.Encoder(zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+			TimeKey:        "ts",
+			LevelKey:       "level",
+			NameKey:        "logger",
+			CallerKey:      "caller",
+			MessageKey:     "msg",
+			StacktraceKey:  "stacktrace",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    zapcore.LowercaseLevelEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.SecondsDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		})),
+	)
 
 	_, found := os.LookupEnv(commonconfig.WatchNamespaceEnvVar)
 	if !found {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 // indirect
 	github.com/ttacon/libphonenumber v1.1.0 // indirect
+	go.uber.org/zap v1.15.0
 	gopkg.in/h2non/gock.v1 v1.0.14
 	gopkg.in/square/go-jose.v2 v2.3.1
 	gotest.tools v2.2.0+incompatible


### PR DESCRIPTION
applies on
- zap logger: configured with custom options, including
  human-readable timestamps)
- Gin logger: configured in production mode with a custom
  formatter to output in JSON

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
