### PR TITLE
Health/readiness probe for proxy

### DIFF
--- a/pkg/controller/health_check.go
+++ b/pkg/controller/health_check.go
@@ -77,7 +77,7 @@ func (c *healthCheckerImpl) Alive(ctx *gin.Context) bool {
 }
 
 func (c *healthCheckerImpl) APIProxyAlive(ctx *gin.Context) bool {
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/health", proxy.ProxyPort))
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/proxyhealth", proxy.ProxyPort))
 	if err != nil {
 		log.Error(ctx, err, "API Proxy health check failed")
 		return false

--- a/pkg/controller/health_check.go
+++ b/pkg/controller/health_check.go
@@ -1,9 +1,12 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
+	"github.com/codeready-toolchain/registration-service/pkg/log"
+	"github.com/codeready-toolchain/registration-service/pkg/proxy"
 	"github.com/codeready-toolchain/toolchain-common/pkg/status"
 
 	"github.com/gin-gonic/gin"
@@ -18,6 +21,11 @@ type HealthCheck struct {
 	checker HealthChecker
 }
 
+type HealthStatus struct {
+	*status.Health
+	ProxyAlive bool
+}
+
 // HealthCheck returns a new HealthCheck instance.
 func NewHealthCheck(checker HealthChecker) *HealthCheck {
 	return &HealthCheck{
@@ -26,21 +34,24 @@ func NewHealthCheck(checker HealthChecker) *HealthCheck {
 }
 
 // getHealthInfo returns the health info.
-func (hc *HealthCheck) getHealthInfo() *status.Health {
+func (hc *HealthCheck) getHealthInfo(ctx *gin.Context) *HealthStatus {
 	cfg := configuration.GetRegistrationServiceConfig()
-	return &status.Health{
-		Alive:       hc.checker.Alive(),
-		Environment: cfg.Environment(),
-		Revision:    configuration.Commit,
-		BuildTime:   configuration.BuildTime,
-		StartTime:   configuration.StartTime,
+	return &HealthStatus{
+		Health: &status.Health{
+			Alive:       hc.checker.Alive(ctx),
+			Environment: cfg.Environment(),
+			Revision:    configuration.Commit,
+			BuildTime:   configuration.BuildTime,
+			StartTime:   configuration.StartTime,
+		},
+		ProxyAlive: hc.checker.APIProxyAlive(ctx),
 	}
 }
 
 // GetHandler returns a default heath check result.
 func (hc *HealthCheck) GetHandler(ctx *gin.Context) {
 	// Default handler for system health
-	healthInfo := hc.getHealthInfo()
+	healthInfo := hc.getHealthInfo(ctx)
 	if healthInfo.Alive {
 		ctx.JSON(http.StatusOK, healthInfo)
 	} else {
@@ -49,7 +60,8 @@ func (hc *HealthCheck) GetHandler(ctx *gin.Context) {
 }
 
 type HealthChecker interface {
-	Alive() bool
+	Alive(*gin.Context) bool
+	APIProxyAlive(*gin.Context) bool
 }
 
 func NewHealthChecker() HealthChecker {
@@ -59,7 +71,16 @@ func NewHealthChecker() HealthChecker {
 type healthCheckerImpl struct {
 }
 
-func (c *healthCheckerImpl) Alive() bool {
+func (c *healthCheckerImpl) Alive(ctx *gin.Context) bool {
 	// TODO check if there are errors in configuration
-	return true
+	return c.APIProxyAlive(ctx)
+}
+
+func (c *healthCheckerImpl) APIProxyAlive(ctx *gin.Context) bool {
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/health", proxy.ProxyPort))
+	if err != nil {
+		log.Error(ctx, err, "API Proxy health check failed")
+		return false
+	}
+	return resp.StatusCode == http.StatusOK
 }

--- a/pkg/controller/health_check_test.go
+++ b/pkg/controller/health_check_test.go
@@ -55,7 +55,7 @@ func (s *TestHealthCheckSuite) TestHealthCheckHandler() {
 		// mock proxy
 		defer gock.Off()
 		gock.New(fmt.Sprintf("http://localhost:%s", proxy.ProxyPort)).
-			Get("/health").
+			Get("/proxyhealth").
 			Persist().
 			Reply(http.StatusOK).
 			BodyString("")
@@ -90,7 +90,7 @@ func (s *TestHealthCheckSuite) TestHealthCheckHandler() {
 		// mock proxy
 		defer gock.Off()
 		gock.New(fmt.Sprintf("http://localhost:%s", proxy.ProxyPort)).
-			Get("/health").
+			Get("/proxyhealth").
 			Persist().
 			Reply(http.StatusOK).
 			BodyString("")
@@ -131,7 +131,7 @@ func (s *TestHealthCheckSuite) TestHealthCheckHandler() {
 		// mock proxy
 		defer gock.Off()
 		gock.New(fmt.Sprintf("http://localhost:%s", proxy.ProxyPort)).
-			Get("/health").
+			Get("/proxyhealth").
 			Persist().
 			Reply(http.StatusOK).
 			BodyString("")

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -105,7 +105,7 @@ func (s *TestAuthMiddlewareSuite) TestAuthMiddlewareService() {
 
 		// mock proxy
 		defer gock.Off()
-		gock.New(fmt.Sprintf("http://localhost:%s/health", proxy.ProxyPort)).
+		gock.New(fmt.Sprintf("http://localhost:%s/proxyhealth", proxy.ProxyPort)).
 			Reply(http.StatusOK).
 			BodyString("")
 
@@ -166,7 +166,7 @@ func (s *TestAuthMiddlewareSuite) TestAuthMiddlewareService() {
 
 				// mock proxy
 				defer gock.Off()
-				gock.New(fmt.Sprintf("http://localhost:%s/health", proxy.ProxyPort)).
+				gock.New(fmt.Sprintf("http://localhost:%s/proxyhealth", proxy.ProxyPort)).
 					Reply(http.StatusOK).
 					BodyString("")
 

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -2,15 +2,18 @@ package middleware_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/codeready-toolchain/registration-service/test/fake"
+	"gopkg.in/h2non/gock.v1"
 
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/middleware"
+	"github.com/codeready-toolchain/registration-service/pkg/proxy"
 	"github.com/codeready-toolchain/registration-service/pkg/server"
 	"github.com/codeready-toolchain/registration-service/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/status"
@@ -94,12 +97,22 @@ func (s *TestAuthMiddlewareSuite) TestAuthMiddlewareService() {
 	require.NotNil(s.T(), srv.Engine())
 
 	s.Run("health check requests", func() {
+		// given
 		health := &status.Health{}
 		resp := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "/api/v1/health", nil)
 		require.NoError(s.T(), err)
 
+		// mock proxy
+		defer gock.Off()
+		gock.New(fmt.Sprintf("http://localhost:%s/health", proxy.ProxyPort)).
+			Reply(http.StatusOK).
+			BodyString("")
+
+		// when
 		srv.Engine().ServeHTTP(resp, req)
+
+		// then
 		// Check the status code is what we expect.
 		assert.Equal(s.T(), http.StatusOK, resp.Code, "request returned wrong status code")
 
@@ -143,13 +156,24 @@ func (s *TestAuthMiddlewareSuite) TestAuthMiddlewareService() {
 		}
 		for _, tt := range authtests {
 			s.Run(tt.name, func() {
+				// given
 				resp := httptest.NewRecorder()
 				req, err := http.NewRequest(tt.method, tt.urlPath, nil)
 				require.NoError(s.T(), err)
 				if tt.tokenHeader != "" {
 					req.Header.Set("Authorization", tt.tokenHeader)
 				}
+
+				// mock proxy
+				defer gock.Off()
+				gock.New(fmt.Sprintf("http://localhost:%s/health", proxy.ProxyPort)).
+					Reply(http.StatusOK).
+					BodyString("")
+
+				// when
 				srv.Engine().ServeHTTP(resp, req)
+
+				// then
 				// Check the status code is what we expect.
 				assert.Equal(s.T(), tt.status, resp.Code, "request returned wrong status code")
 			})

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -80,7 +80,10 @@ func (p *Proxy) StartProxy() *http.Server {
 func (p *Proxy) health(res http.ResponseWriter, req *http.Request) {
 	res.Header().Set("Content-Type", "application/json")
 	res.WriteHeader(http.StatusOK)
-	io.WriteString(res, `{"alive": true}`)
+	_, err := io.WriteString(res, `{"alive": true}`)
+	if err != nil {
+		log.Error(nil, err, "failed to write health response")
+	}
 }
 
 func (p *Proxy) handleRequestAndRedirect(res http.ResponseWriter, req *http.Request) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -64,7 +64,7 @@ func (p *Proxy) StartProxy() *http.Server {
 	// start server
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", p.handleRequestAndRedirect)
-	mux.HandleFunc("/health", p.health)
+	mux.HandleFunc("/proxyhealth", p.health)
 
 	// listen concurrently to allow for graceful shutdown
 	log.Info(nil, "Starting the Proxy server...")

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -69,6 +69,21 @@ func (s *TestProxySuite) TestProxy() {
 		break
 	}
 
+	s.Run("health check ok", func() {
+		req, err := http.NewRequest("GET", "http://localhost:8081/proxyhealth", nil)
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), req)
+
+		// when
+		resp, err := http.DefaultClient.Do(req)
+
+		// then
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), resp)
+		assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
+		s.assertResponseBody(resp, `{"alive": true}`)
+	})
+
 	s.Run("return unauthorized if no token present", func() {
 		req, err := http.NewRequest("GET", "http://localhost:8081/api/mycoolworkspace/pods", nil)
 		require.NoError(s.T(), err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -42,7 +42,7 @@ func (s *TestServerSuite) TestServer() {
 	require.NoError(s.T(), err)
 	gock.OffAll()
 
-	startFakeProxy()
+	startFakeProxy(s.T())
 
 	// Check that there are routes registered.
 	routes := srv.GetRegisteredRoutes()
@@ -101,14 +101,15 @@ func (s *TestServerSuite) TestServer() {
 	})
 }
 
-func startFakeProxy() *http.Server {
+func startFakeProxy(t *testing.T) *http.Server {
 	// start server
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", fakehealth)
 
 	srv := &http.Server{Addr: ":" + proxy.ProxyPort, Handler: mux}
 	go func() {
-		srv.ListenAndServe()
+		err := srv.ListenAndServe()
+		require.NoError(t, err)
 	}()
 	return srv
 }
@@ -116,5 +117,5 @@ func startFakeProxy() *http.Server {
 func fakehealth(res http.ResponseWriter, req *http.Request) {
 	res.Header().Set("Content-Type", "application/json")
 	res.WriteHeader(http.StatusOK)
-	io.WriteString(res, `{"alive": true}`)
+	io.WriteString(res, `{"alive": true}`) //nolint:golint,errcheck
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -104,7 +104,7 @@ func (s *TestServerSuite) TestServer() {
 func startFakeProxy(t *testing.T) *http.Server {
 	// start server
 	mux := http.NewServeMux()
-	mux.HandleFunc("/health", fakehealth)
+	mux.HandleFunc("/proxyhealth", fakehealth)
 
 	srv := &http.Server{Addr: ":" + proxy.ProxyPort, Handler: mux}
 	go func() {


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRT-1372

There can only be one health endpoint per container and since we have the reg service and proxy servers both in the same container there needs to be a combined health endpoint.

Summary of changes:
- Adds a health endpoint to the proxy server
- Modified the reg service health checker to also initiate a GET request to the proxy health endpoint