### PR TITLE
feat: activation code endpoint and service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/codeready-toolchain/registration-service
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20220613074006-851fcc33aeec
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220406062847-51b0d44256d9
+	github.com/codeready-toolchain/api v0.0.0-20220620073500-4403ea044a96
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220620075348-4f3711a55236
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1
 	github.com/gin-gonic/gin v1.7.2
@@ -36,9 +36,5 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	sigs.k8s.io/controller-runtime v0.10.3
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20220614114123-2e8f7b972c9b
-
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20220613135252-ef78663d68a3
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/registration-service
 
 require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20220406062208-83cd78aad988
+	github.com/codeready-toolchain/api v0.0.0-20220613074006-851fcc33aeec
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20220406062847-51b0d44256d9
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/gzip v0.0.1
@@ -36,5 +36,9 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	sigs.k8s.io/controller-runtime v0.10.3
 )
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20220614114123-2e8f7b972c9b
+
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20220613135252-ef78663d68a3
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,10 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20220620073500-4403ea044a96 h1:cUUpd5vcZkE6di9Zmd2iu28hwxQo+dWVc3YtiZHF7As=
+github.com/codeready-toolchain/api v0.0.0-20220620073500-4403ea044a96/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220620075348-4f3711a55236 h1:yp6hQUNbauBu87HW148OariMjxMnzGkG0CX6kPVES5k=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220620075348-4f3711a55236/go.mod h1:hdF7PQh9e9V3Wi+QFJ58Z9a/GATbHAiFQtMMzbMy7NQ=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -708,10 +712,6 @@ github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/xcoulon/api v0.0.0-20220613135252-ef78663d68a3 h1:4UFelG/Ii5eqvkzzCw94FcbctzdCSY9nVSzoEMizczs=
-github.com/xcoulon/api v0.0.0-20220613135252-ef78663d68a3/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
-github.com/xcoulon/toolchain-common v0.0.0-20220614114123-2e8f7b972c9b h1:E28nv2bWes9JrrPpsutmX+1GdNCbMUAkjWXkUSnnR1Y=
-github.com/xcoulon/toolchain-common v0.0.0-20220614114123-2e8f7b972c9b/go.mod h1:GnXuhG8uL3onFz4ZQR9wU6HEHPfPEX2aRSO8f9ULVr0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/go.sum
+++ b/go.sum
@@ -118,10 +118,6 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20220406062208-83cd78aad988 h1:IajrKKCyxUGqhAou4eOTl7devas/DlKtCfe0+DE/8Kk=
-github.com/codeready-toolchain/api v0.0.0-20220406062208-83cd78aad988/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220406062847-51b0d44256d9 h1:IIdePAUIagRm6BzYLNqMqr8gTxdPnvjy4h40kef/UQw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220406062847-51b0d44256d9/go.mod h1:VbqCyyEQjgcRYsAwYbgPNxR2KY3VACCOJ8kR+nUeM50=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -712,6 +708,10 @@ github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/xcoulon/api v0.0.0-20220613135252-ef78663d68a3 h1:4UFelG/Ii5eqvkzzCw94FcbctzdCSY9nVSzoEMizczs=
+github.com/xcoulon/api v0.0.0-20220613135252-ef78663d68a3/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
+github.com/xcoulon/toolchain-common v0.0.0-20220614114123-2e8f7b972c9b h1:E28nv2bWes9JrrPpsutmX+1GdNCbMUAkjWXkUSnnR1Y=
+github.com/xcoulon/toolchain-common v0.0.0-20220614114123-2e8f7b972c9b/go.mod h1:GnXuhG8uL3onFz4ZQR9wU6HEHPfPEX2aRSO8f9ULVr0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -15,9 +15,14 @@ type SignupService interface {
 	PhoneNumberAlreadyInUse(userID, username, phoneNumberOrHash string) error
 }
 
