### PR TITLE
include level in gin logs

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,7 +40,8 @@ func New(application application.Application) *RegistrationServer {
 			SkipPaths: []string{"/api/v1/health"}, // disable logging for the /api/v1/health endpoint so that our logs aren't overwhelmed
 			Formatter: func(params gin.LogFormatterParams) string {
 				// custom JSON format
-				return fmt.Sprintf(`{"client-ip":"%s", "ts":"%s", "method":"%s", "path":"%s", "proto":"%s", "status":"%d", "latency":"%s", "user-agent":"%s", "error-message":"%s"}`,
+				return fmt.Sprintf(`{"level":"%s", "client-ip":"%s", "ts":"%s", "method":"%s", "path":"%s", "proto":"%s", "status":"%d", "latency":"%s", "user-agent":"%s", "error-message":"%s"}`+"\n",
+					"info",
 					params.ClientIP,
 					params.TimeStamp.Format(time.RFC1123),
 					params.Method,


### PR DESCRIPTION
Avoids having some logs without the expected `level` field, which Grafana/Loki would treat as a log with an `error` level.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
