### PR TITLE
When encoding username check for invalid end chars

### DIFF
--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -34,6 +34,7 @@ const (
 	DNS1123NameMaximumLength         = 63
 	DNS1123NotAllowedCharacters      = "[^-a-z0-9]"
 	DNS1123NotAllowedStartCharacters = "^[^a-z0-9]+"
+	DNS1123NotAllowedEndCharacters   = "[^a-z0-9]+$"
 
 	// NoSpaceKey is the query key for specifying whether the UserSignup should be created without a Space
 	NoSpaceKey = "no-space"
@@ -156,6 +157,10 @@ func EncodeUserIdentifier(subject string) string {
 	// Remove invalid start characters
 	nameNotAllowedStartChars := regexp.MustCompile(DNS1123NotAllowedStartCharacters)
 	encoded = nameNotAllowedStartChars.ReplaceAllString(encoded, "")
+
+	// Remove invalid end characters
+	nameNotAllowedEndChars := regexp.MustCompile(DNS1123NotAllowedEndCharacters)
+	encoded = nameNotAllowedEndChars.ReplaceAllString(encoded, "")
 
 	// Add a checksum prefix if the encoded value is different to the original subject value
 	if encoded != subject {

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -354,6 +354,11 @@ func (s *TestSignupServiceSuite) TestEncodeUserID() {
 		encoded := service.EncodeUserIdentifier(userID)
 		require.Equal(s.T(), "a05a4053-abcxyz", encoded)
 	})
+	s.Run("test user ID with invalid end character", func() {
+		userID := "abc---"
+		encoded := service.EncodeUserIdentifier(userID)
+		require.Equal(s.T(), "ed6bd2b5-abc", encoded)
+	})
 }
 
 func (s *TestSignupServiceSuite) TestUserWithExcludedDomainEmailSignsUp() {


### PR DESCRIPTION
This PR addresses an issue in registration service where a user with an invalid character at the end of their username (for example `sbryzak-`) is encoded incorrectly.

Fixes https://issues.redhat.com/browse/CRT-1515