### PR TITLE
Add activate endpoint to allow users to signup using activation code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/registration-service
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20211126114210-ae782bc35b41
+	github.com/codeready-toolchain/api v0.0.0-20211126204635-dc58c4968f5f
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20211129093739-1d3ce7279ca1
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/api v0.0.0-20211126114210-ae782bc35b41 h1:1oYv+6fEKJKhi7HpDIbVtYH6NVvyPx/sK/UEyXWaQ9I=
-github.com/codeready-toolchain/api v0.0.0-20211126114210-ae782bc35b41/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/api v0.0.0-20211126204635-dc58c4968f5f h1:BmKGeWhQPLAIammn4PtpLzt1GYSfYJFle1mIeJJp4uc=
+github.com/codeready-toolchain/api v0.0.0-20211126204635-dc58c4968f5f/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211129093739-1d3ce7279ca1 h1:0bi8Q9rct9XPHjMkLYhZNts9etLLgKVX0NDN+0dD4lQ=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211129093739-1d3ce7279ca1/go.mod h1:DJVsWbbiNJ6XB5DekM5duSoqrUXjjKG6dDArFZsGSDY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -8,6 +8,7 @@ import (
 )
 
 type SignupService interface {
+	Activate(ctx *gin.Context, code string) (*toolchainv1alpha1.UserSignup, error)
 	Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error)
 	GetSignup(userID string) (*signup.Signup, error)
 	GetUserSignup(userID string) (*toolchainv1alpha1.UserSignup, error)

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -31,7 +31,7 @@ func NewSignup(app application.Application) *Signup {
 	}
 }
 
