### PR TITLE
enable cross-platform build

### DIFF
--- a/make/build.mk
+++ b/make/build.mk
@@ -4,7 +4,7 @@ GO_PACKAGE_REPO_NAME ?= $(shell basename $$PWD)
 GO_PACKAGE_PATH ?= github.com/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}
 
 export LDFLAGS=-ldflags "-X ${GO_PACKAGE_PATH}/pkg/configuration.Commit=${GIT_COMMIT_ID} -X ${GO_PACKAGE_PATH}/cmd/configuration.BuildTime=${BUILD_TIME}"
-goarch=$(shell go env GOARCH)
+goarch ?= $(shell go env GOARCH)
 
 .PHONY: build build-prod build-dev
 

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -5,16 +5,17 @@ IMAGE ?= ${TARGET_REGISTRY}/${QUAY_NAMESPACE}/${GO_PACKAGE_REPO_NAME}:${IMAGE_TA
 QUAY_USERNAME ?= ${QUAY_NAMESPACE}
 TIMESTAMP := $(shell date +%s)
 IMAGE_DEV ?= ${TARGET_REGISTRY}/${QUAY_NAMESPACE}/${GO_PACKAGE_REPO_NAME}:${TIMESTAMP}
+IMAGE_PLATFORM ?= linux/amd64
 
 .PHONY: docker-image
 ## Build the docker image locally that can be deployed (only contains bare operator)
 docker-image: build
-	$(Q)docker build -f build/Dockerfile -t ${IMAGE} .
+	$(Q)docker build --platform ${IMAGE_PLATFORM} -f build/Dockerfile -t ${IMAGE} .
 
 .PHONY: docker-image-dev
 ## Build the docker image
 docker-image-dev: build
-	$(Q)docker build -f build/Dockerfile -t ${IMAGE_DEV}
+	$(Q)docker build --platform ${IMAGE_PLATFORM} -f build/Dockerfile -t ${IMAGE_DEV}
 
 .PHONY: docker-push
 ## Push the docker image to quay.io registry
@@ -24,7 +25,7 @@ docker-push: check-namespace docker-image
 .PHONY: podman-image
 ## Build the binary image
 podman-image: build
-	$(Q)podman build -f build/Dockerfile -t ${IMAGE} .
+	$(Q)podman build --platform ${IMAGE_PLATFORM} -f build/Dockerfile -t ${IMAGE} .
 
 .PHONY: podman-push
 ## Push the binary image to quay.io registry

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -1,5 +1,6 @@
 TMP_DIR?=/tmp
 IMAGE_BUILDER?=podman
+IMAGE_PLATFORM?=linux/amd64
 INDEX_IMAGE_NAME?=host-operator-index
 FIRST_RELEASE?=false
 CHANNEL=staging
@@ -26,7 +27,7 @@ push-bundle-and-index-image:
 ifneq (${BUNDLE_TAG},"")
 	$(eval BUNDLE_TAG_PARAM = -bt ${BUNDLE_TAG})
 endif
-	$(MAKE) run-cicd-script SCRIPT_PATH=scripts/cd/push-bundle-and-index-image.sh SCRIPT_PARAMS="-pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/ -qn ${QUAY_NAMESPACE} -ch ${CHANNEL} -td ${TMP_DIR} -ib ${IMAGE_BUILDER} -iin ${INDEX_IMAGE_NAME} -iit ${INDEX_IMAGE_TAG} ${BUNDLE_TAG_PARAM}"
+	$(MAKE) run-cicd-script SCRIPT_PATH=scripts/cd/push-bundle-and-index-image.sh SCRIPT_PARAMS="-pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/ -qn ${QUAY_NAMESPACE} -ch ${CHANNEL} -td ${TMP_DIR} -ib ${IMAGE_BUILDER} -iin ${INDEX_IMAGE_NAME} -iit ${INDEX_IMAGE_TAG} -ip ${IMAGE_PLATFORM} ${BUNDLE_TAG_PARAM}"
 
 .PHONY: publish-current-bundle
 ## Pushes generated manifests as a bundle image to quay and adds is to the image index as a single release using alpha channel


### PR DESCRIPTION
While building docker images on Mac M1 chipset and deploying to AWS dev environment (running on linux/amd64) I need to change the build platform from my default one.

This PR enables configuring the docker build platform option, example command to run from within the toolchain-e2e dir:

make dev-deploy-e2e HOST_REPO_PATH=$(PWD)/../host-operator goarch=amd64 IMAGE_BUILDER=docker

NOTE: doesn't work with podman on Apple M1 apparently, the images starting with FROM scratch are not being built for the architecture specified with --platform option but with the default one (in my case arm64 ). This could be an issue with podman on Mac only, since docker works fine.