### PR TITLE
test: scripts to build/deploy on OpenShift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,3 +343,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/go,vim,git,macos,linux,emacs,windows,eclipse,intellij+all,visualstudiocode
+scripts/registration-service.yaml
+

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -e
+
+#-----------------------------------------------------------------------
+# Deploy the Registration Service in "dev mode":
+#
+# 1. Process the template with the following changes:
+#   a. set `IMAGE` to `quay.io/app-sre/ubi8-ubi:latest`
+#   b. set `REPLICAS` to 1
+# 2. Apply the template with Kustomize to:
+#   a. remove the liveness and healthcheck probes from the container spec
+#   b. set the container command to `sleep 36000` (10hrs)
+#-----------------------------------------------------------------------
+
+DIRNAME=$(dirname $0) # path to this script
+
+setup() {
+    echo "♻️ processing the registration-service.yaml template"
+    oc process \
+        -f $DIRNAME/../deploy/registration-service.yaml \
+        --local \
+        -o yaml > $DIRNAME/registration-service.yaml
+    echo "♻️ kustomizing and applying the registration-service deployment"
+    oc apply -k $DIRNAME 
+    echo "✅ done"
+}
+
+refresh() {
+    # build the registration service
+    echo "📦 building the binary"
+    VERBOSE=0 make build
+    echo "✅ done"
+
+    PODNAME=`oc get pods -l name=registration-service -o json | jq -r '.items[0].metadata.name'`
+    echo "🚚 copying the binary into the $PODNAME pod"
+    oc cp ./build/_output/bin/registration-service $PODNAME:/tmp
+    echo "☠️  stopping the current registration-service process (if applicable)"
+    oc exec $PODNAME -- killall registration-service || true
+    echo "🏃 running the new registration-service"
+    oc exec $PODNAME -- /tmp/registration-service &
+    echo "✅ done"
+}
+
+if declare -f "$1" > /dev/null
+then
+    # call arguments verbatim
+    "$@"
+else
+    # Show a helpful error
+    echo "'$1' is not a valid command" >&2
+    echo "available commands:"
+    echo "setup     Configure the deployment with a single pod"
+    echo "refresh   Rebuild the registration-service and update the pod"
+    echo ""
+    exit 1
+fi
+
+
+# Et voilà!
+echo "👋 all done!"

--- a/scripts/kustomization.yaml
+++ b/scripts/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+
+resources:
+- registration-service.yaml # generated
+
+patchesJson6902:
+- target:
+    version: v1
+    kind: Deployment
+    name: registration-service
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/image
+      # value: quay.io/app-sre/ubi8-ubi:latest
+      value: quay.io/prometheus/busybox:latest
+    - op: replace
+      path: /spec/replicas
+      value: 1
+    - op: remove
+      path: /spec/template/spec/containers/0/livenessProbe
+    - op: remove
+      path: /spec/template/spec/containers/0/readinessProbe
+    - op: replace
+      path: /spec/template/spec/containers/0/command/0
+      value: sleep
+    - op: add
+      path: /spec/template/spec/containers/0/args
+      value: ["36000"] # sleep for 10hrs (zzz...)


### PR DESCRIPTION
The `scripts/deploy-dev.sh` script has 2 functions to:
1. "setup": updates the `registration-service` deployment with the following changes:
  a. change the default image to `busybox` to provide commands such as `ps` and `killall`
  b. scales down to 1 replicas
  c. removes liveness probes and health probes to avoid restart by k8s
  d. runs a `sleep 36000` (10hrs) command instead of `registration-service`
2. "refresh":
  a. builds the binary
  b. copies into the pod
  c. kills previous instance of the `registration-service` process
  d. runs the new `registration-service` binary

After running the `scripts/deploy-dev.sh setup` command, there is a single
pod for the registration service, running the `sleep 36000` command, hence
nothing usable.

After each code change, running `scripts/deploy-dev.sh setup` will replace
the binary in the current pod and changes should be visible in the UI within
a few seconds.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
