### PR TITLE
chore: update api and common modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20220106110828-7a9658006b9d
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20220106135935-9e2e34caa1ab
+
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/codeready-toolchain/registration-service
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20220105073825-91ab6024979a
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220105083637-4cdf4132d9c1
+	github.com/codeready-toolchain/api v0.0.0-20220110101730-04d30e90a574
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220110102259-392256a24155
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1
 	github.com/gin-gonic/gin v1.7.2
@@ -36,9 +36,5 @@ require (
 	k8s.io/klog/v2 v2.8.0
 	sigs.k8s.io/controller-runtime v0.8.3
 )
-
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20220106110828-7a9658006b9d
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20220106135935-9e2e34caa1ab
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -90,11 +90,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20211206130419-fedaada130c4/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/api v0.0.0-20220105073825-91ab6024979a h1:+e/fFBmNIQ5qn4d6p9jV137gts5URvK2IAbLlQTNB/g=
-github.com/codeready-toolchain/api v0.0.0-20220105073825-91ab6024979a/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220105083637-4cdf4132d9c1 h1:kC3cyS0ZJUfI8Glzewf3oH611MABP6mvQNhFFHE1Vdk=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220105083637-4cdf4132d9c1/go.mod h1:sgXpNSR/cfGvhxJsweAsnNeYZ/0ZEZL3y1zmw0VHXFI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -551,6 +546,10 @@ github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/xcoulon/api v0.0.0-20220106110828-7a9658006b9d h1:KT7zBmPjGKiqF7kdAvsThamq66YTAOsn85oiNtrVg+g=
+github.com/xcoulon/api v0.0.0-20220106110828-7a9658006b9d/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/xcoulon/toolchain-common v0.0.0-20220106135935-9e2e34caa1ab h1:R1PTx7TBz9ZAIyHwDdu/2JrY1YMIHBx8Gj5AUMWKkvw=
+github.com/xcoulon/toolchain-common v0.0.0-20220106135935-9e2e34caa1ab/go.mod h1:pj+p15jW9ZnjuoGLyny80IpPTjsPRw+AfhwiiNQHCRE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,10 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/codeready-toolchain/api v0.0.0-20220110101730-04d30e90a574 h1:xjmJjUvjGOW42y4Wd/l6qHkoRAfNiQ5C6PbCWUlXqoo=
+github.com/codeready-toolchain/api v0.0.0-20220110101730-04d30e90a574/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220110102259-392256a24155 h1:pgIv+T2J4BK4BvxJCIkcqeuk8Xsrq2n8VG4UspRYEhs=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220110102259-392256a24155/go.mod h1:6fAhxW0MpXz2KgrNT+12zodepWFqNSOJcy6H2Ip4kV8=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -546,10 +550,6 @@ github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/xcoulon/api v0.0.0-20220106110828-7a9658006b9d h1:KT7zBmPjGKiqF7kdAvsThamq66YTAOsn85oiNtrVg+g=
-github.com/xcoulon/api v0.0.0-20220106110828-7a9658006b9d/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/xcoulon/toolchain-common v0.0.0-20220106135935-9e2e34caa1ab h1:R1PTx7TBz9ZAIyHwDdu/2JrY1YMIHBx8Gj5AUMWKkvw=
-github.com/xcoulon/toolchain-common v0.0.0-20220106135935-9e2e34caa1ab/go.mod h1:pj+p15jW9ZnjuoGLyny80IpPTjsPRw+AfhwiiNQHCRE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
includes removal of custom templates in NSTemplateSet

See also:
- https://github.com/codeready-toolchain/api/pull/284
- https://github.com/codeready-toolchain/toolchain-common/pull/227

Fixes https://issues.redhat.com/browse/CRT-1382

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
