### PR TITLE
Create new UserSignups using the encoded username instead of userID

### DIFF
--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -101,7 +101,7 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 
 	userSignup := &toolchainv1alpha1.UserSignup{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      EncodeUserIdentifier(ctx.GetString(context.SubKey)),
+			Name:      EncodeUserIdentifier(ctx.GetString(context.UsernameKey)),
 			Namespace: configuration.Namespace(),
 			Annotations: map[string]string{
 				toolchainv1alpha1.UserSignupUserEmailAnnotationKey:           userEmail,


### PR DESCRIPTION
This PR modifies registration service to create new UserSignup instances using the user's username instead of userID.

Fixes https://issues.redhat.com/browse/CRT-1401

WIP