### PR TITLE
fix: use the same apiVersion as is used in host-operator

### DIFF
--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -1,5 +1,5 @@
+apiVersion: template.openshift.io/v1
 kind: Template
-apiVersion: v1
 metadata:
   name: registration-service
 objects:


### PR DESCRIPTION
update the template so it matches the latest changes from host-operator: https://github.com/codeready-toolchain/host-operator/pull/606