### PR TITLE
fix: log an error when verification code cannot be sent

### DIFF
--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -88,7 +88,7 @@ func (s *Signup) InitVerificationHandler(ctx *gin.Context) {
 	e164Number := phonenumbers.Format(number, phonenumbers.E164)
 	err = s.app.VerificationService().InitVerification(ctx, userID, e164Number)
 	if err != nil {
-		log.Errorf(ctx, nil, "Verification for %s could not be sent", userID)
+		log.Errorf(ctx, err, "Verification for %s could not be sent", userID)
 		switch t := err.(type) {
 		case *errors.Error:
 			errors.AbortWithError(ctx, int(t.Code), err, t.Message)


### PR DESCRIPTION
 log an error when verification code cannot be sent, otherwise, we don't know what was the cause of the failure 