### PR TITLE
Changes required for proxy e2e tests

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,7 +83,7 @@ func main() {
 	}
 
 	// Start the proxy server
-	p, err := proxy.NewProxy(app, crtConfig)
+	p, err := proxy.NewProxy(app)
 	if err != nil {
 		panic(errs.Wrap(err, "failed to create proxy"))
 	}

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -48,6 +48,7 @@ objects:
         resources:
           - secrets
           - configmaps
+          - serviceaccounts
         verbs:
           - get
           - list

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -48,7 +48,6 @@ objects:
         resources:
           - secrets
           - configmaps
-          - serviceaccounts
         verbs:
           - get
           - list

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -131,10 +131,6 @@ func (r RegistrationServiceConfig) LogLevel() string {
 	return commonconfig.GetString(r.cfg.Host.RegistrationService.LogLevel, "info")
 }
 
-func (r RegistrationServiceConfig) Namespace() string {
-	return commonconfig.GetString(r.cfg.Host.RegistrationService.Namespace, "toolchain-host-operator")
-}
-
 func (r RegistrationServiceConfig) RegistrationServiceURL() string {
 	return commonconfig.GetString(r.cfg.Host.RegistrationService.RegistrationServiceURL, "https://registration.crt-placeholder.com")
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -42,7 +42,6 @@ func TestRegistrationService(t *testing.T) {
 		// then
 		assert.Equal(t, "prod", regServiceCfg.Environment())
 		assert.Equal(t, "info", regServiceCfg.LogLevel())
-		assert.Equal(t, "toolchain-host-operator", regServiceCfg.Namespace())
 		assert.Equal(t, "https://registration.crt-placeholder.com", regServiceCfg.RegistrationServiceURL())
 		assert.Empty(t, regServiceCfg.Analytics().SegmentWriteKey())
 		assert.Empty(t, regServiceCfg.Analytics().WoopraDomain())
@@ -66,7 +65,6 @@ func TestRegistrationService(t *testing.T) {
 		cfg := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.RegistrationService().
 			Environment("e2e-tests").
 			LogLevel("debug").
-			Namespace("another-namespace").
 			RegistrationServiceURL("www.crtregservice.com").
 			Analytics().SegmentWriteKey("keyabc").
 			Analytics().WoopraDomain("woopra.com").
@@ -95,7 +93,6 @@ func TestRegistrationService(t *testing.T) {
 		// then
 		assert.Equal(t, "e2e-tests", regServiceCfg.Environment())
 		assert.Equal(t, "debug", regServiceCfg.LogLevel())
-		assert.Equal(t, "another-namespace", regServiceCfg.Namespace())
 		assert.Equal(t, "www.crtregservice.com", regServiceCfg.RegistrationServiceURL())
 		assert.Equal(t, "keyabc", regServiceCfg.Analytics().SegmentWriteKey())
 		assert.Equal(t, "woopra.com", regServiceCfg.Analytics().WoopraDomain())

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -36,15 +36,15 @@ type Proxy struct {
 	tokenParser *auth.TokenParser
 }
 
-func NewProxy(app application.Application, config configuration.RegistrationServiceConfig) (*Proxy, error) {
+func NewProxy(app application.Application) (*Proxy, error) {
 	cl, err := newClusterClient()
 	if err != nil {
 		return nil, err
 	}
-	return newProxyWithClusterClient(app, config, cl)
+	return newProxyWithClusterClient(app, cl)
 }
 
-func newProxyWithClusterClient(app application.Application, config configuration.RegistrationServiceConfig, cln client.Client) (*Proxy, error) {
+func newProxyWithClusterClient(app application.Application, cln client.Client) (*Proxy, error) {
 	// Initiate toolchain cluster cache service
 	cacheLog := controllerlog.Log.WithName("registration-service")
 	cluster.NewToolchainClusterService(cln, cacheLog, configuration.Namespace(), 5*time.Second)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -47,7 +47,7 @@ func NewProxy(app application.Application, config configuration.RegistrationServ
 func newProxyWithClusterClient(app application.Application, config configuration.RegistrationServiceConfig, cln client.Client) (*Proxy, error) {
 	// Initiate toolchain cluster cache service
 	cacheLog := controllerlog.Log.WithName("registration-service")
-	cluster.NewToolchainClusterService(cln, cacheLog, config.Namespace(), 5*time.Second)
+	cluster.NewToolchainClusterService(cln, cacheLog, configuration.Namespace(), 5*time.Second)
 
 	tokenParser, err := auth.DefaultTokenParser()
 	if err != nil {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
-	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/namespace"
 	"github.com/codeready-toolchain/registration-service/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
@@ -45,7 +44,7 @@ func (s *TestProxySuite) TestProxy() {
 	_, err := auth.InitializeDefaultTokenParser()
 	require.NoError(s.T(), err)
 	fakeApp := &fakeApp{}
-	p, err := newProxyWithClusterClient(fakeApp, configuration.GetRegistrationServiceConfig(), nil)
+	p, err := newProxyWithClusterClient(fakeApp, nil)
 	require.NoError(s.T(), err)
 
 	server := p.StartProxy()

--- a/pkg/proxy/service/cluster_service.go
+++ b/pkg/proxy/service/cluster_service.go
@@ -56,6 +56,8 @@ func (s *ServiceImpl) GetNamespace(ctx *gin.Context, userID string) (*namespace.
 		return nil, errs.New("no member clusters found")
 	}
 	for _, member := range members {
+		// also check that the member cluster name matches because the api endpoint is the same for both members
+		// in the e2e tests because a single cluster is used for testing multi-member scenarios
 		if member.APIEndpoint == signup.APIEndpoint && member.Name == signup.ClusterName {
 			// Obtain the SA token
 			targetNamespace := signup.CompliantUsername

--- a/pkg/proxy/service/cluster_service.go
+++ b/pkg/proxy/service/cluster_service.go
@@ -56,7 +56,7 @@ func (s *ServiceImpl) GetNamespace(ctx *gin.Context, userID string) (*namespace.
 		return nil, errs.New("no member clusters found")
 	}
 	for _, member := range members {
-		if member.APIEndpoint == signup.APIEndpoint {
+		if member.APIEndpoint == signup.APIEndpoint && member.Name == signup.ClusterName {
 			// Obtain the SA token
 			targetNamespace := signup.CompliantUsername
 			saName := fmt.Sprintf("appstudio-%s", signup.CompliantUsername)

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -52,6 +52,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 		},
 	}).addSignup("789-ready", &signup.Signup{
 		APIEndpoint:       "https://api.endpoint.member-2.com:6443",
+		ClusterName:       "member-2",
 		CompliantUsername: "smith",
 		Username:          "smith",
 		Status: signup.Status{
@@ -59,6 +60,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 		},
 	}).addSignup("012-ready-unknown-cluster", &signup.Signup{
 		APIEndpoint:       "https://api.endpoint.unknown.com:6443",
+		ClusterName:       "unknown",
 		CompliantUsername: "smith",
 		Username:          "smith",
 		Status: signup.Status{

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -293,6 +293,7 @@ func (s *ServiceImpl) GetSignup(userID string) (*signup.Signup, error) {
 				signupResponse.ConsoleURL = member.MemberStatus.Routes.ConsoleURL
 				signupResponse.CheDashboardURL = member.MemberStatus.Routes.CheDashboardURL
 				signupResponse.APIEndpoint = member.ApiEndpoint
+				signupResponse.ClusterName = member.ClusterName
 				break
 			}
 		}

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -574,6 +574,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 	require.Equal(s.T(), "", response.ConsoleURL)
 	require.Equal(s.T(), "", response.CheDashboardURL)
 	require.Equal(s.T(), "", response.APIEndpoint)
+	require.Equal(s.T(), "", response.ClusterName)
 }
 
 func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
@@ -638,6 +639,7 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 		require.Equal(s.T(), "", response.ConsoleURL)
 		require.Equal(s.T(), "", response.CheDashboardURL)
 		require.Equal(s.T(), "", response.APIEndpoint)
+		require.Equal(s.T(), "", response.ClusterName)
 	}
 }
 
@@ -709,6 +711,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 	assert.Equal(s.T(), "https://console.member-123.com", response.ConsoleURL)
 	assert.Equal(s.T(), "http://che-toolchain-che.member-123.com", response.CheDashboardURL)
 	assert.Equal(s.T(), "http://api.devcluster.openshift.com", response.APIEndpoint)
+	assert.Equal(s.T(), "member-123", response.ClusterName)
 }
 
 func (s *TestSignupServiceSuite) TestGetSignupStatusFailGetToolchainStatus() {

--- a/pkg/signup/signup.go
+++ b/pkg/signup/signup.go
@@ -9,6 +9,8 @@ type Signup struct {
 	CheDashboardURL string `json:"cheDashboardURL,omitempty"`
 	// The server api URL of the cluster which the user was provisioned to
 	APIEndpoint string `json:"apiEndpoint,omitempty"`
+	// The name of the cluster which the user was provisioned to
+	ClusterName string `json:"clusterName,omitempty"`
 	// The complaint username.  This may differ from the corresponding Identity Provider username, because of the the
 	// limited character set available for naming (see RFC1123) in K8s. If the username contains characters which are
 	// disqualified from the resource name, the username is transformed into an acceptable resource name instead.


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/CRT-1274

Related PRs:
- https://github.com/codeready-toolchain/toolchain-e2e/pull/413

Summary of changes:
- update the call to `cluster.NewToolchainClusterService()` to use the current namespace of the reg service because the RegistrationServiceConfig.Namespace() configuration defaulted to "toolchain-host-operator" but in e2e the host operator namespace is dynamic
- remove Namespace() func from RegistrationServiceConfig because it was confusing and not used anywhere else
- update the check in GetNamespace() to also check the name of the member cluster `member.Name == signup.ClusterName` because the api endpoint is the same in e2e test environment so testing multi-member scenarios led to mismatching the member clusters
  - updated the Signup struct to include ClusterName to support this