### PR TITLE
refactor(err): insert space between message and details

### DIFF
--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -417,7 +417,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 
 		require.Equal(s.T(), "Bad Request", bodyParams["status"])
 		require.Equal(s.T(), float64(400), bodyParams["code"])
-		require.Equal(s.T(), "forbidden request:verification code will not be sent", bodyParams["message"])
+		require.Equal(s.T(), "forbidden request: verification code will not be sent", bodyParams["message"])
 		require.Equal(s.T(), "forbidden request", bodyParams["details"])
 	})
 
@@ -543,7 +543,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 
 		require.Equal(s.T(), "Internal Server Error", bodyParams["status"])
 		require.Equal(s.T(), float64(500), bodyParams["code"])
-		require.Equal(s.T(), fmt.Sprintf("no user:error retrieving usersignup: %s", userSignup.Name), bodyParams["message"])
+		require.Equal(s.T(), fmt.Sprintf("no user: error retrieving usersignup: %s", userSignup.Name), bodyParams["message"])
 		require.Equal(s.T(), "error while verifying code", bodyParams["details"])
 	})
 
@@ -573,7 +573,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 
 		require.Equal(s.T(), "Not Found", bodyParams["status"])
 		require.Equal(s.T(), float64(404), bodyParams["code"])
-		require.Equal(s.T(), fmt.Sprintf(" \"%s\" not found:user not found", userSignup.Name), bodyParams["message"])
+		require.Equal(s.T(), fmt.Sprintf(" \"%s\" not found: user not found", userSignup.Name), bodyParams["message"])
 		require.Equal(s.T(), "error while verifying code", bodyParams["details"])
 	})
 
@@ -604,7 +604,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 		require.Equal(s.T(), float64(500), bodyParams["code"])
 		require.Equal(s.T(), "there was an error while updating your account - please wait a moment before "+
 			"trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for "+
-			"assistance:error while verifying code", bodyParams["message"])
+			"assistance: error while verifying code", bodyParams["message"])
 		require.Equal(s.T(), "error while verifying code", bodyParams["details"])
 	})
 
