### PR TITLE
Added originalsub claim to landing page header

### DIFF
--- a/pkg/assets/static/index.html
+++ b/pkg/assets/static/index.html
@@ -24,6 +24,7 @@
                 <span id="user-loggedin"><span id="username"></span> <button class="logoutbutton" onclick="keycloak.logout()">Logout</button></span>
             </div>
             <div class="pf-l-stack__item"><span id="userid"></span></div>
+            <div class="pf-l-stack__item"><span id="originalsub"></span></div>
             <div class="pf-l-stack__item"><button class="pf-c-button pf-m-inline pf-m-link pf-m-small" type="button"id="login-command" onclick="showLoginCommand()">Proxy login command</button></div>
             <div class="pf-l-stack__item" id="oc-login" style="display:none">
               <div class="pf-c-clipboard-copy">

--- a/pkg/assets/static/landingpage.js
+++ b/pkg/assets/static/landingpage.js
@@ -73,13 +73,16 @@ function showError(errorText) {
 }
 
 // shows a logged in user and its userId.
-function showUser(username, userid) {
+function showUser(username, userid, originalsub) {
   console.log('showing user..');
   document.getElementById('username').textContent = username;
   document.getElementById('user-loggedin').style.display = 'inline';
   console.log('showing userId..')
   document.getElementById('userid').textContent = userid;
   document.getElementById('userid').style.display = 'inline';
+  console.log('showing originalsub..')
+  document.getElementById('originalsub').textContent = originalsub;
+  document.getElementById('originalsub').style.display = 'inline';
   document.getElementById('login-command').style.display = 'inline';
   document.getElementById('oc-login').style.display = 'none';
   document.getElementById('user-notloggedin').style.display = 'none';
@@ -382,7 +385,7 @@ getJSON('GET', configURL, null, function(err, data) {
             .success(function(data) {
               console.log('retrieved user info..');
               idToken = keycloak.idToken
-              showUser(data.preferred_username, data.sub)
+              showUser(data.preferred_username, data.sub, data.original_sub)
               // now check the signup state of the user.
               updateSignupState();
             })


### PR DESCRIPTION
This PR modifies the landing page to display the user's original_sub claim value in the header.

Fixes https://issues.redhat.com/browse/CRT-1590