+type SocialEventService interface {
+	GetEvent(code string) (*toolchainv1alpha1.SocialEvent, error)
+}
+
 type VerificationService interface {
 	InitVerification(ctx *gin.Context, userID, username, e164PhoneNumber string) error
 	VerifyPhoneCode(ctx *gin.Context, userID, username, code string) error
+	VerifyActivationCode(ctx *gin.Context, userID, username, code string) error
 }
 
 type MemberClusterService interface {

--- a/pkg/auth/keymanager_test.go
+++ b/pkg/auth/keymanager_test.go
@@ -15,6 +15,7 @@ import (
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+
 	"github.com/gofrs/uuid"
 	"github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/assert"

--- a/pkg/kubeclient/client.go
+++ b/pkg/kubeclient/client.go
@@ -17,6 +17,7 @@ type V1Alpha1 interface {
 	MasterUserRecords() MasterUserRecordInterface
 	BannedUsers() BannedUserInterface
 	ToolchainStatuses() ToolchainStatusInterface
+	SocialEvents() SocialEventInterface
 }
 
 // NewCRTRESTClient creates a new REST client for managing Codeready Toolchain resources via the Kubernetes API
@@ -119,6 +120,18 @@ func (c *V1Alpha1REST) BannedUsers() BannedUserInterface {
 // ToolchainStatuses returns an interface which may be used to perform query operations on ToolchainStatus resources
 func (c *V1Alpha1REST) ToolchainStatuses() ToolchainStatusInterface {
 	return &toolchainStatusClient{
+		crtClient: crtClient{
+			client: c.client.RestClient,
+			ns:     c.client.NS,
+			cfg:    c.client.Config,
+			scheme: c.client.Scheme,
+		},
+	}
+}
+
+// SocialEvents returns an interface which may be used to perform CRUD operations for SocialEvent resources
+func (c *V1Alpha1REST) SocialEvents() SocialEventInterface {
+	return &socialeventClient{
 		crtClient: crtClient{
 			client: c.client.RestClient,
 			ns:     c.client.NS,

--- a/pkg/kubeclient/socialevent.go
+++ b/pkg/kubeclient/socialevent.go
@@ -1,0 +1,31 @@
+package kubeclient
+
+import (
+	"context"
+
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
+)
+
+const (
+	socialeventResourcePlural = "socialevents"
+)
+
+type socialeventClient struct {
+	crtClient
+}
+
+type SocialEventInterface interface {
+	Get(name string) (*crtapi.SocialEvent, error)
+}
+
+// Get returns the SocialEvent with the specified name, or an error if something went wrong while attempting to retrieve it
+func (c *socialeventClient) Get(name string) (*crtapi.SocialEvent, error) {
+	result := &crtapi.SocialEvent{}
+	err := c.client.Get().
+		Namespace(c.ns).
+		Resource(socialeventResourcePlural).
+		Name(name).
+		Do(context.TODO()).
+		Into(result)
+	return result, err
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -87,7 +87,8 @@ func (srv *RegistrationServer) SetupRoutes() error {
 		// requires a ctx body containing the country_code and phone_number
 		securedV1.PUT("/signup/verification", signupCtrl.InitVerificationHandler)
 		securedV1.GET("/signup", signupCtrl.GetHandler)
-		securedV1.GET("/signup/verification/:code", signupCtrl.VerifyPhoneCodeHandler)
+		securedV1.GET("/signup/verification/:code", signupCtrl.VerifyPhoneCodeHandler) // TODO: also provide a `POST /signup/verification/phone-code` +deprecate this one + migrate UI?
+		securedV1.POST("/signup/verification/activation-code", signupCtrl.VerifyActivationCodeHandler)
 
 		// if we are in testing mode, we also add a secured health route for testing
 		if configuration.IsTestingMode() {

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -386,7 +386,7 @@ func (s *ServiceImpl) VerifyActivationCode(ctx *gin.Context, userID, username, c
 	event, err := s.CRTClient().V1Alpha1().SocialEvents().Get(code)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// The code doesn't match
+			// a SocialEvent was not found for the provided code
 			return crterrors.NewForbiddenError("invalid code", "the provided code is invalid")
 		}
 		return crterrors.NewInternalError(err, fmt.Sprintf("error retrieving event '%s'", code))

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -325,7 +325,7 @@ func (s *ServiceImpl) VerifyPhoneCode(ctx *gin.Context, userID, username, code s
 
 // VerifyActivationCode verifies the activation code:
 // - checks that the SocialEvent resource named after the activation code exists
-// - checks that the SocialEvent has enough capaticity to approve the user
+// - checks that the SocialEvent has enough capacity to approve the user
 func (s *ServiceImpl) VerifyActivationCode(ctx *gin.Context, userID, username, code string) error {
 	log.Infof(ctx, "verifying activation code '%s'", code)
 	// look-up the UserSignup

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -984,7 +984,7 @@ func (s *TestVerificationServiceSuite) TestVerifyActivationCode() {
 		err = s.Application.VerificationService().VerifyActivationCode(ctx, userSignup.Name, userSignup.Spec.Username, event.Name)
 
 		// then
-		require.EqualError(t, err, "invalid code: the provided code is invalid")
+		require.EqualError(t, err, "invalid code: the event is full")
 		userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
 		require.NoError(t, err)
 		require.True(t, states.VerificationRequired(userSignup))

--- a/test/fake/socialevent_client.go
+++ b/test/fake/socialevent_client.go
@@ -36,7 +36,7 @@ func NewFakeSocialEventClient(t *testing.T, namespace string, initObjs ...runtim
 	tracker := kubetesting.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
 	for _, obj := range initObjs {
 		err := tracker.Add(obj)
-		require.NoError(t, err, "failed to add object %v to fake usersignup client", obj)
+		require.NoError(t, err, "failed to add object %v to fake socialevent client", obj)
 	}
 	return &FakeSocialEventClient{
 		Tracker:   tracker,

--- a/test/fake/socialevent_client.go
+++ b/test/fake/socialevent_client.go
@@ -1,0 +1,75 @@
+package fake
+
+import (
+	"encoding/json"
+	"testing"
+
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/registration-service/pkg/kubeclient"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+type FakeSocialEventClient struct { // nolint:revive
+	Tracker               kubetesting.ObjectTracker
+	Scheme                *runtime.Scheme
+	namespace             string
+	MockGet               func(string) (*crtapi.SocialEvent, error)
+	MockCreate            func(*crtapi.SocialEvent) (*crtapi.SocialEvent, error)
+	MockUpdate            func(*crtapi.SocialEvent) (*crtapi.SocialEvent, error)
+	MockDelete            func(name string, options *metav1.DeleteOptions) error
+	MockListByHashedLabel func(labelKey, labelValue string) (*crtapi.SocialEventList, error)
+}
+
+var _ kubeclient.SocialEventInterface = &FakeSocialEventClient{}
+
+func NewFakeSocialEventClient(t *testing.T, namespace string, initObjs ...runtime.Object) *FakeSocialEventClient {
+	clientScheme := runtime.NewScheme()
+	err := crtapi.SchemeBuilder.AddToScheme(clientScheme)
+	require.NoError(t, err, "Error adding to scheme")
+	crtapi.SchemeBuilder.Register(&crtapi.SocialEvent{}, &crtapi.SocialEventList{})
+
+	tracker := kubetesting.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
+	for _, obj := range initObjs {
+		err := tracker.Add(obj)
+		require.NoError(t, err, "failed to add object %v to fake usersignup client", obj)
+	}
+	return &FakeSocialEventClient{
+		Tracker:   tracker,
+		Scheme:    clientScheme,
+		namespace: namespace,
+	}
+}
+
+func (c *FakeSocialEventClient) Get(name string) (*crtapi.SocialEvent, error) {
+	if c.MockGet != nil {
+		return c.MockGet(name)
+	}
+
+	obj := &crtapi.SocialEvent{}
+	gvr, err := getGVRFromObject(obj, c.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := c.Tracker.Get(gvr, c.namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -32,6 +32,7 @@ type UnitTestSuite struct {
 	FakeMasterUserRecordClient *fake.FakeMasterUserRecordClient
 	FakeBannedUserClient       *fake.FakeBannedUserClient
 	FakeToolchainStatusClient  *fake.FakeToolchainStatusClient
+	FakeSocialEventClient      *fake.FakeSocialEventClient
 	factoryOptions             []factory.Option
 }
 
@@ -54,6 +55,7 @@ func (s *UnitTestSuite) SetupDefaultApplication() {
 	s.FakeMasterUserRecordClient = fake.NewFakeMasterUserRecordClient(s.T(), configuration.Namespace())
 	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(s.T(), configuration.Namespace())
 	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(s.T(), configuration.Namespace())
+	s.FakeSocialEventClient = fake.NewFakeSocialEventClient(s.T(), configuration.Namespace())
 	s.Application = fake.NewMockableApplication(s, s.factoryOptions...)
 }
 
@@ -155,4 +157,8 @@ func (s *UnitTestSuite) BannedUsers() kubeclient.BannedUserInterface {
 
 func (s *UnitTestSuite) ToolchainStatuses() kubeclient.ToolchainStatusInterface {
 	return s.FakeToolchainStatusClient
+}
+
+func (s *UnitTestSuite) SocialEvents() kubeclient.SocialEventInterface {
+	return s.FakeSocialEventClient
 }


### PR DESCRIPTION
checks that the activation code is valid, ie:
- there is a `SocialEvent` resource named after the code (same name)
- there are enough seats available
- the start and end dates are valid

if one of the condition above is not met, an error is returned
and the user's attempts counter is incremented, until a max
is reached, after which no other attempt will be permitted.

If all good, then also label the UserSignup resource with the name
of the SocialEvent (ie, the activation code)

Note: updating the status of the `SocialEvent` resource when a user passed
the verification (ie, incrementing the `status.ActivationCount` is the responsibility
of the Host Operator and will be provided in a subsequent PR 
(because pairing multiple PRs with e2e tests is not supported)

See also:
- https://github.com/codeready-toolchain/api/pull/315
- https://github.com/codeready-toolchain/toolchain-common/pull/261
- https://github.com/codeready-toolchain/toolchain-e2e/pull/575

Fixes https://issues.redhat.com/browse/CRT-1386

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