@@ -638,7 +638,7 @@ func (s *TestSignupSuite) TestVerifyCodeHandler() {
 
 		require.Equal(s.T(), "Too Many Requests", bodyParams["status"])
 		require.Equal(s.T(), float64(429), bodyParams["code"])
-		require.Equal(s.T(), "too many verification attempts:", bodyParams["message"])
+		require.Equal(s.T(), "too many verification attempts", bodyParams["message"])
 		require.Equal(s.T(), "error while verifying code", bodyParams["details"])
 	})
 

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -25,7 +25,10 @@ func AbortWithError(ctx *gin.Context, code int, err error, details string) {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("%s:%s", e.Message, e.Details)
+	if e.Details != "" {
+		return fmt.Sprintf("%s: %s", e.Message, e.Details)
+	}
+	return e.Message
 }
 
 func NewForbiddenError(message, details string) *Error {

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -51,14 +51,14 @@ func (s *TestErrorsSuite) TestErrors() {
 		require.Equal(s.T(), "bar", err.Details)
 		require.Equal(s.T(), http.StatusForbidden, err.Code)
 		require.Equal(s.T(), http.StatusText(http.StatusForbidden), err.Status)
-		require.Equal(s.T(), "foo:bar", err.Error())
+		require.Equal(s.T(), "foo: bar", err.Error())
 
 		err = errs.NewUnauthorizedError("foo", "bar")
 		require.Equal(s.T(), "foo", err.Message)
 		require.Equal(s.T(), "bar", err.Details)
 		require.Equal(s.T(), http.StatusUnauthorized, err.Code)
 		require.Equal(s.T(), http.StatusText(http.StatusUnauthorized), err.Status)
-		require.Equal(s.T(), "foo:bar", err.Error())
+		require.Equal(s.T(), "foo: bar", err.Error())
 
 		err = errs.NewTooManyRequestsError("foo", "bar")
 		require.Equal(s.T(), "foo", err.Message)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -115,7 +115,7 @@ func (s *TestProxySuite) TestProxy() {
 					require.NoError(s.T(), err)
 					require.NotNil(s.T(), resp)
 					assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
-					s.assertResponseBody(resp, "invalid bearer token:no token found:a Bearer token is expected\n")
+					s.assertResponseBody(resp, "invalid bearer token: no token found: a Bearer token is expected\n")
 				})
 
 				s.Run("unauthorized if can't parse token", func() {
@@ -130,7 +130,7 @@ func (s *TestProxySuite) TestProxy() {
 					require.NoError(s.T(), err)
 					require.NotNil(s.T(), resp)
 					assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
-					s.assertResponseBody(resp, "invalid bearer token:unable to extract userID from token:token contains an invalid number of segments\n")
+					s.assertResponseBody(resp, "invalid bearer token: unable to extract userID from token: token contains an invalid number of segments\n")
 				})
 
 				s.Run("unauthorized if can't extract userID from a valid token", func() {
@@ -147,7 +147,7 @@ func (s *TestProxySuite) TestProxy() {
 					require.NoError(s.T(), err)
 					require.NotNil(s.T(), resp)
 					assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
-					s.assertResponseBody(resp, "invalid bearer token:unable to extract userID from token:token does not comply to expected claims: subject missing\n")
+					s.assertResponseBody(resp, "invalid bearer token: unable to extract userID from token: token does not comply to expected claims: subject missing\n")
 				})
 
 				s.Run("internal error if get namespace returns an error", func() {
@@ -163,7 +163,7 @@ func (s *TestProxySuite) TestProxy() {
 					require.NoError(s.T(), err)
 					require.NotNil(s.T(), resp)
 					assert.Equal(s.T(), http.StatusInternalServerError, resp.StatusCode)
-					s.assertResponseBody(resp, "unable to get target namespace:some-error\n")
+					s.assertResponseBody(resp, "unable to get target namespace: some-error\n")
 				})
 			})
 
@@ -174,42 +174,42 @@ func (s *TestProxySuite) TestProxy() {
 				}{
 					"empty token": {
 						ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.,dummy"},
-						ExpectedError:   "invalid bearer token:no base64.bearer.authorization token found",
+						ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
 					},
 					"not a jwt token": {
 						ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.dG9rZW4,dummy"},
-						ExpectedError:   "invalid bearer token:unable to extract userID from token:token contains an invalid number of segments",
+						ExpectedError:   "invalid bearer token: unable to extract userID from token: token contains an invalid number of segments",
 					},
 					"invalid token is not base64 encoded": {
 						ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.token,dummy"},
-						ExpectedError:   "invalid bearer token:invalid base64.bearer.authorization token encoding: illegal base64 data at input byte 4",
+						ExpectedError:   "invalid bearer token: invalid base64.bearer.authorization token encoding: illegal base64 data at input byte 4",
 					},
 					"invalid token contains non UTF-8-encoded runes": {
 						ProtocolHeaders: []string{fmt.Sprintf("base64url.bearer.authorization.k8s.io.%s,dummy", base64.RawURLEncoding.EncodeToString([]byte("aa\xe2")))},
-						ExpectedError:   "invalid bearer token:invalid base64.bearer.authorization token: contains non UTF-8-encoded runes",
+						ExpectedError:   "invalid bearer token: invalid base64.bearer.authorization token: contains non UTF-8-encoded runes",
 					},
 					"no header": {
 						ProtocolHeaders: nil,
-						ExpectedError:   "invalid bearer token:no base64.bearer.authorization token found",
+						ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
 					},
 					"empty header": {
 						ProtocolHeaders: []string{""},
-						ExpectedError:   "invalid bearer token:no base64.bearer.authorization token found",
+						ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
 					},
 					"non-bearer header": {
 						ProtocolHeaders: []string{"undefined"},
-						ExpectedError:   "invalid bearer token:no base64.bearer.authorization token found",
+						ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
 					},
 					"empty bearer token": {
 						ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io."},
-						ExpectedError:   "invalid bearer token:no base64.bearer.authorization token found",
+						ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
 					},
 					"multiple bearer tokens": {
 						ProtocolHeaders: []string{
 							"base64url.bearer.authorization.k8s.io.dG9rZW4,dummy",
 							"base64url.bearer.authorization.k8s.io.dG9rZW4,dummy",
 						},
-						ExpectedError: "invalid bearer token:multiple base64.bearer.authorization tokens specified",
+						ExpectedError: "invalid bearer token: multiple base64.bearer.authorization tokens specified",
 					},
 				}
 

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -198,8 +198,7 @@ func (s *TestSignupServiceSuite) TestSignupFailsWhenClientReturnsError() {
 
 	// when
 	_, err = s.Application.SignupService().Signup(ctx)
-	require.Error(s.T(), err)
-	require.Equal(s.T(), "an internal error:an internal error happened", err.Error())
+	require.EqualError(s.T(), err, "an internal error: an internal error happened", err.Error())
 }
 
 func (s *TestSignupServiceSuite) TestSignupFailsWithNotFoundThenOtherError() {
@@ -227,8 +226,7 @@ func (s *TestSignupServiceSuite) TestSignupFailsWithNotFoundThenOtherError() {
 
 	// when
 	_, err = s.Application.SignupService().Signup(ctx)
-	require.Error(s.T(), err)
-	require.Equal(s.T(), "something bad happened:something very bad happened", err.Error())
+	require.EqualError(s.T(), err, "something bad happened: something very bad happened", err.Error())
 }
 
 func (s *TestSignupServiceSuite) TestGetSignupFailsWithNotFoundThenOtherError() {
@@ -243,8 +241,7 @@ func (s *TestSignupServiceSuite) TestGetSignupFailsWithNotFoundThenOtherError() 
 
 	// when
 	_, err := s.Application.SignupService().GetSignup("000", "abc")
-	require.Error(s.T(), err)
-	require.Equal(s.T(), "something quite unfortunate happened:something bad", err.Error())
+	require.EqualError(s.T(), err, "something quite unfortunate happened: something bad", err.Error())
 }
 
 func (s *TestSignupServiceSuite) TestSignupNoSpaces() {
@@ -409,8 +406,7 @@ func (s *TestSignupServiceSuite) TestCRTAdminUserSignup() {
 	ctx.Set(context.CompanyKey, "red hat")
 
 	userSignup, err := s.Application.SignupService().Signup(ctx)
-	require.Error(s.T(), err)
-	require.Equal(s.T(), "forbidden: failed to create usersignup for jsmith-crtadmin", err.Error())
+	require.EqualError(s.T(), err, "forbidden: failed to create usersignup for jsmith-crtadmin", err.Error())
 	require.Nil(s.T(), userSignup)
 }
 
@@ -518,8 +514,7 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseBannedUser() {
 	ctx.Set(context.SubKey, userID.String())
 	ctx.Set(context.EmailKey, "jsmith@gmail.com")
 	err = s.Application.SignupService().PhoneNumberAlreadyInUse(bannedUserID.String(), "jsmith", "+12268213044")
-	require.Error(s.T(), err)
-	require.Equal(s.T(), "cannot re-register with phone number:phone number already in use", err.Error())
+	require.EqualError(s.T(), err, "cannot re-register with phone number: phone number already in use", err.Error())
 }
 
 func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseUserSignup() {
@@ -550,8 +545,7 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseUserSignup() {
 	newUserID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 	err = s.Application.SignupService().PhoneNumberAlreadyInUse(newUserID.String(), "jsmith", "+12268213044")
-	require.Error(s.T(), err)
-	require.Equal(s.T(), "cannot re-register with phone number:phone number already in use", err.Error())
+	require.EqualError(s.T(), err, "cannot re-register with phone number: phone number already in use", err.Error())
 }
 
 func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -198,7 +198,7 @@ func (s *TestSignupServiceSuite) TestSignupFailsWhenClientReturnsError() {
 
 	// when
 	_, err = s.Application.SignupService().Signup(ctx)
-	require.EqualError(s.T(), err, "an internal error: an internal error happened", err.Error())
+	require.EqualError(s.T(), err, "an internal error: an internal error happened")
 }
 
 func (s *TestSignupServiceSuite) TestSignupFailsWithNotFoundThenOtherError() {
@@ -226,7 +226,7 @@ func (s *TestSignupServiceSuite) TestSignupFailsWithNotFoundThenOtherError() {
 
 	// when
 	_, err = s.Application.SignupService().Signup(ctx)
-	require.EqualError(s.T(), err, "something bad happened: something very bad happened", err.Error())
+	require.EqualError(s.T(), err, "something bad happened: something very bad happened")
 }
 
 func (s *TestSignupServiceSuite) TestGetSignupFailsWithNotFoundThenOtherError() {
@@ -241,7 +241,7 @@ func (s *TestSignupServiceSuite) TestGetSignupFailsWithNotFoundThenOtherError() 
 
 	// when
 	_, err := s.Application.SignupService().GetSignup("000", "abc")
-	require.EqualError(s.T(), err, "something quite unfortunate happened: something bad", err.Error())
+	require.EqualError(s.T(), err, "something quite unfortunate happened: something bad")
 }
 
 func (s *TestSignupServiceSuite) TestSignupNoSpaces() {
@@ -406,7 +406,7 @@ func (s *TestSignupServiceSuite) TestCRTAdminUserSignup() {
 	ctx.Set(context.CompanyKey, "red hat")
 
 	userSignup, err := s.Application.SignupService().Signup(ctx)
-	require.EqualError(s.T(), err, "forbidden: failed to create usersignup for jsmith-crtadmin", err.Error())
+	require.EqualError(s.T(), err, "forbidden: failed to create usersignup for jsmith-crtadmin")
 	require.Nil(s.T(), userSignup)
 }
 
@@ -514,7 +514,7 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseBannedUser() {
 	ctx.Set(context.SubKey, userID.String())
 	ctx.Set(context.EmailKey, "jsmith@gmail.com")
 	err = s.Application.SignupService().PhoneNumberAlreadyInUse(bannedUserID.String(), "jsmith", "+12268213044")
-	require.EqualError(s.T(), err, "cannot re-register with phone number: phone number already in use", err.Error())
+	require.EqualError(s.T(), err, "cannot re-register with phone number: phone number already in use")
 }
 
 func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseUserSignup() {
@@ -545,7 +545,7 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseUserSignup() {
 	newUserID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
 	err = s.Application.SignupService().PhoneNumberAlreadyInUse(newUserID.String(), "jsmith", "+12268213044")
-	require.EqualError(s.T(), err, "cannot re-register with phone number: phone number already in use", err.Error())
+	require.EqualError(s.T(), err, "cannot re-register with phone number: phone number already in use")
 }
 
 func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
@@ -971,8 +971,7 @@ func (s *TestSignupServiceSuite) TestGetUserSignup() {
 		}
 
 		val, err := s.Application.SignupService().GetUserSignup("foo", "")
-		require.Error(s.T(), err)
-		require.Equal(s.T(), "get failed", err.Error())
+		require.EqualError(s.T(), err, "get failed")
 		require.Nil(s.T(), val)
 	})
 
@@ -1013,8 +1012,7 @@ func (s *TestSignupServiceSuite) TestUpdateUserSignup() {
 		require.NoError(s.T(), err)
 
 		updated, err := s.Application.SignupService().UpdateUserSignup(val)
-		require.Error(s.T(), err)
-		require.Equal(s.T(), "update failed", err.Error())
+		require.EqualError(s.T(), err, "update failed")
 		require.Nil(s.T(), updated)
 	})
 }

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -275,8 +275,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
-		require.Error(s.T(), err)
-		require.Equal(s.T(), "get failed:error retrieving usersignup: 123", err.Error())
+		require.EqualError(s.T(), err, "get failed: error retrieving usersignup: 123", err.Error())
 	})
 
 	s.T().Run("when client UPDATE call fails indefinitely should return error", func(t *testing.T) {
@@ -289,10 +288,9 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 		err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
-		require.Error(s.T(), err)
-		require.Equal(s.T(), "there was an error while updating your account - please wait a moment before "+
+		require.EqualError(s.T(), err, "there was an error while updating your account - please wait a moment before "+
 			"trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com "+
-			"for assistance:error while verifying code", err.Error())
+			"for assistance: error while verifying code", err.Error())
 	})
 
 	s.T().Run("when client UPDATE call fails twice should return ok", func(t *testing.T) {
@@ -435,8 +433,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenCountContain
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
-	require.Error(s.T(), err)
-	require.Equal(s.T(), "daily limit exceeded:cannot generate new verification code", err.Error())
+	require.EqualError(s.T(), err, "daily limit exceeded: cannot generate new verification code")
 }
 
 func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExceeded() {
@@ -478,9 +475,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	err = s.Application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.Username, "+1NUMBER")
-	require.Error(s.T(), err)
-	require.Equal(s.T(), "daily limit exceeded:cannot generate new verification code", err.Error())
-
+	require.EqualError(s.T(), err, "daily limit exceeded: cannot generate new verification code", err.Error())
 	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 }
 
@@ -547,7 +542,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	err = s.Application.VerificationService().InitVerification(ctx, bravoUserSignup.Name, bravoUserSignup.Spec.Username, e164PhoneNumber)
 	require.Error(s.T(), err)
-	require.Equal(s.T(), "phone number already in use:cannot register using phone number: +19875551122", err.Error())
+	require.Equal(s.T(), "phone number already in use: cannot register using phone number: +19875551122", err.Error())
 
 	// Reload bravoUserSignup
 	bravoUserSignup, err = s.FakeUserSignupClient.Get(bravoUserSignup.Name)
@@ -637,7 +632,6 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 	s.T().Run("verification ok", func(t *testing.T) {
 
 		userSignup := &toolchainv1alpha1.UserSignup{
-			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "123",
 				Namespace: configuration.Namespace(),
@@ -673,7 +667,6 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 	s.T().Run("verification ok for usersignup with username identifier", func(t *testing.T) {
 
 		userSignup := &toolchainv1alpha1.UserSignup{
-			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "employee085",
 				Namespace: configuration.Namespace(),
@@ -709,7 +702,6 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 	s.T().Run("when verification code is invalid", func(t *testing.T) {
 
 		userSignup := &toolchainv1alpha1.UserSignup{
-			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "123",
 				Namespace: configuration.Namespace(),
@@ -739,14 +731,13 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 		require.Error(s.T(), err)
 		e := &crterrors.Error{}
 		require.True(s.T(), errors.As(err, &e))
-		require.Equal(s.T(), "invalid code:the provided code is invalid", e.Error())
+		require.Equal(s.T(), "invalid code: the provided code is invalid", e.Error())
 		require.Equal(s.T(), http.StatusForbidden, int(e.Code))
 	})
 
 	s.T().Run("when verification code has expired", func(t *testing.T) {
 
 		userSignup := &toolchainv1alpha1.UserSignup{
-			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "123",
 				Namespace: configuration.Namespace(),
@@ -774,14 +765,13 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
 		e := &crterrors.Error{}
 		require.True(s.T(), errors.As(err, &e))
-		require.Equal(s.T(), "expired:verification code expired", e.Error())
+		require.Equal(s.T(), "expired: verification code expired", e.Error())
 		require.Equal(s.T(), http.StatusForbidden, int(e.Code))
 	})
 
 	s.T().Run("when verifications exceeded maximum attempts", func(t *testing.T) {
 
 		userSignup := &toolchainv1alpha1.UserSignup{
-			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "123",
 				Namespace: configuration.Namespace(),
@@ -807,14 +797,12 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
-		require.Error(s.T(), err)
-		require.Equal(s.T(), "too many verification attempts:", err.Error())
+		require.EqualError(s.T(), err, "too many verification attempts", err.Error())
 	})
 
 	s.T().Run("when verifications attempts has invalid value", func(t *testing.T) {
 
 		userSignup := &toolchainv1alpha1.UserSignup{
-			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "123",
 				Namespace: configuration.Namespace(),
@@ -840,8 +828,7 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
-		require.Error(s.T(), err)
-		require.Equal(s.T(), "too many verification attempts:", err.Error())
+		require.EqualError(s.T(), err, "too many verification attempts", err.Error())
 
 		userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
 		require.NoError(s.T(), err)
@@ -852,7 +839,6 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 	s.T().Run("when verifications expiry is corrupt", func(t *testing.T) {
 
 		userSignup := &toolchainv1alpha1.UserSignup{
-			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "123",
 				Namespace: configuration.Namespace(),
@@ -878,8 +864,6 @@ func (s *TestVerificationServiceSuite) TestVerifyCode() {
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 		err = s.Application.VerificationService().VerifyCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
-		require.Error(s.T(), err)
-		require.Equal(s.T(), "parsing time \"ABC\" as \"2006-01-02T15:04:05.000Z07:00\": cannot parse \"ABC\" as \"2006\":error parsing expiry timestamp", err.Error())
+		require.EqualError(s.T(), err, "parsing time \"ABC\" as \"2006-01-02T15:04:05.000Z07:00\": cannot parse \"ABC\" as \"2006\": error parsing expiry timestamp", err.Error())
 	})
-
 }


### PR DESCRIPTION
also, no need for a `:` suffix character when error has no details

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
