### PR TITLE
Modify registration service to support locating UserSignup by username if userID lookup fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/registration-service
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220210004531-4c2368ecebee
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1
 	github.com/gin-gonic/gin v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574 h1:lwAkKKU
 github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084 h1:9V+OvCQU9h7V3W6bx0hhqO3JQL/hyENwuRPeq24XYf4=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084/go.mod h1:+wXPryRgWG13u0OQ1iv8ZxjLdEV0VwomkVceAu2bRKI=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220210004531-4c2368ecebee h1:fNc9lAP2Ef49yKtcw1ll/Y3jdQkW64Rzpa5HmIHf8vc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220210004531-4c2368ecebee/go.mod h1:+wXPryRgWG13u0OQ1iv8ZxjLdEV0VwomkVceAu2bRKI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -9,8 +9,8 @@ import (
 
 type SignupService interface {
 	Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error)
-	GetSignup(userID string) (*signup.Signup, error)
-	GetUserSignup(userID string) (*toolchainv1alpha1.UserSignup, error)
+	GetSignup(userID, username string) (*signup.Signup, error)
+	GetUserSignup(userID, username string) (*toolchainv1alpha1.UserSignup, error)
 	UpdateUserSignup(userSignup *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error)
 	PhoneNumberAlreadyInUse(userID, phoneNumberOrHash string) error
 }

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -12,7 +12,7 @@ type SignupService interface {
 	GetSignup(userID, username string) (*signup.Signup, error)
 	GetUserSignup(userID, username string) (*toolchainv1alpha1.UserSignup, error)
 	UpdateUserSignup(userSignup *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error)
-	PhoneNumberAlreadyInUse(userID, phoneNumberOrHash string) error
+	PhoneNumberAlreadyInUse(userID, username, phoneNumberOrHash string) error
 }
 
 type VerificationService interface {

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -16,8 +16,8 @@ type SignupService interface {
 }
 
 type VerificationService interface {
-	InitVerification(ctx *gin.Context, userID string, e164PhoneNumber string) error
-	VerifyCode(ctx *gin.Context, userID string, code string) error
+	InitVerification(ctx *gin.Context, userID, username, e164PhoneNumber string) error
+	VerifyCode(ctx *gin.Context, userID, username, code string) error
 }
 
 type MemberClusterService interface {

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -21,7 +21,7 @@ type VerificationService interface {
 }
 
 type MemberClusterService interface {
-	GetNamespace(ctx *gin.Context, userID string) (*namespace.NamespaceAccess, error)
+	GetNamespace(ctx *gin.Context, userID, username string) (*namespace.NamespaceAccess, error)
 }
 
 type Services interface {

--- a/pkg/auth/tokenparser.go
+++ b/pkg/auth/tokenparser.go
@@ -19,14 +19,14 @@ const leeway = 5000
 
 // TokenClaims represents access token claims
 type TokenClaims struct {
-	Name          string `json:"name"`
-	Username      string `json:"preferred_username"`
-	GivenName     string `json:"given_name"`
-	FamilyName    string `json:"family_name"`
-	Email         string `json:"email"`
-	EmailVerified bool   `json:"email_verified"`
-	Company       string `json:"company"`
-	OriginalSub   string `json:"original_sub"`
+	Name              string `json:"name"`
+	PreferredUsername string `json:"preferred_username"`
+	GivenName         string `json:"given_name"`
+	FamilyName        string `json:"family_name"`
+	Email             string `json:"email"`
+	EmailVerified     bool   `json:"email_verified"`
+	Company           string `json:"company"`
+	OriginalSub       string `json:"original_sub"`
 	jwt.StandardClaims
 }
 
@@ -82,7 +82,7 @@ func (tp *TokenParser) FromString(jwtEncoded string) (*TokenClaims, error) {
 	}
 	if claims, ok := token.Claims.(*TokenClaims); ok && token.Valid {
 		// we need username and email, so check if those are contained in the claims
-		if claims.Username == "" {
+		if claims.PreferredUsername == "" {
 			return nil, errors.New("token does not comply to expected claims: username missing")
 		}
 		if claims.Email == "" {

--- a/pkg/auth/tokenparser_test.go
+++ b/pkg/auth/tokenparser_test.go
@@ -102,7 +102,7 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 			s.Run(tt.name, func() {
 				claims, err := tokenParser.FromString(tt.jwt)
 				require.NoError(s.T(), err)
-				require.Equal(s.T(), tt.username, claims.Username)
+				require.Equal(s.T(), tt.username, claims.PreferredUsername)
 				require.Equal(s.T(), tt.email, claims.Email)
 			})
 		}
@@ -303,7 +303,7 @@ func (s *TestTokenParserSuite) TestTokenParser() {
 
 		claims, err := tokenParser.FromString(jwt0)
 		require.NoError(s.T(), err)
-		require.Equal(s.T(), identity0.Username, claims.Username)
+		require.Equal(s.T(), identity0.Username, claims.PreferredUsername)
 		require.Equal(s.T(), email0, claims.Email)
 		require.Equal(s.T(), "OriginalSubValue:1234-ABCD", claims.OriginalSub)
 	})

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -117,7 +117,7 @@ func (s *Signup) GetHandler(ctx *gin.Context) {
 		crterrors.AbortWithError(ctx, http.StatusInternalServerError, err, "error getting UserSignup resource")
 	}
 	if signupResource == nil {
-		log.Infof(ctx, "UserSignup resource for userID: %s resource not found", userID)
+		log.Infof(ctx, "UserSignup resource for userID: %s, username: %s resource not found", userID, username)
 		ctx.AbortWithStatus(http.StatusNotFound)
 	} else {
 		ctx.JSON(http.StatusOK, signupResource)

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -86,7 +86,7 @@ func (s *Signup) InitVerificationHandler(ctx *gin.Context) {
 	}
 
 	e164Number := phonenumbers.Format(number, phonenumbers.E164)
-	err = s.app.VerificationService().InitVerification(ctx, userID, e164Number)
+	err = s.app.VerificationService().InitVerification(ctx, userID, "", e164Number)
 	if err != nil {
 		log.Errorf(ctx, err, "Verification for %s could not be sent", userID)
 		e := &crterrors.Error{}
@@ -109,7 +109,8 @@ func (s *Signup) GetHandler(ctx *gin.Context) {
 
 	// Get the UserSignup resource from the service by the userID
 	userID := ctx.GetString(context.SubKey)
-	signupResource, err := s.app.SignupService().GetSignup(userID)
+	username := ctx.GetString(context.UsernameKey)
+	signupResource, err := s.app.SignupService().GetSignup(userID, username)
 	if err != nil {
 		log.Error(ctx, err, "error getting UserSignup resource")
 		crterrors.AbortWithError(ctx, http.StatusInternalServerError, err, "error getting UserSignup resource")
@@ -133,7 +134,7 @@ func (s *Signup) VerifyCodeHandler(ctx *gin.Context) {
 
 	userID := ctx.GetString(context.SubKey)
 
-	err := s.app.VerificationService().VerifyCode(ctx, userID, code)
+	err := s.app.VerificationService().VerifyCode(ctx, userID, "", code)
 	if err != nil {
 		log.Error(ctx, err, "error validating user verification code")
 		e := &crterrors.Error{}

--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -61,6 +61,7 @@ func (s *Signup) PostHandler(ctx *gin.Context) {
 // provided by the user.
 func (s *Signup) InitVerificationHandler(ctx *gin.Context) {
 	userID := ctx.GetString(context.SubKey)
+	username := ctx.GetString(context.UsernameKey)
 
 	// Read the Body content
 	var phone Phone
@@ -86,7 +87,7 @@ func (s *Signup) InitVerificationHandler(ctx *gin.Context) {
 	}
 
 	e164Number := phonenumbers.Format(number, phonenumbers.E164)
-	err = s.app.VerificationService().InitVerification(ctx, userID, "", e164Number)
+	err = s.app.VerificationService().InitVerification(ctx, userID, username, e164Number)
 	if err != nil {
 		log.Errorf(ctx, err, "Verification for %s could not be sent", userID)
 		e := &crterrors.Error{}
@@ -133,8 +134,9 @@ func (s *Signup) VerifyCodeHandler(ctx *gin.Context) {
 	}
 
 	userID := ctx.GetString(context.SubKey)
+	username := ctx.GetString(context.UsernameKey)
 
-	err := s.app.VerificationService().VerifyCode(ctx, userID, "", code)
+	err := s.app.VerificationService().VerifyCode(ctx, userID, username, code)
 	if err != nil {
 		log.Error(ctx, err, "error validating user verification code")
 		e := &crterrors.Error{}

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -448,7 +448,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 			MockUpdateUserSignup: func(userSignup *crtapi.UserSignup) (userSignup2 *crtapi.UserSignup, e error) {
 				return userSignup, nil
 			},
-			MockPhoneNumberAlreadyInUse: func(userID, e164phoneNumber string) error {
+			MockPhoneNumberAlreadyInUse: func(userID, username, e164phoneNumber string) error {
 				return nil
 			},
 		}
@@ -729,7 +729,7 @@ type FakeSignupService struct {
 	MockSignup                  func(ctx *gin.Context) (*crtapi.UserSignup, error)
 	MockGetUserSignup           func(userID, username string) (*crtapi.UserSignup, error)
 	MockUpdateUserSignup        func(userSignup *crtapi.UserSignup) (*crtapi.UserSignup, error)
-	MockPhoneNumberAlreadyInUse func(userID, value string) error
+	MockPhoneNumberAlreadyInUse func(userID, username, value string) error
 }
 
 func (m *FakeSignupService) GetSignup(userID, username string) (*signup.Signup, error) {
@@ -748,6 +748,6 @@ func (m *FakeSignupService) UpdateUserSignup(userSignup *crtapi.UserSignup) (*cr
 	return m.MockUpdateUserSignup(userSignup)
 }
 
-func (m *FakeSignupService) PhoneNumberAlreadyInUse(userID, e164phoneNumber string) error {
-	return m.MockPhoneNumberAlreadyInUse(userID, e164phoneNumber)
+func (m *FakeSignupService) PhoneNumberAlreadyInUse(userID, username, e164phoneNumber string) error {
+	return m.MockPhoneNumberAlreadyInUse(userID, username, e164phoneNumber)
 }

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -691,7 +691,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 			Key:   "code",
 			Value: "999127",
 		}
-		rr := initVerification(s.T(), handler, param, nil, otherUserSignup.Spec.Userid, otherUserSignup.Spec.Username, http.MethodGet, "/api/v1/signup/verification")
+		rr := initVerification(s.T(), handler, param, nil, "", otherUserSignup.Spec.Username, http.MethodGet, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusOK, rr.Code)

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -201,7 +201,7 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 				Reason: "Provisioning",
 			},
 		}
-		svc.MockGetSignup = func(id string) (*signup.Signup, error) {
+		svc.MockGetSignup = func(id, username string) (*signup.Signup, error) {
 			if id == userID {
 				return expected, nil
 			}
@@ -228,7 +228,7 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 		ctx.Request = req
 		ctx.Set(context.SubKey, userID)
 
-		svc.MockGetSignup = func(id string) (*signup.Signup, error) {
+		svc.MockGetSignup = func(id, username string) (*signup.Signup, error) {
 			return nil, nil
 		}
 
@@ -245,7 +245,7 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 		ctx.Request = req
 		ctx.Set(context.SubKey, userID)
 
-		svc.MockGetSignup = func(id string) (*signup.Signup, error) {
+		svc.MockGetSignup = func(id, username string) (*signup.Signup, error) {
 			return nil, errors.New("oopsie woopsie")
 		}
 
@@ -429,7 +429,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 
 		// Create a mock SignupService
 		svc := &FakeSignupService{
-			MockGetUserSignup: func(userID string) (userSignup *crtapi.UserSignup, e error) {
+			MockGetUserSignup: func(userID, username string) (userSignup *crtapi.UserSignup, e error) {
 				us := crtapi.UserSignup{
 					TypeMeta: v1.TypeMeta{},
 					ObjectMeta: v1.ObjectMeta{
@@ -674,23 +674,23 @@ func initVerification(t *testing.T, handler gin.HandlerFunc, params gin.Param, d
 }
 
 type FakeSignupService struct {
-	MockGetSignup               func(userID string) (*signup.Signup, error)
+	MockGetSignup               func(userID, username string) (*signup.Signup, error)
 	MockSignup                  func(ctx *gin.Context) (*crtapi.UserSignup, error)
-	MockGetUserSignup           func(userID string) (*crtapi.UserSignup, error)
+	MockGetUserSignup           func(userID, username string) (*crtapi.UserSignup, error)
 	MockUpdateUserSignup        func(userSignup *crtapi.UserSignup) (*crtapi.UserSignup, error)
 	MockPhoneNumberAlreadyInUse func(userID, value string) error
 }
 
-func (m *FakeSignupService) GetSignup(userID string) (*signup.Signup, error) {
-	return m.MockGetSignup(userID)
+func (m *FakeSignupService) GetSignup(userID, username string) (*signup.Signup, error) {
+	return m.MockGetSignup(userID, username)
 }
 
 func (m *FakeSignupService) Signup(ctx *gin.Context) (*crtapi.UserSignup, error) {
 	return m.MockSignup(ctx)
 }
 
-func (m *FakeSignupService) GetUserSignup(userID string) (*crtapi.UserSignup, error) {
-	return m.MockGetUserSignup(userID)
+func (m *FakeSignupService) GetUserSignup(userID, username string) (*crtapi.UserSignup, error) {
+	return m.MockGetUserSignup(userID, username)
 }
 
 func (m *FakeSignupService) UpdateUserSignup(userSignup *crtapi.UserSignup) (*crtapi.UserSignup, error) {

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -300,7 +300,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 			BodyString("")
 
 		data := []byte(fmt.Sprintf(`{"phone_number": "%s", "country_code": "1"}`, phoneNumber))
-		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, http.MethodPut, "/api/v1/signup/verification")
+		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, "", http.MethodPut, "/api/v1/signup/verification")
 		require.Equal(s.T(), http.StatusNoContent, rr.Code)
 
 		updatedUserSignup, err := s.FakeUserSignupClient.Get(userSignup.Name)
@@ -333,7 +333,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 			BodyString("")
 
 		data := []byte(`{"phone_number": "2268213044", "country_code": "(1)"}`)
-		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, http.MethodPut, "/api/v1/signup/verification")
+		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, "", http.MethodPut, "/api/v1/signup/verification")
 		require.Equal(s.T(), http.StatusBadRequest, rr.Code)
 
 		bodyParams := make(map[string]interface{})
@@ -347,7 +347,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 	})
 	s.Run("init verification request body could not be read", func() {
 		data := []byte(`{"test_number": "2268213044", "test_code": "1"}`)
-		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, http.MethodPut, "/api/v1/signup/verification")
+		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, "", http.MethodPut, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
@@ -372,7 +372,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 		defer s.SetConfig(testconfig.RegistrationService().Verification().DailyLimit(originalValue))
 
 		data := []byte(`{"phone_number": "2268213044", "country_code": "1"}`)
-		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, http.MethodPut, "/api/v1/signup/verification")
+		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, "", http.MethodPut, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		assert.Equal(s.T(), http.StatusForbidden, rr.Code, "handler returned wrong status code")
@@ -406,7 +406,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 		handler := gin.HandlerFunc(ctrl.InitVerificationHandler)
 
 		data := []byte(`{"phone_number": "2268213044", "country_code": "1"}`)
-		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, http.MethodPut, "/api/v1/signup/verification")
+		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, "", http.MethodPut, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
@@ -461,7 +461,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 
 		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
 		data := []byte(`{"phone_number": "!226%213044", "country_code": "1"}`)
-		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, http.MethodPut, "/api/v1/signup/verification")
+		rr := initVerification(s.T(), handler, gin.Param{}, data, userID, "", http.MethodPut, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
@@ -502,7 +502,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 			Key:   "code",
 			Value: "999888",
 		}
-		rr := initVerification(s.T(), handler, param, nil, userID, http.MethodGet, "/api/v1/signup/verification")
+		rr := initVerification(s.T(), handler, param, nil, userID, "", http.MethodGet, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusOK, rr.Code)
@@ -532,7 +532,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 			Key:   "code",
 			Value: "111233",
 		}
-		rr := initVerification(s.T(), handler, param, nil, userID, http.MethodGet, "/api/v1/signup/verification")
+		rr := initVerification(s.T(), handler, param, nil, userID, "", http.MethodGet, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusInternalServerError, rr.Code)
@@ -562,7 +562,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 			Key:   "code",
 			Value: "111233",
 		}
-		rr := initVerification(s.T(), handler, param, nil, userID, http.MethodGet, "/api/v1/signup/verification/111233")
+		rr := initVerification(s.T(), handler, param, nil, userID, "", http.MethodGet, "/api/v1/signup/verification/111233")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusNotFound, rr.Code)
@@ -591,7 +591,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 			Key:   "code",
 			Value: "555555",
 		}
-		rr := initVerification(s.T(), handler, param, nil, userID, http.MethodGet, "/api/v1/signup/verification/555555")
+		rr := initVerification(s.T(), handler, param, nil, userID, "", http.MethodGet, "/api/v1/signup/verification/555555")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusInternalServerError, rr.Code)
@@ -627,7 +627,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 			Key:   "code",
 			Value: "333333",
 		}
-		rr := initVerification(s.T(), handler, param, nil, userID, http.MethodGet, "/api/v1/signup/verification/333333")
+		rr := initVerification(s.T(), handler, param, nil, userID, "", http.MethodGet, "/api/v1/signup/verification/333333")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusTooManyRequests, rr.Code)
@@ -651,14 +651,64 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 			Key:   "code",
 			Value: "",
 		}
-		rr := initVerification(s.T(), handler, param, nil, userID, http.MethodGet, "/api/v1/signup/verification/")
+		rr := initVerification(s.T(), handler, param, nil, userID, "", http.MethodGet, "/api/v1/signup/verification/")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusBadRequest, rr.Code)
 	})
+
+	s.Run("usersignup stored by its username", func() {
+		// Create another UserSignup
+		otherUserID := uuid.Must(uuid.NewV4()).String()
+
+		otherUserSignup := &crtapi.UserSignup{
+			TypeMeta: v1.TypeMeta{},
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "jsmith",
+				Namespace: configuration.Namespace(),
+				Annotations: map[string]string{
+					crtapi.UserSignupUserEmailAnnotationKey:        "jsmith@acme.com",
+					crtapi.UserVerificationAttemptsAnnotationKey:   "0",
+					crtapi.UserSignupVerificationCodeAnnotationKey: "999127",
+					crtapi.UserVerificationExpiryAnnotationKey:     time.Now().Add(10 * time.Second).Format(service.TimestampLayout),
+				},
+			},
+			Spec: crtapi.UserSignupSpec{
+				Userid:   otherUserID,
+				Username: "jsmith",
+			},
+			Status: crtapi.UserSignupStatus{},
+		}
+
+		err = s.FakeUserSignupClient.Tracker.Add(otherUserSignup)
+		require.NoError(s.T(), err)
+
+		// Create Signup controller instance.
+		ctrl := controller.NewSignup(s.Application)
+		handler := gin.HandlerFunc(ctrl.VerifyCodeHandler)
+
+		param := gin.Param{
+			Key:   "code",
+			Value: "999127",
+		}
+		rr := initVerification(s.T(), handler, param, nil, otherUserSignup.Spec.Userid, otherUserSignup.Spec.Username, http.MethodGet, "/api/v1/signup/verification")
+
+		// Check the status code is what we expect.
+		require.Equal(s.T(), http.StatusOK, rr.Code)
+
+		updatedUserSignup, err := s.FakeUserSignupClient.Get(otherUserSignup.Name)
+		require.NoError(s.T(), err)
+
+		// Check that the correct UserSignup is passed into the FakeSignupService for update
+		require.False(s.T(), states.VerificationRequired(updatedUserSignup))
+		require.Empty(s.T(), updatedUserSignup.Annotations[crtapi.UserVerificationAttemptsAnnotationKey])
+		require.Empty(s.T(), updatedUserSignup.Annotations[crtapi.UserSignupVerificationCodeAnnotationKey])
+		require.Empty(s.T(), updatedUserSignup.Annotations[crtapi.UserVerificationExpiryAnnotationKey])
+
+	})
 }
 
-func initVerification(t *testing.T, handler gin.HandlerFunc, params gin.Param, data []byte, userID, httpMethod, url string) *httptest.ResponseRecorder {
+func initVerification(t *testing.T, handler gin.HandlerFunc, params gin.Param, data []byte, userID, username, httpMethod, url string) *httptest.ResponseRecorder {
 	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
 	rr := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(rr)
@@ -666,6 +716,7 @@ func initVerification(t *testing.T, handler gin.HandlerFunc, params gin.Param, d
 	require.NoError(t, err)
 	ctx.Request = req
 	ctx.Set(context.SubKey, userID)
+	ctx.Set(context.UsernameKey, username)
 
 	ctx.Params = append(ctx.Params, params)
 	handler(ctx)

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -68,7 +68,7 @@ func (m *JWTMiddleware) HandlerFunc() gin.HandlerFunc {
 		}
 		// all checks done, add username, subject and email to the context.
 		// the tokenparser has already checked these claims are in the token at this point.
-		c.Set(context.UsernameKey, token.Username)
+		c.Set(context.UsernameKey, token.PreferredUsername)
 		c.Set(context.EmailKey, token.Email)
 		c.Set(context.SubKey, token.Subject)
 		c.Set(context.OriginalSubKey, token.OriginalSub)

--- a/pkg/proxy/cache.go
+++ b/pkg/proxy/cache.go
@@ -16,7 +16,7 @@ func NewUserNamespaces(app application.Application) *UserNamespaces {
 	}
 }
 
-func (c *UserNamespaces) GetNamespace(ctx *gin.Context, userID string) (*namespace.NamespaceAccess, error) {
+func (c *UserNamespaces) GetNamespace(ctx *gin.Context, userID, username string) (*namespace.NamespaceAccess, error) {
 	// TODO implement cache
-	return c.app.MemberClusterService().GetNamespace(ctx, userID)
+	return c.app.MemberClusterService().GetNamespace(ctx, userID, username)
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -132,7 +132,8 @@ func (p *Proxy) createContext(req *http.Request) (*gin.Context, error) {
 
 func (p *Proxy) getTargetNamespace(ctx *gin.Context) (*namespace.NamespaceAccess, error) {
 	userID := ctx.GetString(context.SubKey)
-	return p.namespaces.GetNamespace(ctx, userID)
+	username := ctx.GetString(context.UsernameKey)
+	return p.namespaces.GetNamespace(ctx, userID, username)
 }
 
 func (p *Proxy) extractUserID(req *http.Request) (string, error) {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -496,6 +496,6 @@ type fakeClusterService struct {
 	fakeApp *fakeApp
 }
 
-func (f *fakeClusterService) GetNamespace(_ *gin.Context, userID string) (*namespace.NamespaceAccess, error) {
+func (f *fakeClusterService) GetNamespace(_ *gin.Context, userID, username string) (*namespace.NamespaceAccess, error) {
 	return f.fakeApp.namespaces[userID], f.fakeApp.err
 }

--- a/pkg/proxy/service/cluster_service.go
+++ b/pkg/proxy/service/cluster_service.go
@@ -40,9 +40,9 @@ func NewMemberClusterService(context servicecontext.ServiceContext, options ...O
 	return si
 }
 
-func (s *ServiceImpl) GetNamespace(ctx *gin.Context, userID string) (*namespace.NamespaceAccess, error) {
+func (s *ServiceImpl) GetNamespace(ctx *gin.Context, userID, username string) (*namespace.NamespaceAccess, error) {
 	// Get Signup
-	signup, err := s.ServiceContext.Services().SignupService().GetSignup(userID, "")
+	signup, err := s.ServiceContext.Services().SignupService().GetSignup(userID, username)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proxy/service/cluster_service.go
+++ b/pkg/proxy/service/cluster_service.go
@@ -42,7 +42,7 @@ func NewMemberClusterService(context servicecontext.ServiceContext, options ...O
 
 func (s *ServiceImpl) GetNamespace(ctx *gin.Context, userID string) (*namespace.NamespaceAccess, error) {
 	// Get Signup
-	signup, err := s.ServiceContext.Services().SignupService().GetSignup(userID)
+	signup, err := s.ServiceContext.Services().SignupService().GetSignup(userID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -87,7 +87,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 			}
 
 			// when
-			_, err := svc.GetNamespace(ctx, "789-ready")
+			_, err := svc.GetNamespace(ctx, "789-ready", "")
 
 			// then
 			require.EqualError(s.T(), err, "oopsi woopsi")
@@ -97,7 +97,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 
 		s.Run("user is not found", func() {
 			// when
-			_, err := svc.GetNamespace(ctx, "unknown_id")
+			_, err := svc.GetNamespace(ctx, "unknown_id", "")
 
 			// then
 			require.EqualError(s.T(), err, "user is not (yet) provisioned")
@@ -105,7 +105,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 
 		s.Run("user is not provisioned yet", func() {
 			// when
-			_, err := svc.GetNamespace(ctx, "456-not-ready")
+			_, err := svc.GetNamespace(ctx, "456-not-ready", "")
 
 			// then
 			require.EqualError(s.T(), err, "user is not (yet) provisioned")
@@ -127,7 +127,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 			)
 
 			// when
-			_, err := svc.GetNamespace(ctx, "789-ready")
+			_, err := svc.GetNamespace(ctx, "789-ready", "")
 
 			// then
 			require.EqualError(s.T(), err, "no member clusters found")
@@ -147,7 +147,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 			)
 
 			// when
-			_, err := svc.GetNamespace(ctx, "012-ready-unknown-cluster")
+			_, err := svc.GetNamespace(ctx, "012-ready-unknown-cluster", "")
 
 			// then
 			require.EqualError(s.T(), err, "no member cluster found for the user")
@@ -204,7 +204,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 				}
 
 				// when
-				_, err := svc.GetNamespace(ctx, "789-ready")
+				_, err := svc.GetNamespace(ctx, "789-ready", "")
 
 				// then
 				require.EqualError(s.T(), err, "can't obtain SA")
@@ -216,7 +216,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 				}
 
 				// when
-				_, err := svc.GetNamespace(ctx, "789-ready")
+				_, err := svc.GetNamespace(ctx, "789-ready", "")
 
 				// then
 				require.EqualError(s.T(), err, "no SA found for the user")
@@ -242,7 +242,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 				}
 
 				// when
-				_, err := svc.GetNamespace(ctx, "789-ready")
+				_, err := svc.GetNamespace(ctx, "789-ready", "")
 
 				// then
 				require.EqualError(s.T(), err, "can't obtain secret")
@@ -291,7 +291,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 			require.NoError(s.T(), memberClient.Create(context.TODO(), scr3))
 
 			// when
-			ns, err := svc.GetNamespace(ctx, "789-ready")
+			ns, err := svc.GetNamespace(ctx, "789-ready", "")
 
 			// then
 			require.NoError(s.T(), err)
@@ -343,11 +343,11 @@ func newFakeSignupService() *fakeSignupService {
 	return f
 }
 
-func (m *fakeSignupService) addSignup(userID string, userSignup *signup.Signup) *fakeSignupService {
+func (m *fakeSignupService) addSignup(identifier string, userSignup *signup.Signup) *fakeSignupService {
 	if m.userSignups == nil {
 		m.userSignups = make(map[string]*signup.Signup)
 	}
-	m.userSignups[userID] = userSignup
+	m.userSignups[identifier] = userSignup
 	return m
 }
 

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -82,7 +82,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 
 	s.Run("unable to get signup", func() {
 		s.Run("signup service returns error", func() {
-			sc.mockGetSignup = func(userID string) (*signup.Signup, error) {
+			sc.mockGetSignup = func(userID, username string) (*signup.Signup, error) {
 				return nil, errors.New("oopsi woopsi")
 			}
 
@@ -352,24 +352,24 @@ func (m *fakeSignupService) addSignup(userID string, userSignup *signup.Signup) 
 }
 
 type fakeSignupService struct {
-	mockGetSignup func(userID string) (*signup.Signup, error)
+	mockGetSignup func(userID, username string) (*signup.Signup, error)
 	userSignups   map[string]*signup.Signup
 }
 
-func (m *fakeSignupService) defaultMockGetSignup() func(userID string) (*signup.Signup, error) {
-	return func(userID string) (userSignup *signup.Signup, e error) {
+func (m *fakeSignupService) defaultMockGetSignup() func(userID, username string) (*signup.Signup, error) {
+	return func(userID, username string) (userSignup *signup.Signup, e error) {
 		return m.userSignups[userID], nil
 	}
 }
 
-func (m *fakeSignupService) GetSignup(userID string) (*signup.Signup, error) {
-	return m.mockGetSignup(userID)
+func (m *fakeSignupService) GetSignup(userID, username string) (*signup.Signup, error) {
+	return m.mockGetSignup(userID, username)
 }
 
 func (m *fakeSignupService) Signup(_ *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
 	return nil, nil
 }
-func (m *fakeSignupService) GetUserSignup(_ string) (*toolchainv1alpha1.UserSignup, error) {
+func (m *fakeSignupService) GetUserSignup(_, _ string) (*toolchainv1alpha1.UserSignup, error) {
 	return nil, nil
 }
 func (m *fakeSignupService) UpdateUserSignup(_ *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -375,6 +375,6 @@ func (m *fakeSignupService) GetUserSignup(_, _ string) (*toolchainv1alpha1.UserS
 func (m *fakeSignupService) UpdateUserSignup(_ *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
 	return nil, nil
 }
-func (m *fakeSignupService) PhoneNumberAlreadyInUse(_, _ string) error {
+func (m *fakeSignupService) PhoneNumberAlreadyInUse(_, _, _ string) error {
 	return nil
 }

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -165,10 +165,9 @@ func EncodeUserIdentifier(subject string) string {
 // if doesn't exist yet.
 func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
 	encodedUserID := EncodeUserIdentifier(ctx.GetString(context.SubKey))
-	var userSignup *toolchainv1alpha1.UserSignup
-	var err error
+
 	// Retrieve UserSignup resource from the host cluster
-	userSignup, err = s.CRTClient().V1Alpha1().UserSignups().Get(encodedUserID)
+	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(encodedUserID)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// The UserSignup could not be located by its encoded UserID, attempt to load it using its encoded PreferredUsername instead
@@ -235,12 +234,8 @@ func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing *toolchain
 // and MasterUserRecord resources in the host cluster.
 // Returns nil, nil if the UserSignup resource is not found or if it's deactivated.
 func (s *ServiceImpl) GetSignup(userID, username string) (*signup.Signup, error) {
-	// Declare variables up front
-	var userSignup *toolchainv1alpha1.UserSignup
-	var err error
-
 	// Retrieve UserSignup resource from the host cluster, using the specified UserID and username
-	userSignup, err = s.GetUserSignup(userID, username)
+	userSignup, err := s.GetUserSignup(userID, username)
 	// If an error was returned, *or* the returned userSignup is nil, then return here
 	if err != nil || userSignup == nil {
 		if err != nil && apierrors.IsNotFound(err) {
@@ -320,17 +315,12 @@ func (s *ServiceImpl) GetSignup(userID, username string) (*signup.Signup, error)
 
 // GetUserSignup is used to return the actual UserSignup resource instance, rather than the Signup DTO
 func (s *ServiceImpl) GetUserSignup(userID, username string) (*toolchainv1alpha1.UserSignup, error) {
-	// Declare variables up front
-	var userSignup *toolchainv1alpha1.UserSignup
-	var err error
-	var err2 error
-
 	// Retrieve UserSignup resource from the host cluster
-	userSignup, err = s.CRTClient().V1Alpha1().UserSignups().Get(EncodeUserIdentifier(userID))
+	userSignup, err := s.CRTClient().V1Alpha1().UserSignups().Get(EncodeUserIdentifier(userID))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Capture any error here in a separate var, as we need to preserve the original
-			userSignup, err2 = s.CRTClient().V1Alpha1().UserSignups().Get(EncodeUserIdentifier(username))
+			userSignup, err2 := s.CRTClient().V1Alpha1().UserSignups().Get(EncodeUserIdentifier(username))
 			if err2 != nil {
 				if apierrors.IsNotFound(err2) {
 					return nil, err

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -236,12 +236,17 @@ func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing *toolchain
 func (s *ServiceImpl) GetSignup(userID, username string) (*signup.Signup, error) {
 	// Retrieve UserSignup resource from the host cluster, using the specified UserID and username
 	userSignup, err := s.GetUserSignup(userID, username)
-	// If an error was returned, *or* the returned userSignup is nil, then return here
-	if err != nil || userSignup == nil {
-		if err != nil && apierrors.IsNotFound(err) {
+	// If an error was returned, then return here
+	if err != nil {
+		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
+	}
+
+	// Otherwise if the returned userSignup is nil, return here also
+	if userSignup == nil {
+		return nil, nil
 	}
 
 	signupResponse := &signup.Signup{

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -171,7 +171,7 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 	userSignup, err = s.CRTClient().V1Alpha1().UserSignups().Get(encodedUserID)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// The UserSignup could not be located by its encoded UserID, attempt to load it using its encoded Username instead
+			// The UserSignup could not be located by its encoded UserID, attempt to load it using its encoded PreferredUsername instead
 			encodedUsername := EncodeUserIdentifier(ctx.GetString(context.UsernameKey))
 			userSignup, err = s.CRTClient().V1Alpha1().UserSignups().Get(encodedUsername)
 			if err != nil {

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -474,7 +474,7 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseBannedUser() {
 	ctx.Set(context.UsernameKey, "jsmith")
 	ctx.Set(context.SubKey, userID.String())
 	ctx.Set(context.EmailKey, "jsmith@gmail.com")
-	err = s.Application.SignupService().PhoneNumberAlreadyInUse(bannedUserID.String(), "+12268213044")
+	err = s.Application.SignupService().PhoneNumberAlreadyInUse(bannedUserID.String(), "jsmith", "+12268213044")
 	require.Error(s.T(), err)
 	require.Equal(s.T(), "cannot re-register with phone number:phone number already in use", err.Error())
 }
@@ -506,7 +506,7 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseUserSignup() {
 
 	newUserID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
-	err = s.Application.SignupService().PhoneNumberAlreadyInUse(newUserID.String(), "+12268213044")
+	err = s.Application.SignupService().PhoneNumberAlreadyInUse(newUserID.String(), "jsmith", "+12268213044")
 	require.Error(s.T(), err)
 	require.Equal(s.T(), "cannot re-register with phone number:phone number already in use", err.Error())
 }

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -219,27 +219,27 @@ func (s *TestSignupServiceSuite) TestUserSignupWithInvalidSubjectPrefix() {
 func (s *TestSignupServiceSuite) TestEncodeUserID() {
 	s.Run("test valid user ID unchanged", func() {
 		userID := "abcde-12345"
-		encoded := service.EncodeUserID(userID)
+		encoded := service.EncodeUserIdentifier(userID)
 		require.Equal(s.T(), userID, encoded)
 	})
 	s.Run("test user ID with invalid characters", func() {
 		userID := "abcde\\*-12345"
-		encoded := service.EncodeUserID(userID)
+		encoded := service.EncodeUserIdentifier(userID)
 		require.Equal(s.T(), "c0177ca4-abcde-12345", encoded)
 	})
 	s.Run("test user ID with invalid prefix", func() {
 		userID := "-1234567"
-		encoded := service.EncodeUserID(userID)
+		encoded := service.EncodeUserIdentifier(userID)
 		require.Equal(s.T(), "ca3e1e0f-1234567", encoded)
 	})
 	s.Run("test user ID that exceeds max length", func() {
 		userID := "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-01234567890123456789"
-		encoded := service.EncodeUserID(userID)
+		encoded := service.EncodeUserIdentifier(userID)
 		require.Equal(s.T(), "e3632025-0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr", encoded)
 	})
 	s.Run("test user ID with colon separator", func() {
 		userID := "abc:xyz"
-		encoded := service.EncodeUserID(userID)
+		encoded := service.EncodeUserIdentifier(userID)
 		require.Equal(s.T(), "a05a4053-abcxyz", encoded)
 	})
 }

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -54,8 +54,8 @@ func NewVerificationService(context servicecontext.ServiceContext, opts ...Verif
 // InitVerification sends a verification message to the specified user, using the Twilio service.  If successful,
 // the user will receive a verification SMS.  The UserSignup resource is updated with a number of annotations in order
 // to manage the phone verification process and protect against system abuse.
-func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164PhoneNumber string) error {
-	signup, err := s.Services().SignupService().GetUserSignup(userID)
+func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID, username, e164PhoneNumber string) error {
+	signup, err := s.Services().SignupService().GetUserSignup(userID, username)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Error(ctx, err, "usersignup not found")
@@ -164,7 +164,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID string, e164Phon
 	}
 
 	doUpdate := func() error {
-		signup, err := s.Services().SignupService().GetUserSignup(userID)
+		signup, err := s.Services().SignupService().GetUserSignup(userID, "")
 		if err != nil {
 			return err
 		}
@@ -211,11 +211,11 @@ func generateVerificationCode() (string, error) {
 
 // VerifyCode validates the user's phone verification code.  It updates the specified UserSignup value, so even
 // if an error is returned by this function the caller should still process changes to it
-func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (verificationErr error) {
+func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID, username, code string) (verificationErr error) {
 
 	cfg := configuration.GetRegistrationServiceConfig()
 	// If we can't even find the UserSignup, then die here
-	signup, lookupErr := s.Services().SignupService().GetUserSignup(userID)
+	signup, lookupErr := s.Services().SignupService().GetUserSignup(userID, username)
 	if lookupErr != nil {
 		if apierrors.IsNotFound(lookupErr) {
 			log.Error(ctx, lookupErr, "usersignup not found")
@@ -289,7 +289,7 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID string, code string) (
 	}
 
 	doUpdate := func() error {
-		signup, err := s.Services().SignupService().GetUserSignup(userID)
+		signup, err := s.Services().SignupService().GetUserSignup(userID, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -74,7 +74,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID, username, e164P
 	}
 
 	// Check if the provided phone number is already being used by another user
-	err = s.Services().SignupService().PhoneNumberAlreadyInUse(userID, e164PhoneNumber)
+	err = s.Services().SignupService().PhoneNumberAlreadyInUse(userID, username, e164PhoneNumber)
 	if err != nil {
 		e := &crterrors.Error{}
 		switch {
@@ -229,7 +229,7 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID, username, code string
 	annotationsToDelete := []string{}
 	unsetVerificationRequired := false
 
-	err := s.Services().SignupService().PhoneNumberAlreadyInUse(userID, signup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey])
+	err := s.Services().SignupService().PhoneNumberAlreadyInUse(userID, username, signup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey])
 	if err != nil {
 		log.Error(ctx, err, "phone number to verify already in use")
 		return crterrors.NewBadRequest("phone number already in use",

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -289,7 +289,7 @@ func (s *ServiceImpl) VerifyCode(ctx *gin.Context, userID, username, code string
 	}
 
 	doUpdate := func() error {
-		signup, err := s.Services().SignupService().GetUserSignup(userID, "")
+		signup, err := s.Services().SignupService().GetUserSignup(userID, username)
 		if err != nil {
 			return err
 		}

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -164,7 +164,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID, username, e164P
 	}
 
 	doUpdate := func() error {
-		signup, err := s.Services().SignupService().GetUserSignup(userID, "")
+		signup, err := s.Services().SignupService().GetUserSignup(userID, username)
 		if err != nil {
 			return err
 		}

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -112,6 +112,7 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 	var reqBody io.ReadCloser
 	obs := func(request *http.Request, mock gock.Mock) {
 		reqBody = request.Body
+		defer request.Body.Close()
 	}
 
 	gock.Observe(obs)
@@ -194,6 +195,7 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 
 	obs = func(request *http.Request, mock gock.Mock) {
 		reqBody = request.Body
+		defer request.Body.Close()
 	}
 	gock.Observe(obs)
 

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -139,7 +139,7 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 	require.NoError(s.T(), err)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
+	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
 	require.NoError(s.T(), err)
 
 	userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
@@ -211,7 +211,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 		defer func() { s.FakeUserSignupClient.MockGet = nil }()
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
+		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
 		require.Error(s.T(), err)
 		require.Equal(s.T(), "get failed:error retrieving usersignup: 123", err.Error())
 	})
@@ -225,7 +225,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 		defer func() { s.FakeUserSignupClient.MockUpdate = nil }()
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
+		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
 		require.Error(s.T(), err)
 		require.Equal(s.T(), "there was an error while updating your account - please wait a moment before "+
 			"trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com "+
@@ -248,7 +248,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 		defer func() { s.FakeUserSignupClient.MockUpdate = nil }()
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
+		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
 		require.NoError(s.T(), err)
 
 		userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
@@ -314,7 +314,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 	require.NoError(s.T(), err)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
+	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
 	require.NoError(s.T(), err)
 
 	userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
@@ -371,7 +371,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenCountContain
 	require.NoError(s.T(), err)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
+	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
 	require.Error(s.T(), err)
 	require.Equal(s.T(), "daily limit exceeded:cannot generate new verification code", err.Error())
 }
@@ -414,7 +414,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 	require.NoError(s.T(), err)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, "+1NUMBER")
+	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
 	require.Error(s.T(), err)
 	require.Equal(s.T(), "daily limit exceeded:cannot generate new verification code", err.Error())
 
@@ -482,7 +482,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 	require.NoError(s.T(), err)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err = s.Application.VerificationService().InitVerification(ctx, bravoUserSignup.Name, e164PhoneNumber)
+	err = s.Application.VerificationService().InitVerification(ctx, bravoUserSignup.Name, bravoUserSignup.Spec.Username, e164PhoneNumber)
 	require.Error(s.T(), err)
 	require.Equal(s.T(), "phone number already in use:cannot register using phone number: +19875551122", err.Error())
 
@@ -556,7 +556,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUs
 	require.NoError(s.T(), err)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err = s.Application.VerificationService().InitVerification(ctx, bravoUserSignup.Name, e164PhoneNumber)
+	err = s.Application.VerificationService().InitVerification(ctx, bravoUserSignup.Name, bravoUserSignup.Spec.Username, e164PhoneNumber)
 	require.NoError(s.T(), err)
 
 	// Reload bravoUserSignup
@@ -598,7 +598,7 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 		require.NoError(s.T(), err)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, "123456")
+		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
 		require.NoError(s.T(), err)
 
 		userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
@@ -636,7 +636,7 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 		require.NoError(s.T(), err)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, "123456")
+		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
 		require.Error(s.T(), err)
 		e := &crterrors.Error{}
 		require.True(s.T(), errors.As(err, &e))
@@ -672,7 +672,7 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 		require.NoError(s.T(), err)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, "123456")
+		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
 		e := &crterrors.Error{}
 		require.True(s.T(), errors.As(err, &e))
 		require.Equal(s.T(), "expired:verification code expired", e.Error())
@@ -707,7 +707,7 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 		require.NoError(s.T(), err)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, "123456")
+		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
 		require.Error(s.T(), err)
 		require.Equal(s.T(), "too many verification attempts:", err.Error())
 	})
@@ -740,7 +740,7 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 		require.NoError(s.T(), err)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, "123456")
+		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
 		require.Error(s.T(), err)
 		require.Equal(s.T(), "too many verification attempts:", err.Error())
 
@@ -778,7 +778,7 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 		require.NoError(s.T(), err)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, "123456")
+		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
 		require.Error(s.T(), err)
 		require.Equal(s.T(), "parsing time \"ABC\" as \"2006-01-02T15:04:05.000Z07:00\": cannot parse \"ABC\" as \"2006\":error parsing expiry timestamp", err.Error())
 	})


### PR DESCRIPTION
This PR updates the registration service to allow it to locate UserSignup resources by the user's username (i.e. the `username` claim in the JWT token) if the user ID (i.e. the `sub` claim) lookup fails.

Fixes https://issues.redhat.com/browse/CRT-1398

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/472