### PR TITLE
Fix username

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,9 @@ require (
 	gotest.tools v2.2.0+incompatible
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.60.1
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 )
+
+require k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 
 require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect

--- a/pkg/proxy/access/clusteraccess.go
+++ b/pkg/proxy/access/clusteraccess.go
@@ -2,8 +2,6 @@ package access
 
 import (
 	"net/url"
-
-	"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
 )
 
 // ClusterAccess holds information needed to access user namespaces in a member cluster for the specific user via impersonation
@@ -12,15 +10,15 @@ type ClusterAccess struct { // nolint:revive
 	apiURL url.URL
 	// impersonatorToken is a token of the impersonator's Service Account, usually the impersonator SA belongs to a member toolchaincluster
 	impersonatorToken string
-	// username is the id of the user to use for impersonation
-	username string
+	// compliantUsername is the transformed username of the user (same as UserSignup.Status.CompliantUsername) to use for impersonation
+	compliantUsername string
 }
 
-func NewClusterAccess(apiURL url.URL, impersonatorToken, username string) *ClusterAccess {
+func NewClusterAccess(apiURL url.URL, impersonatorToken, compliantUsername string) *ClusterAccess {
 	return &ClusterAccess{
 		apiURL:            apiURL,
 		impersonatorToken: impersonatorToken,
-		username:          usersignup.TransformUsername(username),
+		compliantUsername: compliantUsername,
 	}
 }
 
@@ -32,6 +30,6 @@ func (a *ClusterAccess) ImpersonatorToken() string {
 	return a.impersonatorToken
 }
 
-func (a *ClusterAccess) Username() string {
-	return a.username
+func (a *ClusterAccess) CompliantUsername() string {
+	return a.compliantUsername
 }

--- a/pkg/proxy/access/clusteraccess.go
+++ b/pkg/proxy/access/clusteraccess.go
@@ -2,6 +2,8 @@ package access
 
 import (
 	"net/url"
+
+	"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
 )
 
 // ClusterAccess holds information needed to access user namespaces in a member cluster for the specific user via impersonation
@@ -18,7 +20,7 @@ func NewClusterAccess(apiURL url.URL, impersonatorToken, username string) *Clust
 	return &ClusterAccess{
 		apiURL:            apiURL,
 		impersonatorToken: impersonatorToken,
-		username:          username,
+		username:          usersignup.TransformUsername(username),
 	}
 }
 

--- a/pkg/proxy/cache_test.go
+++ b/pkg/proxy/cache_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test/fake"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,14 +26,14 @@ func (s *TestCacheSuite) TestCache() {
 	// given
 	memberURL, err := url.Parse("https://my.domain.com")
 	require.NoError(s.T(), err)
-	fakeApp := &fakeApp{}
+	fakeApp := &fake.ProxyFakeApp{}
 	csh := NewUserAccess(fakeApp)
 
 	johnNamespaceAccess := access.NewClusterAccess(*memberURL, "someToken", "john")
 
 	s.Run("first time - not found in existing cache", func() {
 		// when
-		fakeApp.accesses = map[string]*access.ClusterAccess{
+		fakeApp.Accesses = map[string]*access.ClusterAccess{
 			"johnUserID": johnNamespaceAccess,
 		}
 
@@ -44,7 +45,7 @@ func (s *TestCacheSuite) TestCache() {
 
 	s.Run("second time - valid cluster access found in cache", func() {
 		// when
-		fakeApp.accesses = map[string]*access.ClusterAccess{} // Fake access service doesn't have any access. To ensure that cache is used instead.
+		fakeApp.Accesses = map[string]*access.ClusterAccess{} // Fake access service doesn't have any access. To ensure that cache is used instead.
 
 		// then
 		ns, err := csh.Get(nil, "johnUserID", "john")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -193,7 +193,7 @@ func (p *Proxy) newReverseProxy(ctx *gin.Context, req *http.Request, target *acc
 		}
 
 		// Set impersonation header
-		req.Header.Set("Impersonate-User", target.Username())
+		req.Header.Set("Impersonate-User", target.CompliantUsername())
 	}
 	transport := http.DefaultTransport
 	if !configuration.GetRegistrationServiceConfig().IsProdEnvironment() {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	service2 "github.com/codeready-toolchain/registration-service/pkg/application/service"
+	appservice "github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/service"
@@ -268,6 +268,7 @@ func (s *TestProxySuite) TestProxy() {
 						ProxyRequestMethod: "OPTIONS",
 						ProxyRequestHeaders: map[string][]string{
 							"Origin":           {"https://domain.com"},
+							"Authorization":    {"Bearer clusterSAToken"},
 							"Impersonate-User": {"smith2"},
 						},
 						ExpectedProxyResponseHeaders: noCORSHeaders,
@@ -279,6 +280,7 @@ func (s *TestProxySuite) TestProxy() {
 						ProxyRequestHeaders: map[string][]string{
 							"Origin":                        {"https://domain.com"},
 							"Access-Control-Request-Method": {"UNKNOWN"},
+							"Authorization":                 {"Bearer clusterSAToken"},
 							"Impersonate-User":              {"smith2"},
 						},
 						ExpectedProxyResponseHeaders: noCORSHeaders,
@@ -449,7 +451,7 @@ func (s *TestProxySuite) TestProxy() {
 	}
 }
 
-func (s *TestProxySuite) newMemberClusterServiceWithMembers(serverURL string) service2.MemberClusterService {
+func (s *TestProxySuite) newMemberClusterServiceWithMembers(serverURL string) appservice.MemberClusterService {
 	return service.NewMemberClusterService(
 		fake.MemberClusterServiceContext{
 			Client: s,

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -386,7 +386,6 @@ func (s *TestProxySuite) TestProxy() {
 							}
 						}
 
-						// this is so silly :facepalm:
 						fakeApp.Err = nil
 
 						if !tc.Standalone {

--- a/pkg/proxy/service/cluster_service.go
+++ b/pkg/proxy/service/cluster_service.go
@@ -58,7 +58,7 @@ func (s *ServiceImpl) GetClusterAccess(ctx *gin.Context, userID, username string
 			}
 			// requests are made with member ToolchainCluster token, not user tokens
 			token := member.RestConfig.BearerToken
-			return access.NewClusterAccess(*apiURL, token, username), nil
+			return access.NewClusterAccess(*apiURL, token, signup.CompliantUsername), nil
 		}
 	}
 

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -6,14 +6,12 @@ import (
 	"net/url"
 	"testing"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	appservice "github.com/codeready-toolchain/registration-service/pkg/application/service"
 	regservicecontext "github.com/codeready-toolchain/registration-service/pkg/context"
-	"github.com/codeready-toolchain/registration-service/pkg/kubeclient"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/service"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/test"
+	"github.com/codeready-toolchain/registration-service/test/fake"
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 
@@ -35,19 +33,19 @@ func TestRunClusterServiceSuite(t *testing.T) {
 func (s *TestClusterServiceSuite) TestGetNamespace() {
 	// given
 
-	sc := newFakeSignupService().addSignup("123-noise", &signup.Signup{
+	sc := fake.NewSignupService(fake.Signup("123-noise", &signup.Signup{
 		CompliantUsername: "noise1",
 		Username:          "noise1",
 		Status: signup.Status{
 			Ready: true,
 		},
-	}).addSignup("456-not-ready", &signup.Signup{
+	}), fake.Signup("456-not-ready", &signup.Signup{
 		CompliantUsername: "john",
 		Username:          "john",
 		Status: signup.Status{
 			Ready: false,
 		},
-	}).addSignup("789-ready", &signup.Signup{
+	}), fake.Signup("789-ready", &signup.Signup{
 		APIEndpoint:       "https://api.endpoint.member-2.com:6443",
 		ClusterName:       "member-2",
 		CompliantUsername: "smith",
@@ -55,7 +53,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 		Status: signup.Status{
 			Ready: true,
 		},
-	}).addSignup("012-ready-unknown-cluster", &signup.Signup{
+	}), fake.Signup("012-ready-unknown-cluster", &signup.Signup{
 		APIEndpoint:       "https://api.endpoint.unknown.com:6443",
 		ClusterName:       "unknown",
 		CompliantUsername: "doe",
@@ -63,7 +61,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 		Status: signup.Status{
 			Ready: true,
 		},
-	})
+	}))
 	s.Application.MockSignupService(sc)
 
 	keys := make(map[string]interface{})
@@ -71,15 +69,15 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 	ctx := &gin.Context{Keys: keys}
 
 	svc := service.NewMemberClusterService(
-		serviceContext{
-			cl:  s,
-			svc: s.Application,
+		fake.MemberClusterServiceContext{
+			Client: s,
+			Svcs:   s.Application,
 		},
 	)
 
 	s.Run("unable to get signup", func() {
 		s.Run("signup service returns error", func() {
-			sc.mockGetSignup = func(userID, username string) (*signup.Signup, error) {
+			sc.MockGetSignup = func(userID, username string) (*signup.Signup, error) {
 				return nil, errors.New("oopsi woopsi")
 			}
 
@@ -90,7 +88,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 			require.EqualError(s.T(), err, "oopsi woopsi")
 		})
 
-		sc.mockGetSignup = sc.defaultMockGetSignup() // restore the default signup service, so it doesn't return an error anymore
+		sc.MockGetSignup = sc.DefaultMockGetSignup() // restore the default signup service, so it doesn't return an error anymore
 
 		s.Run("user is not found", func() {
 			// when
@@ -112,9 +110,9 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 	s.Run("no member cluster found", func() {
 		s.Run("no member clusters", func() {
 			svc := service.NewMemberClusterService(
-				serviceContext{
-					cl:  s,
-					svc: s.Application,
+				fake.MemberClusterServiceContext{
+					Client: s,
+					Svcs:   s.Application,
 				},
 				func(si *service.ServiceImpl) {
 					si.GetMembersFunc = func(conditions ...commoncluster.Condition) []*commoncluster.CachedToolchainCluster {
@@ -132,9 +130,9 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 
 		s.Run("no member cluster with the given URL", func() {
 			svc := service.NewMemberClusterService(
-				serviceContext{
-					cl:  s,
-					svc: s.Application,
+				fake.MemberClusterServiceContext{
+					Client: s,
+					Svcs:   s.Application,
 				},
 				func(si *service.ServiceImpl) {
 					si.GetMembersFunc = func(conditions ...commoncluster.Condition) []*commoncluster.CachedToolchainCluster {
@@ -155,9 +153,9 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 		memberClient := commontest.NewFakeClient(s.T())
 
 		svc := service.NewMemberClusterService(
-			serviceContext{
-				cl:  s,
-				svc: s.Application,
+			fake.MemberClusterServiceContext{
+				Client: s,
+				Svcs:   s.Application,
 			},
 			func(si *service.ServiceImpl) {
 				si.GetMembersFunc = func(conditions ...commoncluster.Condition) []*commoncluster.CachedToolchainCluster {
@@ -248,68 +246,4 @@ func (s *TestClusterServiceSuite) memberClusters() []*commoncluster.CachedToolch
 		})
 	}
 	return cls
-}
-
-type serviceContext struct {
-	cl  kubeclient.CRTClient
-	svc appservice.Services
-}
-
-func (sc serviceContext) CRTClient() kubeclient.CRTClient {
-	return sc.cl
-}
-
-func (sc serviceContext) Services() appservice.Services {
-	return sc.svc
-}
-
-func newFakeSignupService() *fakeSignupService {
-	f := &fakeSignupService{}
-	f.mockGetSignup = f.defaultMockGetSignup()
-	return f
-}
-
-func (m *fakeSignupService) addSignup(identifier string, userSignup *signup.Signup) *fakeSignupService {
-	if m.userSignups == nil {
-		m.userSignups = make(map[string]*signup.Signup)
-	}
-	m.userSignups[identifier] = userSignup
-	return m
-}
-
-type fakeSignupService struct {
-	mockGetSignup func(userID, username string) (*signup.Signup, error)
-	userSignups   map[string]*signup.Signup
-}
-
-func (m *fakeSignupService) defaultMockGetSignup() func(userID, username string) (*signup.Signup, error) {
-	return func(userID, username string) (userSignup *signup.Signup, e error) {
-		us := m.userSignups[userID]
-		if us != nil {
-			return us, nil
-		}
-		for _, v := range m.userSignups {
-			if v.Username == username {
-				return v, nil
-			}
-		}
-		return nil, nil
-	}
-}
-
-func (m *fakeSignupService) GetSignup(userID, username string) (*signup.Signup, error) {
-	return m.mockGetSignup(userID, username)
-}
-
-func (m *fakeSignupService) Signup(_ *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
-	return nil, nil
-}
-func (m *fakeSignupService) GetUserSignup(_, _ string) (*toolchainv1alpha1.UserSignup, error) {
-	return nil, nil
-}
-func (m *fakeSignupService) UpdateUserSignup(_ *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
-	return nil, nil
-}
-func (m *fakeSignupService) PhoneNumberAlreadyInUse(_, _, _ string) error {
-	return nil
 }

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -41,15 +41,15 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 		},
 	}), fake.Signup("456-not-ready", &signup.Signup{
 		CompliantUsername: "john",
-		Username:          "john",
+		Username:          "john@",
 		Status: signup.Status{
 			Ready: false,
 		},
 	}), fake.Signup("789-ready", &signup.Signup{
 		APIEndpoint:       "https://api.endpoint.member-2.com:6443",
 		ClusterName:       "member-2",
-		CompliantUsername: "smith",
-		Username:          "smith",
+		CompliantUsername: "smith2",
+		Username:          "smith@",
 		Status: signup.Status{
 			Ready: true,
 		},
@@ -57,7 +57,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 		APIEndpoint:       "https://api.endpoint.unknown.com:6443",
 		ClusterName:       "unknown",
 		CompliantUsername: "doe",
-		Username:          "doe",
+		Username:          "doe@",
 		Status: signup.Status{
 			Ready: true,
 		},
@@ -205,12 +205,13 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 			require.NotNil(s.T(), ca)
 			expectedURL, err := url.Parse("https://api.endpoint.member-2.com:6443")
 			require.NoError(s.T(), err)
+			assert.Equal(s.T(), "smith2", ca.CompliantUsername())
 
 			s.assertClusterAccess(access.NewClusterAccess(*expectedURL, expectedToken, ""), ca)
 
 			s.Run("cluster access correct when username provided", func() {
 				// when
-				ca, err := svc.GetClusterAccess(ctx, "", "smith")
+				ca, err := svc.GetClusterAccess(ctx, "", "smith@")
 
 				// then
 				require.NoError(s.T(), err)
@@ -218,6 +219,7 @@ func (s *TestClusterServiceSuite) TestGetNamespace() {
 				expectedURL, err := url.Parse("https://api.endpoint.member-2.com:6443")
 				require.NoError(s.T(), err)
 				s.assertClusterAccess(access.NewClusterAccess(*expectedURL, expectedToken, "smith"), ca)
+				assert.Equal(s.T(), "smith2", ca.CompliantUsername())
 			})
 		})
 	})

--- a/test/fake/proxy.go
+++ b/test/fake/proxy.go
@@ -1,0 +1,127 @@
+package fake
+
+import (
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/registration-service/pkg/application/service"
+	appservice "github.com/codeready-toolchain/registration-service/pkg/application/service"
+	"github.com/codeready-toolchain/registration-service/pkg/kubeclient"
+	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
+	"github.com/codeready-toolchain/registration-service/pkg/signup"
+	"github.com/gin-gonic/gin"
+)
+
+// This whole service abstraction is such a huge pain. We have to get rid of it!!!
+
+type ProxyFakeApp struct {
+	Accesses                 map[string]*access.ClusterAccess
+	Err                      error
+	SignupServiceMock        service.SignupService
+	MemberClusterServiceMock service.MemberClusterService
+}
+
+func (a *ProxyFakeApp) SignupService() service.SignupService {
+	if a.SignupServiceMock != nil {
+		return a.SignupServiceMock
+	}
+	panic("SignupService shouldn't be called")
+}
+
+func (a *ProxyFakeApp) VerificationService() service.VerificationService {
+	panic("VerificationService shouldn't be called")
+}
+
+func (a *ProxyFakeApp) MemberClusterService() service.MemberClusterService {
+	if a.MemberClusterServiceMock != nil {
+		return a.MemberClusterServiceMock
+	}
+	return &fakeClusterService{a}
+}
+
+type fakeClusterService struct {
+	fakeApp *ProxyFakeApp
+}
+
+func (f *fakeClusterService) GetClusterAccess(_ *gin.Context, userID, _ string) (*access.ClusterAccess, error) {
+	return f.fakeApp.Accesses[userID], f.fakeApp.Err
+}
+
+type SignupDef func() (string, *signup.Signup)
+
+func Signup(identifier string, userSignup *signup.Signup) SignupDef {
+	return func() (string, *signup.Signup) {
+		return identifier, userSignup
+	}
+}
+
+func NewSignupService(signupDefs ...SignupDef) *SignupService {
+	sc := newFakeSignupService()
+	for _, signupDef := range signupDefs {
+		identifier, signup := signupDef()
+		sc.addSignup(identifier, signup)
+	}
+	return sc
+}
+
+func newFakeSignupService() *SignupService {
+	f := &SignupService{}
+	f.MockGetSignup = f.DefaultMockGetSignup()
+	return f
+}
+
+func (m *SignupService) addSignup(identifier string, userSignup *signup.Signup) *SignupService {
+	if m.userSignups == nil {
+		m.userSignups = make(map[string]*signup.Signup)
+	}
+	m.userSignups[identifier] = userSignup
+	return m
+}
+
+type SignupService struct {
+	MockGetSignup func(userID, username string) (*signup.Signup, error)
+	userSignups   map[string]*signup.Signup
+}
+
+func (m *SignupService) DefaultMockGetSignup() func(userID, username string) (*signup.Signup, error) {
+	return func(userID, username string) (userSignup *signup.Signup, e error) {
+		us := m.userSignups[userID]
+		if us != nil {
+			return us, nil
+		}
+		for _, v := range m.userSignups {
+			if v.Username == username {
+				return v, nil
+			}
+		}
+		return nil, nil
+	}
+}
+
+func (m *SignupService) GetSignup(userID, username string) (*signup.Signup, error) {
+	return m.MockGetSignup(userID, username)
+}
+
+func (m *SignupService) Signup(_ *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
+	return nil, nil
+}
+func (m *SignupService) GetUserSignup(_, _ string) (*toolchainv1alpha1.UserSignup, error) {
+	return nil, nil
+}
+func (m *SignupService) UpdateUserSignup(_ *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
+	return nil, nil
+}
+func (m *SignupService) PhoneNumberAlreadyInUse(_, _, _ string) error {
+	return nil
+}
+
+type MemberClusterServiceContext struct {
+	Client kubeclient.CRTClient
+	Svcs   appservice.Services
+}
+
+func (sc MemberClusterServiceContext) CRTClient() kubeclient.CRTClient {
+	return sc.Client
+}
+
+func (sc MemberClusterServiceContext) Services() appservice.Services {
+	return sc.Svcs
+}


### PR DESCRIPTION
CompliantUsername should be used for impersonation since the username in the RoleBinding in the user namespace is the CompliantUsername.

```
subjects:
  - kind: User
    apiGroup: rbac.authorization.k8s.io
    name: compliantusername
```