### PR TITLE
refactor: log messages

### DIFF
--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -45,7 +45,7 @@ func (s *Signup) PostHandler(ctx *gin.Context) {
 		return
 	}
 
-	log.Infof(ctx, "UserSignup %s created", userSignup.Name)
+	log.Infof(ctx, "UserSignup %s created or reactivated", userSignup.Name)
 	ctx.Status(http.StatusAccepted)
 	ctx.Writer.WriteHeaderNow()
 }
@@ -109,7 +109,7 @@ func (s *Signup) GetHandler(ctx *gin.Context) {
 		errors.AbortWithError(ctx, http.StatusInternalServerError, err, "error getting UserSignup resource")
 	}
 	if signupResource == nil {
-		log.Errorf(ctx, nil, "UserSignup resource for userID: %s resource not found", userID)
+		log.Infof(ctx, "UserSignup resource for userID: %s resource not found", userID)
 		ctx.AbortWithStatus(http.StatusNotFound)
 	} else {
 		ctx.JSON(http.StatusOK, signupResource)

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/application"
 	"github.com/codeready-toolchain/registration-service/pkg/context"
 	"github.com/codeready-toolchain/registration-service/pkg/errors"
@@ -45,7 +46,11 @@ func (s *Signup) PostHandler(ctx *gin.Context) {
 		return
 	}
 
-	log.Infof(ctx, "UserSignup %s created or reactivated", userSignup.Name)
+	if _, exists := userSignup.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey]; exists {
+		log.Infof(ctx, "UserSignup created: %s", userSignup.Name)
+	} else {
+		log.Infof(ctx, "UserSignup reactivated: %s", userSignup.Name)
+	}
 	ctx.Status(http.StatusAccepted)
 	ctx.Writer.WriteHeaderNow()
 }

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -46,7 +46,7 @@ func (s *Signup) PostHandler(ctx *gin.Context) {
 		return
 	}
 
-	if _, exists := userSignup.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey]; exists {
+	if _, exists := userSignup.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey]; !exists {
 		log.Infof(ctx, "UserSignup created: %s", userSignup.Name)
 	} else {
 		log.Infof(ctx, "UserSignup reactivated: %s", userSignup.Name)


### PR DESCRIPTION
2 changes to improve the result of log queries on our monitoring platform:
- when a user is reactivated, the logs should not contain a message such
as: "user <name> created", but instead, "user <name> created or reactivated"
- when a user is not found (because it's her first time on the platform),
the level of the log message should not be "error" but "info", since it's not
an error per-se.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
