### PR TITLE
fix: set DefaultTransport for prod in proxy

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -169,7 +169,7 @@ func (p *Proxy) newReverseProxy(ctx *gin.Context, target *namespace.NamespaceAcc
 		// Replace token
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", target.SAToken))
 	}
-	var transport *http.Transport
+	transport := http.DefaultTransport
 	if !configuration.GetRegistrationServiceConfig().IsProdEnvironment() {
 		transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},


### PR DESCRIPTION
otherwise the proxy panics in prod
```
2021/12/14 13:55:01 http: panic serving 10.130.2.8:37876: runtime error: invalid memory address or nil pointer dereference
goroutine 3645 [running]:
net/http.(*conn).serve.func1(0xc000226640)
	/opt/hostedtoolcache/go/1.16.10/x64/src/net/http/server.go:1804 +0x153
panic(0x167f340, 0x2616860)
	/opt/hostedtoolcache/go/1.16.10/x64/src/runtime/panic.go:971 +0x499
net/http.(*Transport).roundTrip(0x0, 0xc001085b00, 0x1631fe0, 0xc000eaab01, 0xc00027ef10)
	/opt/hostedtoolcache/go/1.16.10/x64/src/net/http/transport.go:503 +0x3a
net/http.(*Transport).RoundTrip(0x0, 0xc001085b00, 0x1841fdb, 0xf, 0xc00027efb0)
	/opt/hostedtoolcache/go/1.16.10/x64/src/net/http/roundtrip.go:17 +0x35
net/http/httputil.(*ReverseProxy).ServeHTTP(0xc00033c4b0, 0x1c360b0, 0xc00091a000, 0xc001084000)
	/opt/hostedtoolcache/go/1.16.10/x64/src/net/http/httputil/reverseproxy.go:293 +0x337
github.com/codeready-toolchain/registration-service/pkg/proxy.(*Proxy).handleRequestAndRedirect(0xc0000c6dc0, 0x1c360b0, 0xc00091a000, 0xc001084000)
	/home/runner/work/registration-service/registration-service/pkg/proxy/proxy.go:104 +0x2da
net/http.HandlerFunc.ServeHTTP(0xc0000c6e40, 0x1c360b0, 0xc00091a000, 0xc001084000)
	/opt/hostedtoolcache/go/1.16.10/x64/src/net/http/server.go:2049 +0x44
net/http.(*ServeMux).ServeHTTP(0xc000d10140, 0x1c360b0, 0xc00091a000, 0xc001084000)
	/opt/hostedtoolcache/go/1.16.10/x64/src/net/http/server.go:2428 +0x1ad
net/http.serverHandler.ServeHTTP(0xc000e60000, 0x1c360b0, 0xc00091a000, 0xc001084000)
	/opt/hostedtoolcache/go/1.16.10/x64/src/net/http/server.go:2867 +0xa3
net/http.(*conn).serve(0xc000226640, 0x1c38c80, 0xc00042c280)
	/opt/hostedtoolcache/go/1.16.10/x64/src/net/http/server.go:1932 +0x8cd
created by net/http.(*Server).Serve
	/opt/hostedtoolcache/go/1.16.10/x64/src/net/http/server.go:2993 +0x39b
```