-// PostHandler creates a Signup resource
+// ActivateHandler is used to allow a user to register by providing an activation code for a ToolchainEvent
 func (s *Signup) ActivateHandler(ctx *gin.Context) {
 	code := ctx.Param("code")
 	if code == "" {
@@ -52,7 +52,7 @@ func (s *Signup) ActivateHandler(ctx *gin.Context) {
 		return
 	}
 
-	log.Infof(ctx, "UserSignup %s created", userSignup.Name)
+	log.Infof(ctx, "UserSignup %s created via activation code", userSignup.Name)
 	ctx.Status(http.StatusAccepted)
 	ctx.Writer.WriteHeaderNow()
 }

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -674,11 +674,16 @@ func initVerification(t *testing.T, handler gin.HandlerFunc, params gin.Param, d
 }
 
 type FakeSignupService struct {
+	MockActivate                func(ctx *gin.Context, code string) (*crtapi.UserSignup, error)
 	MockGetSignup               func(userID string) (*signup.Signup, error)
 	MockSignup                  func(ctx *gin.Context) (*crtapi.UserSignup, error)
 	MockGetUserSignup           func(userID string) (*crtapi.UserSignup, error)
 	MockUpdateUserSignup        func(userSignup *crtapi.UserSignup) (*crtapi.UserSignup, error)
 	MockPhoneNumberAlreadyInUse func(userID, value string) error
+}
+
+func (m *FakeSignupService) Activate(ctx *gin.Context, code string) (*crtapi.UserSignup, error) {
+	return m.MockActivate(ctx, code)
 }
 
 func (m *FakeSignupService) GetSignup(userID string) (*signup.Signup, error) {

--- a/pkg/kubeclient/client.go
+++ b/pkg/kubeclient/client.go
@@ -17,6 +17,7 @@ type V1Alpha1 interface {
 	MasterUserRecords() MasterUserRecordInterface
 	BannedUsers() BannedUserInterface
 	ToolchainStatuses() ToolchainStatusInterface
+	ToolchainEvents() ToolchainEventInterface
 }
 
 // NewCRTRESTClient creates a new REST client for managing Codeready Toolchain resources via the Kubernetes API

--- a/pkg/kubeclient/client.go
+++ b/pkg/kubeclient/client.go
@@ -60,6 +60,8 @@ func getRegisterObject() []runtime.Object {
 		&crtapi.MasterUserRecordList{},
 		&crtapi.BannedUser{},
 		&crtapi.BannedUserList{},
+		&crtapi.ToolchainEvent{},
+		&crtapi.ToolchainEventList{},
 		&crtapi.ToolchainStatus{},
 		&crtapi.ToolchainStatusList{},
 	}
@@ -108,6 +110,18 @@ func (c *V1Alpha1REST) MasterUserRecords() MasterUserRecordInterface {
 // BannedUsers returns an interface which may be used to perform query operations on BannedUser resources
 func (c *V1Alpha1REST) BannedUsers() BannedUserInterface {
 	return &bannedUserClient{
+		crtClient: crtClient{
+			client: c.client.RestClient,
+			ns:     c.client.NS,
+			cfg:    c.client.Config,
+			scheme: c.client.Scheme,
+		},
+	}
+}
+
+// ToolchainEvents returns an interface which may be used to perform query operations on ToolchainEvent resources
+func (c *V1Alpha1REST) ToolchainEvents() ToolchainEventInterface {
+	return &toolchainEventClient{
 		crtClient: crtClient{
 			client: c.client.RestClient,
 			ns:     c.client.NS,

--- a/pkg/kubeclient/toolchainevent.go
+++ b/pkg/kubeclient/toolchainevent.go
@@ -1,0 +1,65 @@
+package kubeclient
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
+)
+
+const (
+	toolchainEventResourcePlural = "toolchainevents"
+)
+
+type toolchainEventClient struct {
+	crtClient
+}
+
+// ToolchainEventInterface is the interface for toolchain events.
+type ToolchainEventInterface interface {
+	Update(obj *crtapi.ToolchainEvent) (*crtapi.ToolchainEvent, error)
+	ListActiveEvents() (*crtapi.ToolchainEventList, error)
+}
+
+// Update will update an existing ToolchainEvent resource in the cluster, returning an error if something went wrong
+func (c *toolchainEventClient) Update(obj *crtapi.ToolchainEvent) (*crtapi.ToolchainEvent, error) {
+	result := &crtapi.ToolchainEvent{}
+	err := c.client.Put().
+		Namespace(c.ns).
+		Resource(toolchainEventResourcePlural).
+		Name(obj.Name).
+		Body(obj).
+		Do(context.TODO()).
+		Into(result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ListActiveEvents returns the ToolchainEvent with the specified activation code, or an error if something went
+// wrong while attempting to retrieve it. If not found then NotFound error returned
+func (c *toolchainEventClient) ListActiveEvents() (*crtapi.ToolchainEventList, error) {
+	intf, err := dynamic.NewForConfig(&c.cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	r := schema.GroupVersionResource{Group: "toolchain.dev.openshift.com", Version: "v1alpha1", Resource: toolchainEventResourcePlural}
+	listOptions := v1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s!=%s,%s=%s", crtapi.ToolchainEvent StateLabelKey, crtapi.ToolchainEventStateLabelValueDeactivated, labelKey, labelValue),
+	}
+
+	list, err := intf.Resource(r).Namespace(c.ns).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &crtapi.UserSignupList{}
+
+	err = c.crtClient.scheme.Convert(list, result, nil)
+	return result, err
+}

--- a/pkg/kubeclient/toolchainevent.go
+++ b/pkg/kubeclient/toolchainevent.go
@@ -44,6 +44,7 @@ func (c *toolchainEventClient) Update(obj *crtapi.ToolchainEvent) (*crtapi.Toolc
 // ListByActivationCode returns all ToolchainEvent resources with the specified activation code, or an error if something went
 // wrong while attempting to retrieve them.
 func (c *toolchainEventClient) ListByActivationCode(activationCode string) (*crtapi.ToolchainEventList, error) {
+
 	intf, err := dynamic.NewForConfig(&c.cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -366,6 +366,10 @@ func (m *fakeSignupService) GetSignup(userID string) (*signup.Signup, error) {
 	return m.mockGetSignup(userID)
 }
 
+func (m *fakeSignupService) Activate(ctx *gin.Context, code string) (*toolchainv1alpha1.UserSignup, error) {
+	return nil, nil
+}
+
 func (m *fakeSignupService) Signup(_ *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
 	return nil, nil
 }

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -83,6 +83,7 @@ func (srv *RegistrationServer) SetupRoutes() error {
 		// secured routes
 		securedV1 := srv.router.Group("/api/v1")
 		securedV1.Use(authMiddleware.HandlerFunc())
+		securedV1.PUT("/signup/activate/:code", signupCtrl.ActivateHandler)
 		securedV1.POST("/signup", signupCtrl.PostHandler)
 		// requires a ctx body containing the country_code and phone_number
 		securedV1.PUT("/signup/verification", signupCtrl.InitVerificationHandler)

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -194,7 +194,7 @@ func (s *ServiceImpl) Activate(ctx *gin.Context, code string) (*toolchainv1alpha
 	// If no event was found, return an error
 	if event == nil {
 		err := errors.NewBadRequest("invalid activation code")
-		log.Error(ctx, err, "invalid activation code")
+		log.Error(ctx, err, "invalid activation code, no matching active event found")
 		return nil, err
 	}
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -314,10 +314,7 @@ func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing *toolchain
 
 func applyEventToUserSignup(userSignup *toolchainv1alpha1.UserSignup, event *toolchainv1alpha1.ToolchainEvent) {
 	if event != nil {
-		// If the event is not set to require verification, then remove the verification-required state from the UserSignup
-		if !event.Spec.VerificationRequired {
-			states.SetVerificationRequired(userSignup, false)
-		}
+		states.SetVerificationRequired(userSignup, event.Spec.VerificationRequired)
 
 		// Set the ToolchainEvent Label value to the name of the ToolchainEvent resource
 		userSignup.Labels[toolchainv1alpha1.UserSignupToolchainEventLabelKey] = event.Name

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -161,6 +161,21 @@ func EncodeUserID(subject string) string {
 	return encoded
 }
 
+// Activate allows a user to register via the use of an activation code
+func (s *ServiceImpl) Activate(ctx *gin.Context, code string) (*toolchainv1alpha1.UserSignup, error) {
+
+	// Lookup the ToolchainEvent resource based on the provided activation code
+	toolchainEvent, err := s.CRTClient().V1Alpha1().ToolchainEvents().GetByActivationCode(code)
+
+	// Check if the activation code is currently active, i.e. the current
+
+	// First check if the user already exists, if they do and are currently active, return an error
+
+	// If the user does exist but they are not active, they may proceed with the activation
+
+	return nil, nil
+}
+
 // Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username and userID
 // if doesn't exist yet.
 func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error) {

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -862,6 +862,14 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 
 		require.NotEmpty(s.T(), event.Labels[toolchainv1alpha1.ToolchainEventActivationCodeLabelKey])
 
+		// Add some noise
+		for i := 0; i < 10; i++ {
+			noisyEvent, err := s.newToolchainEvent(5, false, ToolchainEventOptionActive)
+			require.NoError(s.T(), err)
+			err = s.FakeToolchainEventClient.Tracker.Add(noisyEvent)
+			require.NoError(s.T(), err)
+		}
+
 		// given
 		userID, err := uuid.NewV4()
 		require.NoError(s.T(), err)
@@ -871,9 +879,6 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 		ctx.Set(context.UsernameKey, "jackjones")
 		ctx.Set(context.SubKey, userID.String())
 		ctx.Set(context.EmailKey, "jjones1999@gmail.com")
-		ctx.Set(context.GivenNameKey, "jack")
-		ctx.Set(context.FamilyNameKey, "jones")
-		ctx.Set(context.CompanyKey, "red hat")
 
 		// when
 		userSignup, err := s.Application.SignupService().Activate(ctx, event.Labels[toolchainv1alpha1.ToolchainEventActivationCodeLabelKey])
@@ -902,9 +907,6 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 		ctx.Set(context.UsernameKey, "janetsmith")
 		ctx.Set(context.SubKey, userID.String())
 		ctx.Set(context.EmailKey, "jsmith@gmail.com")
-		ctx.Set(context.GivenNameKey, "janet")
-		ctx.Set(context.FamilyNameKey, "smith")
-		ctx.Set(context.CompanyKey, "red hat")
 		userSignup, err := s.Application.SignupService().Signup(ctx)
 		require.NoError(s.T(), err)
 
@@ -945,9 +947,6 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 		ctx.Set(context.UsernameKey, "bobjones")
 		ctx.Set(context.SubKey, userID.String())
 		ctx.Set(context.EmailKey, "bobjones1980@gmail.com")
-		ctx.Set(context.GivenNameKey, "bob")
-		ctx.Set(context.FamilyNameKey, "jones")
-		ctx.Set(context.CompanyKey, "red hat")
 
 		// when
 		userSignup, err := s.Application.SignupService().Activate(ctx, event.Labels[toolchainv1alpha1.ToolchainEventActivationCodeLabelKey])
@@ -976,9 +975,6 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 		ctx.Set(context.UsernameKey, "jilljones")
 		ctx.Set(context.SubKey, userID.String())
 		ctx.Set(context.EmailKey, "jilljones1992@gmail.com")
-		ctx.Set(context.GivenNameKey, "jill")
-		ctx.Set(context.FamilyNameKey, "jones")
-		ctx.Set(context.CompanyKey, "red hat")
 
 		// when
 		userSignup, err := s.Application.SignupService().Activate(ctx, event.Labels[toolchainv1alpha1.ToolchainEventActivationCodeLabelKey])
@@ -1007,9 +1003,6 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 		ctx.Set(context.UsernameKey, "hankjohnson")
 		ctx.Set(context.SubKey, userID.String())
 		ctx.Set(context.EmailKey, "hankjohnson@gmail.com")
-		ctx.Set(context.GivenNameKey, "hank")
-		ctx.Set(context.FamilyNameKey, "johnson")
-		ctx.Set(context.CompanyKey, "red hat")
 
 		// when
 		userSignup, err := s.Application.SignupService().Activate(ctx, event.Labels[toolchainv1alpha1.ToolchainEventActivationCodeLabelKey])
@@ -1046,9 +1039,6 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 		ctx.Set(context.UsernameKey, "hankjohnson")
 		ctx.Set(context.SubKey, userID.String())
 		ctx.Set(context.EmailKey, "hankjohnson@gmail.com")
-		ctx.Set(context.GivenNameKey, "hank")
-		ctx.Set(context.FamilyNameKey, "johnson")
-		ctx.Set(context.CompanyKey, "red hat")
 
 		// when
 		userSignup, err := s.Application.SignupService().Activate(ctx, "AAA-BBB-CCC")
@@ -1075,9 +1065,6 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 		ctx1.Set(context.UsernameKey, "user1")
 		ctx1.Set(context.SubKey, userID1.String())
 		ctx1.Set(context.EmailKey, "user1@gmail.com")
-		ctx1.Set(context.GivenNameKey, "user")
-		ctx1.Set(context.FamilyNameKey, "one")
-		ctx1.Set(context.CompanyKey, "red hat")
 
 		userID2, err := uuid.NewV4()
 		require.NoError(s.T(), err)
@@ -1086,9 +1073,6 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 		ctx2.Set(context.UsernameKey, "user2")
 		ctx2.Set(context.SubKey, userID2.String())
 		ctx2.Set(context.EmailKey, "user2@gmail.com")
-		ctx2.Set(context.GivenNameKey, "user")
-		ctx2.Set(context.FamilyNameKey, "two")
-		ctx2.Set(context.CompanyKey, "red hat")
 
 		userID3, err := uuid.NewV4()
 		require.NoError(s.T(), err)
@@ -1097,9 +1081,6 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 		ctx3.Set(context.UsernameKey, "user3")
 		ctx3.Set(context.SubKey, userID3.String())
 		ctx3.Set(context.EmailKey, "user3@gmail.com")
-		ctx3.Set(context.GivenNameKey, "user")
-		ctx3.Set(context.FamilyNameKey, "three")
-		ctx3.Set(context.CompanyKey, "red hat")
 
 		userSignup1, err := s.Application.SignupService().Activate(ctx1, event.Labels[toolchainv1alpha1.ToolchainEventActivationCodeLabelKey])
 		require.NoError(s.T(), err)
@@ -1113,6 +1094,26 @@ func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
 		require.Error(s.T(), err)
 		require.Equal(s.T(), "limit reached for activation code", err.Error())
 		require.Nil(s.T(), userSignup3)
+	})
+
+	s.Run("Test register user with no events fails", func() {
+		// given
+		userID, err := uuid.NewV4()
+		require.NoError(s.T(), err)
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "hankjohnson")
+		ctx.Set(context.SubKey, userID.String())
+		ctx.Set(context.EmailKey, "hankjohnson@gmail.com")
+
+		// when
+		userSignup, err := s.Application.SignupService().Activate(ctx, "F00-BAR")
+
+		// then
+		require.Error(s.T(), err)
+		require.Equal(s.T(), "invalid activation code", err.Error())
+		require.Nil(s.T(), userSignup)
 	})
 }
 
@@ -1179,7 +1180,7 @@ func (s *TestSignupServiceSuite) newProvisionedMUR() *toolchainv1alpha1.MasterUs
 	}
 }
 
-// ToolchainEventOptionIsActive sets the start time of the specified event to 24 hours in the past, the end time to
+// ToolchainEventOptionActive sets the start time of the specified event to 24 hours in the past, the end time to
 // 24 hours in the future, and sets the "Ready" condition to true
 func ToolchainEventOptionActive(event *toolchainv1alpha1.ToolchainEvent) {
 	now := time.Now()

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -845,6 +845,10 @@ func (s *TestSignupServiceSuite) TestUpdateUserSignup() {
 	})
 }
 
+func (s *TestSignupServiceSuite) TestRegisterByActivationCode() {
+
+}
+
 func (s *TestSignupServiceSuite) newUserSignupComplete() *toolchainv1alpha1.UserSignup {
 	return s.newUserSignupCompleteWithReason("")
 }

--- a/test/fake/toolchainevent_client.go
+++ b/test/fake/toolchainevent_client.go
@@ -60,7 +60,7 @@ func (c *FakeToolchainEventClient) ListByActivationCode(activationCode string) (
 		return c.MockListByActivationCode(activationCode)
 	}
 
-	obj := &crtapi.UserSignup{}
+	obj := &crtapi.ToolchainEvent{}
 	gvr, err := getGVRFromObject(obj, c.Scheme)
 	if err != nil {
 		return nil, err

--- a/test/fake/toolchainevent_client.go
+++ b/test/fake/toolchainevent_client.go
@@ -1,0 +1,92 @@
+package fake
+
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+type FakeToolchainEventClient struct { // nolint: golint
+	Tracker                  kubetesting.ObjectTracker
+	Scheme                   *runtime.Scheme
+	namespace                string
+	MockUpdate               func(*crtapi.ToolchainEvent) (*crtapi.ToolchainEvent, error)
+	MockListByActivationCode func(string) (*crtapi.ToolchainEventList, error)
+}
+
+func NewFakeToolchainEventClient(t *testing.T, namespace string, initObjs ...runtime.Object) *FakeToolchainEventClient {
+	clientScheme := runtime.NewScheme()
+	err := crtapi.SchemeBuilder.AddToScheme(clientScheme)
+	require.NoError(t, err, "Error adding to scheme")
+	crtapi.SchemeBuilder.Register(&crtapi.ToolchainEvent{}, &crtapi.ToolchainEventList{})
+
+	tracker := kubetesting.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
+	for _, obj := range initObjs {
+		err := tracker.Add(obj)
+		require.NoError(t, err, "failed to add object %v to fake toolchainevent client", obj)
+	}
+	return &FakeToolchainEventClient{
+		Tracker:   tracker,
+		Scheme:    clientScheme,
+		namespace: namespace,
+	}
+}
+
+func (c *FakeToolchainEventClient) Update(obj *crtapi.ToolchainEvent) (*crtapi.ToolchainEvent, error) {
+	if c.MockUpdate != nil {
+		return c.MockUpdate(obj)
+	}
+
+	gvr, err := getGVRFromObject(obj, c.Scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = c.Tracker.Update(gvr, obj, obj.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *FakeToolchainEventClient) ListByActivationCode(activationCode string) (*crtapi.ToolchainEventList, error) {
+	if c.MockListByActivationCode != nil {
+		return c.MockListByActivationCode(activationCode)
+	}
+
+	obj := &crtapi.UserSignup{}
+	gvr, err := getGVRFromObject(obj, c.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := c.Tracker.List(gvr, gvk, c.namespace)
+	if err != nil {
+		return nil, err
+	}
+	list := o.(*crtapi.ToolchainEventList)
+
+	objs := []crtapi.ToolchainEvent{}
+
+	for _, bu := range list.Items {
+		if bu.Labels[crtapi.ToolchainEventActivationCodeLabelKey] == activationCode {
+			objs = append(objs, bu)
+		}
+	}
+
+	return &crtapi.ToolchainEventList{
+			Items: objs,
+		},
+		nil
+}

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -31,6 +31,7 @@ type UnitTestSuite struct {
 	FakeUserSignupClient       *fake.FakeUserSignupClient
 	FakeMasterUserRecordClient *fake.FakeMasterUserRecordClient
 	FakeBannedUserClient       *fake.FakeBannedUserClient
+	FakeToolchainEventClient   *fake.FakeToolchainEventClient
 	FakeToolchainStatusClient  *fake.FakeToolchainStatusClient
 	factoryOptions             []factory.Option
 }
@@ -134,6 +135,7 @@ func (s *UnitTestSuite) TearDownSuite() {
 	s.FakeUserSignupClient = nil
 	s.FakeMasterUserRecordClient = nil
 	s.FakeBannedUserClient = nil
+	s.FakeToolchainEventClient = nil
 	s.FakeToolchainStatusClient = nil
 }
 
@@ -151,6 +153,10 @@ func (s *UnitTestSuite) MasterUserRecords() kubeclient.MasterUserRecordInterface
 
 func (s *UnitTestSuite) BannedUsers() kubeclient.BannedUserInterface {
 	return s.FakeBannedUserClient
+}
+
+func (s *UnitTestSuite) ToolchainEvents() kubeclient.ToolchainEventInterface {
+	return s.FakeToolchainEventClient
 }
 
 func (s *UnitTestSuite) ToolchainStatuses() kubeclient.ToolchainStatusInterface {

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -54,6 +54,7 @@ func (s *UnitTestSuite) SetupDefaultApplication() {
 	s.FakeUserSignupClient = fake.NewFakeUserSignupClient(s.T(), configuration.Namespace())
 	s.FakeMasterUserRecordClient = fake.NewFakeMasterUserRecordClient(s.T(), configuration.Namespace())
 	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(s.T(), configuration.Namespace())
+	s.FakeToolchainEventClient = fake.NewFakeToolchainEventClient(s.T(), configuration.Namespace())
 	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(s.T(), configuration.Namespace())
 	s.Application = fake.NewMockableApplication(s, s.factoryOptions...)
 }
@@ -63,6 +64,7 @@ func (s *UnitTestSuite) OverrideApplicationDefault(opts ...testconfig.ToolchainC
 	s.FakeUserSignupClient = fake.NewFakeUserSignupClient(s.T(), configuration.Namespace())
 	s.FakeMasterUserRecordClient = fake.NewFakeMasterUserRecordClient(s.T(), configuration.Namespace())
 	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(s.T(), configuration.Namespace())
+	s.FakeToolchainEventClient = fake.NewFakeToolchainEventClient(s.T(), configuration.Namespace())
 	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(s.T(), configuration.Namespace())
 	s.Application = fake.NewMockableApplication(s, s.factoryOptions...)
 }


### PR DESCRIPTION
This PR adds a new `/activate` endpoint to the registration service that allows a user to register for an event using an activation code.

Fixes https://issues.redhat.com/browse/CRT-1340