### PR TITLE
Parameter to skip space creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/registration-service
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574
+	github.com/codeready-toolchain/api v0.0.0-20220224160109-6c2f447c08aa
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,9 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574 h1:lwAkKKUSpTawVSzFWuadyWlT9StIKjgUZhOS0ncxiYE=
 github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/api v0.0.0-20220224160109-6c2f447c08aa h1:t4lNOUUi/5A5GinikpcaA5DdF8avGIBE0Gq/mHVL+js=
+github.com/codeready-toolchain/api v0.0.0-20220224160109-6c2f447c08aa/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084 h1:9V+OvCQU9h7V3W6bx0hhqO3JQL/hyENwuRPeq24XYf4=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084/go.mod h1:+wXPryRgWG13u0OQ1iv8ZxjLdEV0VwomkVceAu2bRKI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -17,4 +17,6 @@ const (
 	OriginalSubKey = "originalSub"
 	// JWTClaimsKey is the context key for the claims struct
 	JWTClaimsKey = "jwtClaims"
+	// NoSpaceKey is the context key for specifying whether the UserSignup should be created without a Space
+	NoSpaceKey = "no-space"
 )

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -123,6 +123,12 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 	}
 	states.SetVerificationRequired(userSignup, verificationRequired)
 
+	// set the skip-auto-create-space annotation to true if the no-space query parameter was set to true
+	if param, _ := ctx.GetQuery(context.NoSpaceKey); param == "true" {
+		log.Info(ctx, fmt.Sprintf("setting '%s' annotation to true", toolchainv1alpha1.SkipAutoCreateSpaceAnnotationKey))
+		userSignup.Annotations[toolchainv1alpha1.SkipAutoCreateSpaceAnnotationKey] = "true"
+	}
+
 	return userSignup, nil
 }
 

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -1,9 +1,11 @@
 package service_test
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"hash/crc32"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -171,6 +173,46 @@ func (s *TestSignupServiceSuite) TestSignup() {
 		// then
 		require.EqualError(s.T(), err, "an error occurred")
 	})
+}
+
+func (s *TestSignupServiceSuite) TestSignupNoSpaces() {
+	s.ServiceConfiguration(TestNamespace, true, "", 5)
+
+	// given
+	userID, err := uuid.NewV4()
+	require.NoError(s.T(), err)
+
+	rr := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rr)
+	ctx.Set(context.UsernameKey, "jsmith")
+	ctx.Set(context.SubKey, userID.String())
+	ctx.Set(context.OriginalSubKey, "original-sub-value")
+	ctx.Set(context.EmailKey, "jsmith@gmail.com")
+	ctx.Set(context.GivenNameKey, "jane")
+	ctx.Set(context.FamilyNameKey, "doe")
+	ctx.Set(context.CompanyKey, "red hat")
+	ctx.Request, _ = http.NewRequest("POST", "/?no-space=true", bytes.NewBufferString(""))
+
+	// when
+	userSignup, err := s.Application.SignupService().Signup(ctx)
+
+	// then
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), userSignup)
+
+	gvk, err := apiutil.GVKForObject(userSignup, s.FakeUserSignupClient.Scheme)
+	require.NoError(s.T(), err)
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+
+	values, err := s.FakeUserSignupClient.Tracker.List(gvr, gvk, configuration.Namespace())
+	require.NoError(s.T(), err)
+
+	userSignups := values.(*toolchainv1alpha1.UserSignupList)
+	require.NotEmpty(s.T(), userSignups.Items)
+	require.Len(s.T(), userSignups.Items, 1)
+
+	val := userSignups.Items[0]
+	require.Equal(s.T(), "true", val.Annotations[toolchainv1alpha1.SkipAutoCreateSpaceAnnotationKey]) // skip auto create space annotation is set
 }
 
 func (s *TestSignupServiceSuite) TestUserSignupWithInvalidSubjectPrefix() {


### PR DESCRIPTION
Adds the parameter `no-space` to the POST /signup endpoint that signals the UserSignup controller to create only a UserSignup and MasterUserRecord (no space)

eg. `POST /signup?no-space=true`

e2e PR: 
Related Issue: https://issues.redhat.com/browse/CRT-1416