### PR TITLE
Proxy workspace context

### DIFF
--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -32,9 +32,10 @@ objects:
           - toolchain.dev.openshift.com
         resources:
           - masteruserrecords
+          - socialevents
+          - spaces
           - toolchainconfigs
           - toolchainstatuses
-          - socialevents
         verbs:
           - get
           - list
@@ -98,7 +99,7 @@ objects:
                 - registration-service
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                failureThreshold: 3
+                failureThreshold: 5
                 httpGet:
                   path: /api/v1/health
                   port: 8080

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -119,13 +119,13 @@ objects:
                 successThreshold: 1
                 timeoutSeconds: 1
               startupProbe:
-                failureThreshold: 18
+                failureThreshold: 180
                 httpGet:
                   path: /api/v1/health
                   port: 8080
                   scheme: HTTP
                 initialDelaySeconds: 1
-                periodSeconds: 10
+                periodSeconds: 1
                 successThreshold: 1
                 timeoutSeconds: 1
               env:

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -99,12 +99,12 @@ objects:
                 - registration-service
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                failureThreshold: 5
+                failureThreshold: 3
                 httpGet:
                   path: /api/v1/health
                   port: 8080
                   scheme: HTTP
-                initialDelaySeconds: 30
+                initialDelaySeconds: 1
                 periodSeconds: 10
                 successThreshold: 1
                 timeoutSeconds: 1
@@ -114,8 +114,18 @@ objects:
                   path: /api/v1/health
                   port: 8080
                   scheme: HTTP
-                initialDelaySeconds: 30
+                initialDelaySeconds: 1
                 periodSeconds: 1
+                successThreshold: 1
+                timeoutSeconds: 1
+              startupProbe:
+                failureThreshold: 18
+                httpGet:
+                  path: /api/v1/health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 1
+                periodSeconds: 10
                 successThreshold: 1
                 timeoutSeconds: 1
               env:

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -9,6 +9,7 @@ import (
 
 type InformerService interface {
 	GetMasterUserRecord(name string) (*toolchainv1alpha1.MasterUserRecord, error)
+	GetSpace(name string) (*toolchainv1alpha1.Space, error)
 	GetToolchainStatus() (*toolchainv1alpha1.ToolchainStatus, error)
 	GetUserSignup(name string) (*toolchainv1alpha1.UserSignup, error)
 }
@@ -34,6 +35,7 @@ type VerificationService interface {
 
 type MemberClusterService interface {
 	GetClusterAccess(userID, username string) (*access.ClusterAccess, error)
+	GetWorkspaceAccess(userID, username, workspace string) (*access.ClusterAccess, error)
 }
 
 type Services interface {

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -34,8 +34,7 @@ type VerificationService interface {
 }
 
 type MemberClusterService interface {
-	GetClusterAccess(userID, username string) (*access.ClusterAccess, error)
-	GetWorkspaceAccess(userID, username, workspace string) (*access.ClusterAccess, error)
+	GetClusterAccess(userID, username, workspace string) (*access.ClusterAccess, error)
 }
 
 type Services interface {

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -34,7 +34,7 @@ type VerificationService interface {
 }
 
 type MemberClusterService interface {
-	GetClusterAccess(userID, username, workspace string) (*access.ClusterAccess, error)
+	GetClusterAccess(ctx *gin.Context, userID, username, workspace string) (*access.ClusterAccess, error)
 }
 
 type Services interface {

--- a/pkg/informers/informers.go
+++ b/pkg/informers/informers.go
@@ -38,7 +38,7 @@ func StartInformer(cfg *rest.Config) (*Informer, chan struct{}, error) {
 	masterUserRecordInformer := genericMasterUserRecordInformer.Informer()
 
 	// Space
-	genericSpaceInformer := factory.ForResource(schema.GroupVersionResource{Group: "toolchain.dev.openshift.com", Version: "v1alpha1", Resource: kubeclient.SpaceResourcePlural})
+	genericSpaceInformer := factory.ForResource(schema.GroupVersionResource{Group: "toolchain.dev.openshift.com", Version: "v1alpha1", Resource: resources.SpaceResourcePlural})
 	informer.Space = genericSpaceInformer.Lister()
 	spaceInformer := genericSpaceInformer.Informer()
 

--- a/pkg/informers/informers.go
+++ b/pkg/informers/informers.go
@@ -17,8 +17,9 @@ import (
 
 type Informer struct {
 	Masteruserrecord cache.GenericLister
-	UserSignup       cache.GenericLister
+	Space            cache.GenericLister
 	ToolchainStatus  cache.GenericLister
+	UserSignup       cache.GenericLister
 }
 
 func StartInformer(cfg *rest.Config) (*Informer, chan struct{}, error) {
@@ -36,6 +37,11 @@ func StartInformer(cfg *rest.Config) (*Informer, chan struct{}, error) {
 	informer.Masteruserrecord = genericMasterUserRecordInformer.Lister()
 	masterUserRecordInformer := genericMasterUserRecordInformer.Informer()
 
+	// Space
+	genericSpaceInformer := factory.ForResource(schema.GroupVersionResource{Group: "toolchain.dev.openshift.com", Version: "v1alpha1", Resource: kubeclient.SpaceResourcePlural})
+	informer.Space = genericSpaceInformer.Lister()
+	spaceInformer := genericSpaceInformer.Informer()
+
 	// ToolchainStatus
 	genericToolchainStatusInformer := factory.ForResource(schema.GroupVersionResource{Group: "toolchain.dev.openshift.com", Version: "v1alpha1", Resource: kubeclient.ToolchainStatusPlural})
 	informer.ToolchainStatus = genericToolchainStatusInformer.Lister()
@@ -51,7 +57,12 @@ func StartInformer(cfg *rest.Config) (*Informer, chan struct{}, error) {
 	log.Info(nil, "Starting proxy cache informers")
 	factory.Start(stopper)
 
-	if !cache.WaitForCacheSync(stopper, masterUserRecordInformer.HasSynced, userSignupInformer.HasSynced, toolchainstatusInformer.HasSynced) {
+	if !cache.WaitForCacheSync(stopper,
+		masterUserRecordInformer.HasSynced,
+		spaceInformer.HasSynced,
+		toolchainstatusInformer.HasSynced,
+		userSignupInformer.HasSynced,
+	) {
 		err := fmt.Errorf("timed out waiting for caches to sync")
 		log.Error(nil, err, "Failed to create informers")
 		return nil, nil, err

--- a/pkg/informers/service/informer_service.go
+++ b/pkg/informers/service/informer_service.go
@@ -50,6 +50,21 @@ func (s *ServiceImpl) GetMasterUserRecord(name string) (*toolchainv1alpha1.Maste
 	return mur, err
 }
 
+func (s *ServiceImpl) GetSpace(name string) (*toolchainv1alpha1.Space, error) {
+	obj, err := s.informer.Space.ByNamespace(configuration.Namespace()).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	unobj := obj.(*unstructured.Unstructured)
+	space := &toolchainv1alpha1.Space{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unobj.UnstructuredContent(), space); err != nil {
+		log.Errorf(nil, err, "failed to get Space '%s'", name)
+		return nil, err
+	}
+	return space, err
+}
+
 func (s *ServiceImpl) GetToolchainStatus() (*toolchainv1alpha1.ToolchainStatus, error) {
 	obj, err := s.informer.ToolchainStatus.ByNamespace(configuration.Namespace()).Get(kubeclient.ToolchainStatusName)
 	if err != nil {

--- a/pkg/kubeclient/resources.go
+++ b/pkg/kubeclient/resources.go
@@ -3,5 +3,6 @@ package kubeclient
 const (
 	UserSignupResourcePlural = "usersignups"
 	MurResourcePlural        = "masteruserrecords"
+	SpaceResourcePlural      = "spaces"
 	ToolchainStatusPlural    = "toolchainstatuses"
 )

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -107,8 +107,6 @@ func (p *Proxy) handleRequestAndRedirect(res http.ResponseWriter, req *http.Requ
 	userID := ctx.GetString(context.SubKey)
 	username := ctx.GetString(context.UsernameKey)
 
-	log.Info(ctx, fmt.Sprintf("req.URL.Path: %s", req.URL.Path)) // req.URL.Path: /workspaces/mycoolworkspace/api/pods
-
 	cluster, err := p.getClusterAccess(req, userID, username)
 	if err != nil {
 		log.Error(ctx, err, "unable to get target cluster")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -107,7 +107,13 @@ func (p *Proxy) handleRequestAndRedirect(res http.ResponseWriter, req *http.Requ
 	userID := ctx.GetString(context.SubKey)
 	username := ctx.GetString(context.UsernameKey)
 
-	cluster, err := p.getClusterAccess(req, userID, username)
+	workspace, err := handleWorkspaceContext(req)
+	if err != nil {
+		log.Error(ctx, err, "unable to get handle workspace context")
+		responseWithError(res, crterrors.NewInternalError(errs.New("unable to get target cluster"), err.Error()))
+	}
+
+	cluster, err := p.app.MemberClusterService().GetClusterAccess(userID, username, workspace)
 	if err != nil {
 		log.Error(ctx, err, "unable to get target cluster")
 		responseWithError(res, crterrors.NewInternalError(errs.New("unable to get target cluster"), err.Error()))
@@ -118,22 +124,22 @@ func (p *Proxy) handleRequestAndRedirect(res http.ResponseWriter, req *http.Requ
 	p.newReverseProxy(ctx, req, cluster).ServeHTTP(res, req)
 }
 
-func (p *Proxy) getClusterAccess(req *http.Request, userID, username string) (*access.ClusterAccess, error) {
+func handleWorkspaceContext(req *http.Request) (string, error) {
 	path := req.URL.Path
-	workspace := ""
+	var workspace string
 	// handle specific workspace request eg. /workspaces/mycoolworkspace/api/pods
 	if strings.HasPrefix(path, "/workspaces/") {
 		segments := strings.Split(path, "/")
 		// there should be at least 4 segments eg. /workspaces/mycoolworkspace/api counts as 4
 		if len(segments) < 4 {
-			return nil, fmt.Errorf("invalid workspace context request")
+			return "", fmt.Errorf("workspace request path has too few segments '%s'", path)
 		}
 		// get the workspace segment eg. mycoolworkspace
-		workspace := segments[2]
+		workspace = segments[2]
 		// remove workspaces/mycoolworkspace from the request path before forwarding the request
 		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/workspaces/"+workspace)
 	}
-	return p.app.MemberClusterService().GetClusterAccess(userID, username, workspace)
+	return workspace, nil
 }
 
 func responseWithError(res http.ResponseWriter, err *crterrors.Error) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -132,7 +132,7 @@ func handleWorkspaceContext(req *http.Request) (string, error) {
 		segments := strings.Split(path, "/")
 		// there should be at least 4 segments eg. /workspaces/mycoolworkspace/api counts as 4
 		if len(segments) < 4 {
-			return "", fmt.Errorf("workspace request path has too few segments '%s'", path)
+			return "", fmt.Errorf("workspace request path has too few segments '%s'; expected path format: /workspaces/<workspace_name>/api/...", path)
 		}
 		// get the workspace segment eg. mycoolworkspace
 		workspace = segments[2]

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -132,7 +132,7 @@ func handleWorkspaceContext(req *http.Request) (string, error) {
 		segments := strings.Split(path, "/")
 		// there should be at least 4 segments eg. /workspaces/mycoolworkspace/api counts as 4
 		if len(segments) < 4 {
-			return "", fmt.Errorf("workspace request path has too few segments '%s'; expected path format: /workspaces/<workspace_name>/api/...", path)
+			return "", fmt.Errorf("workspace request path has too few segments '%s'; expected path format: /workspaces/<workspace_name>/api/...", path) // nolint:revive
 		}
 		// get the workspace segment eg. mycoolworkspace
 		workspace = segments[2]

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -107,7 +107,7 @@ func (p *Proxy) handleRequestAndRedirect(res http.ResponseWriter, req *http.Requ
 	userID := ctx.GetString(context.SubKey)
 	username := ctx.GetString(context.UsernameKey)
 
-	cluster, err := p.getClusterAccess(ctx, req, userID, username)
+	cluster, err := p.getClusterAccess(req, userID, username)
 	if err != nil {
 		log.Error(ctx, err, "unable to get target cluster")
 		responseWithError(res, crterrors.NewInternalError(errs.New("unable to get target cluster"), err.Error()))
@@ -118,7 +118,7 @@ func (p *Proxy) handleRequestAndRedirect(res http.ResponseWriter, req *http.Requ
 	p.newReverseProxy(ctx, req, cluster).ServeHTTP(res, req)
 }
 
-func (p *Proxy) getClusterAccess(ctx *gin.Context, req *http.Request, userID, username string) (*access.ClusterAccess, error) {
+func (p *Proxy) getClusterAccess(req *http.Request, userID, username string) (*access.ClusterAccess, error) {
 	path := req.URL.Path
 	workspace := ""
 	// handle specific workspace request eg. /workspaces/mycoolworkspace/api/pods

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -113,7 +113,7 @@ func (p *Proxy) handleRequestAndRedirect(res http.ResponseWriter, req *http.Requ
 		responseWithError(res, crterrors.NewInternalError(errs.New("unable to get target cluster"), err.Error()))
 	}
 
-	cluster, err := p.app.MemberClusterService().GetClusterAccess(userID, username, workspace)
+	cluster, err := p.app.MemberClusterService().GetClusterAccess(ctx, userID, username, workspace)
 	if err != nil {
 		log.Error(ctx, err, "unable to get target cluster")
 		responseWithError(res, crterrors.NewInternalError(errs.New("unable to get target cluster"), err.Error()))

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -382,6 +382,8 @@ func (s *TestProxySuite) TestProxy() {
 				for k, tc := range tests {
 					s.Run(k, func() {
 
+						// Test each request using both the default workspace URL and a URL that uses the
+						// workspace context. Both should yield the same results.
 						for workspaceContext, reqPath := range map[string]string{
 							"default workspace": "http://localhost:8081/api/mycoolworkspace/pods",
 							"workspace context": "http://localhost:8081/workspaces/mycoolworkspace/api/pods",

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -2,20 +2,26 @@ package proxy
 
 import (
 	"bytes"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	appservice "github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
+	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/service"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/test"
 	"github.com/codeready-toolchain/registration-service/test/fake"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
@@ -88,160 +94,160 @@ func (s *TestProxySuite) TestProxy() {
 			}
 			require.True(s.T(), ready, "Proxy is not ready after %d seconds", sec)
 
-			// s.Run("health check ok", func() {
-			// 	req, err := http.NewRequest("GET", "http://localhost:8081/proxyhealth", nil)
-			// 	require.NoError(s.T(), err)
-			// 	require.NotNil(s.T(), req)
+			s.Run("health check ok", func() {
+				req, err := http.NewRequest("GET", "http://localhost:8081/proxyhealth", nil)
+				require.NoError(s.T(), err)
+				require.NotNil(s.T(), req)
 
-			// 	// when
-			// 	resp, err := http.DefaultClient.Do(req)
+				// when
+				resp, err := http.DefaultClient.Do(req)
 
-			// 	// then
-			// 	require.NoError(s.T(), err)
-			// 	require.NotNil(s.T(), resp)
-			// 	assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
-			// 	s.assertResponseBody(resp, `{"alive": true}`)
-			// })
+				// then
+				require.NoError(s.T(), err)
+				require.NotNil(s.T(), resp)
+				assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
+				s.assertResponseBody(resp, `{"alive": true}`)
+			})
 
-			// s.Run("plain http error", func() {
-			// 	s.Run("unauthorized if no token present", func() {
-			// 		req, err := http.NewRequest("GET", "http://localhost:8081/api/mycoolworkspace/pods", nil)
-			// 		require.NoError(s.T(), err)
-			// 		require.NotNil(s.T(), req)
+			s.Run("plain http error", func() {
+				s.Run("unauthorized if no token present", func() {
+					req, err := http.NewRequest("GET", "http://localhost:8081/api/mycoolworkspace/pods", nil)
+					require.NoError(s.T(), err)
+					require.NotNil(s.T(), req)
 
-			// 		// when
-			// 		resp, err := http.DefaultClient.Do(req)
+					// when
+					resp, err := http.DefaultClient.Do(req)
 
-			// 		// then
-			// 		require.NoError(s.T(), err)
-			// 		require.NotNil(s.T(), resp)
-			// 		assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
-			// 		s.assertResponseBody(resp, "invalid bearer token: no token found: a Bearer token is expected\n")
-			// 	})
+					// then
+					require.NoError(s.T(), err)
+					require.NotNil(s.T(), resp)
+					assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
+					s.assertResponseBody(resp, "invalid bearer token: no token found: a Bearer token is expected\n")
+				})
 
-			// 	s.Run("unauthorized if can't parse token", func() {
-			// 		// when
-			// 		req, err := http.NewRequest("GET", "http://localhost:8081/api/mycoolworkspace/pods", nil)
-			// 		require.NoError(s.T(), err)
-			// 		require.NotNil(s.T(), req)
-			// 		req.Header.Set("Authorization", "Bearer not-a-token")
-			// 		resp, err := http.DefaultClient.Do(req)
+				s.Run("unauthorized if can't parse token", func() {
+					// when
+					req, err := http.NewRequest("GET", "http://localhost:8081/api/mycoolworkspace/pods", nil)
+					require.NoError(s.T(), err)
+					require.NotNil(s.T(), req)
+					req.Header.Set("Authorization", "Bearer not-a-token")
+					resp, err := http.DefaultClient.Do(req)
 
-			// 		// then
-			// 		require.NoError(s.T(), err)
-			// 		require.NotNil(s.T(), resp)
-			// 		assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
-			// 		s.assertResponseBody(resp, "invalid bearer token: unable to extract userID from token: token contains an invalid number of segments\n")
-			// 	})
+					// then
+					require.NoError(s.T(), err)
+					require.NotNil(s.T(), resp)
+					assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
+					s.assertResponseBody(resp, "invalid bearer token: unable to extract userID from token: token contains an invalid number of segments\n")
+				})
 
-			// 	s.Run("unauthorized if can't extract userID from a valid token", func() {
-			// 		// when
-			// 		req, err := http.NewRequest("GET", "http://localhost:8081/api/mycoolworkspace/pods", nil)
-			// 		require.NoError(s.T(), err)
-			// 		require.NotNil(s.T(), req)
-			// 		userID, err := uuid.NewV4()
-			// 		require.NoError(s.T(), err)
-			// 		req.Header.Set("Authorization", "Bearer "+s.token(userID, authsupport.WithSubClaim("")))
-			// 		resp, err := http.DefaultClient.Do(req)
+				s.Run("unauthorized if can't extract userID from a valid token", func() {
+					// when
+					req, err := http.NewRequest("GET", "http://localhost:8081/api/mycoolworkspace/pods", nil)
+					require.NoError(s.T(), err)
+					require.NotNil(s.T(), req)
+					userID, err := uuid.NewV4()
+					require.NoError(s.T(), err)
+					req.Header.Set("Authorization", "Bearer "+s.token(userID, authsupport.WithSubClaim("")))
+					resp, err := http.DefaultClient.Do(req)
 
-			// 		// then
-			// 		require.NoError(s.T(), err)
-			// 		require.NotNil(s.T(), resp)
-			// 		assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
-			// 		s.assertResponseBody(resp, "invalid bearer token: unable to extract userID from token: token does not comply to expected claims: subject missing\n")
-			// 	})
+					// then
+					require.NoError(s.T(), err)
+					require.NotNil(s.T(), resp)
+					assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
+					s.assertResponseBody(resp, "invalid bearer token: unable to extract userID from token: token does not comply to expected claims: subject missing\n")
+				})
 
-			// 	s.Run("internal error if get accesses returns an error", func() {
-			// 		// given
-			// 		req, _ := s.request()
-			// 		fakeApp.Accesses = map[string]*access.ClusterAccess{}
-			// 		fakeApp.Err = errors.New("some-error")
+				s.Run("internal error if get accesses returns an error", func() {
+					// given
+					req, _ := s.request()
+					fakeApp.Accesses = map[string]*access.ClusterAccess{}
+					fakeApp.Err = errors.New("some-error")
 
-			// 		// when
-			// 		resp, err := http.DefaultClient.Do(req)
+					// when
+					resp, err := http.DefaultClient.Do(req)
 
-			// 		// then
-			// 		require.NoError(s.T(), err)
-			// 		require.NotNil(s.T(), resp)
-			// 		assert.Equal(s.T(), http.StatusInternalServerError, resp.StatusCode)
-			// 		s.assertResponseBody(resp, "unable to get target cluster: some-error\n")
-			// 	})
-			// })
+					// then
+					require.NoError(s.T(), err)
+					require.NotNil(s.T(), resp)
+					assert.Equal(s.T(), http.StatusInternalServerError, resp.StatusCode)
+					s.assertResponseBody(resp, "unable to get target cluster: some-error\n")
+				})
+			})
 
-			// s.Run("websockets error", func() {
-			// 	tests := map[string]struct {
-			// 		ProtocolHeaders []string
-			// 		ExpectedError   string
-			// 	}{
-			// 		"empty token": {
-			// 			ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.,dummy"},
-			// 			ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
-			// 		},
-			// 		"not a jwt token": {
-			// 			ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.dG9rZW4,dummy"},
-			// 			ExpectedError:   "invalid bearer token: unable to extract userID from token: token contains an invalid number of segments",
-			// 		},
-			// 		"invalid token is not base64 encoded": {
-			// 			ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.token,dummy"},
-			// 			ExpectedError:   "invalid bearer token: invalid base64.bearer.authorization token encoding: illegal base64 data at input byte 4",
-			// 		},
-			// 		"invalid token contains non UTF-8-encoded runes": {
-			// 			ProtocolHeaders: []string{fmt.Sprintf("base64url.bearer.authorization.k8s.io.%s,dummy", base64.RawURLEncoding.EncodeToString([]byte("aa\xe2")))},
-			// 			ExpectedError:   "invalid bearer token: invalid base64.bearer.authorization token: contains non UTF-8-encoded runes",
-			// 		},
-			// 		"no header": {
-			// 			ProtocolHeaders: nil,
-			// 			ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
-			// 		},
-			// 		"empty header": {
-			// 			ProtocolHeaders: []string{""},
-			// 			ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
-			// 		},
-			// 		"non-bearer header": {
-			// 			ProtocolHeaders: []string{"undefined"},
-			// 			ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
-			// 		},
-			// 		"empty bearer token": {
-			// 			ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io."},
-			// 			ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
-			// 		},
-			// 		"multiple bearer tokens": {
-			// 			ProtocolHeaders: []string{
-			// 				"base64url.bearer.authorization.k8s.io.dG9rZW4,dummy",
-			// 				"base64url.bearer.authorization.k8s.io.dG9rZW4,dummy",
-			// 			},
-			// 			ExpectedError: "invalid bearer token: multiple base64.bearer.authorization tokens specified",
-			// 		},
-			// 	}
+			s.Run("websockets error", func() {
+				tests := map[string]struct {
+					ProtocolHeaders []string
+					ExpectedError   string
+				}{
+					"empty token": {
+						ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.,dummy"},
+						ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
+					},
+					"not a jwt token": {
+						ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.dG9rZW4,dummy"},
+						ExpectedError:   "invalid bearer token: unable to extract userID from token: token contains an invalid number of segments",
+					},
+					"invalid token is not base64 encoded": {
+						ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.token,dummy"},
+						ExpectedError:   "invalid bearer token: invalid base64.bearer.authorization token encoding: illegal base64 data at input byte 4",
+					},
+					"invalid token contains non UTF-8-encoded runes": {
+						ProtocolHeaders: []string{fmt.Sprintf("base64url.bearer.authorization.k8s.io.%s,dummy", base64.RawURLEncoding.EncodeToString([]byte("aa\xe2")))},
+						ExpectedError:   "invalid bearer token: invalid base64.bearer.authorization token: contains non UTF-8-encoded runes",
+					},
+					"no header": {
+						ProtocolHeaders: nil,
+						ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
+					},
+					"empty header": {
+						ProtocolHeaders: []string{""},
+						ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
+					},
+					"non-bearer header": {
+						ProtocolHeaders: []string{"undefined"},
+						ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
+					},
+					"empty bearer token": {
+						ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io."},
+						ExpectedError:   "invalid bearer token: no base64.bearer.authorization token found",
+					},
+					"multiple bearer tokens": {
+						ProtocolHeaders: []string{
+							"base64url.bearer.authorization.k8s.io.dG9rZW4,dummy",
+							"base64url.bearer.authorization.k8s.io.dG9rZW4,dummy",
+						},
+						ExpectedError: "invalid bearer token: multiple base64.bearer.authorization tokens specified",
+					},
+				}
 
-			// 	for k, tc := range tests {
-			// 		s.Run(k, func() {
-			// 			req, err := http.NewRequest("GET", "http://localhost:8081/api/mycoolworkspace/pods", nil)
-			// 			require.NoError(s.T(), err)
-			// 			require.NotNil(s.T(), req)
-			// 			upgradeToWebsocket(req)
-			// 			for _, h := range tc.ProtocolHeaders {
-			// 				req.Header.Add("Sec-Websocket-Protocol", h)
-			// 			}
+				for k, tc := range tests {
+					s.Run(k, func() {
+						req, err := http.NewRequest("GET", "http://localhost:8081/api/mycoolworkspace/pods", nil)
+						require.NoError(s.T(), err)
+						require.NotNil(s.T(), req)
+						upgradeToWebsocket(req)
+						for _, h := range tc.ProtocolHeaders {
+							req.Header.Add("Sec-Websocket-Protocol", h)
+						}
 
-			// 			// when
-			// 			resp, err := http.DefaultClient.Do(req)
+						// when
+						resp, err := http.DefaultClient.Do(req)
 
-			// 			// then
-			// 			require.NoError(s.T(), err)
-			// 			require.NotNil(s.T(), resp)
-			// 			assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
-			// 			s.assertResponseBody(resp, tc.ExpectedError+"\n")
-			// 		})
-			// 	}
-			// })
+						// then
+						require.NoError(s.T(), err)
+						require.NotNil(s.T(), resp)
+						assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
+						s.assertResponseBody(resp, tc.ExpectedError+"\n")
+					})
+				}
+			})
 
 			s.Run("successfully proxy", func() {
 				userID, err := uuid.NewV4()
 				require.NoError(s.T(), err)
 
-				// encodedSAToken := base64.RawURLEncoding.EncodeToString([]byte("clusterSAToken"))
-				// encodedSSOToken := base64.RawURLEncoding.EncodeToString([]byte(s.token(userID)))
+				encodedSAToken := base64.RawURLEncoding.EncodeToString([]byte("clusterSAToken"))
+				encodedSSOToken := base64.RawURLEncoding.EncodeToString([]byte(s.token(userID)))
 
 				// Start the member-2 API Server
 				testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -262,78 +268,78 @@ func (s *TestProxySuite) TestProxy() {
 					ExpectedProxyResponseStatus     int
 					Standalone                      bool // If true then the request is not expected to be forwarded to the kube api server
 				}{
-					// "plain http cors preflight request with no request method": {
-					// 	ProxyRequestMethod: "OPTIONS",
-					// 	ProxyRequestHeaders: map[string][]string{
-					// 		"Origin":           {"https://domain.com"},
-					// 		"Authorization":    {"Bearer clusterSAToken"},
-					// 		"Impersonate-User": {"smith2"},
-					// 	},
-					// 	ExpectedProxyResponseHeaders: noCORSHeaders,
-					// 	ExpectedProxyResponseStatus:  http.StatusUnauthorized,
-					// 	Standalone:                   true,
-					// },
-					// "plain http cors preflight request with unknown request method": {
-					// 	ProxyRequestMethod: "OPTIONS",
-					// 	ProxyRequestHeaders: map[string][]string{
-					// 		"Origin":                        {"https://domain.com"},
-					// 		"Access-Control-Request-Method": {"UNKNOWN"},
-					// 		"Authorization":                 {"Bearer clusterSAToken"},
-					// 		"Impersonate-User":              {"smith2"},
-					// 	},
-					// 	ExpectedProxyResponseHeaders: noCORSHeaders,
-					// 	ExpectedProxyResponseStatus:  http.StatusNoContent,
-					// 	Standalone:                   true,
-					// },
-					// "plain http cors preflight request with no origin": {
-					// 	ProxyRequestMethod: "OPTIONS",
-					// 	ProxyRequestHeaders: map[string][]string{
-					// 		"Access-Control-Request-Method": {"GET"},
-					// 		"Authorization":                 {"Bearer clusterSAToken"},
-					// 		"Impersonate-User":              {"smith2"},
-					// 	},
-					// 	ExpectedProxyResponseHeaders: noCORSHeaders,
-					// 	ExpectedProxyResponseStatus:  http.StatusNoContent,
-					// 	Standalone:                   true,
-					// },
-					// "plain http cors preflight request": {
-					// 	ProxyRequestMethod: "OPTIONS",
-					// 	ProxyRequestHeaders: map[string][]string{
-					// 		"Origin":                         {"https://domain.com"},
-					// 		"Access-Control-Request-Method":  {"GET"},
-					// 		"Access-Control-Request-Headers": {"Authorization"},
-					// 		"Authorization":                  {"Bearer clusterSAToken"},
-					// 		"Impersonate-User":               {"smith2"},
-					// 	},
-					// 	ExpectedProxyResponseHeaders: map[string][]string{
-					// 		"Access-Control-Allow-Origin":      {"https://domain.com"},
-					// 		"Access-Control-Allow-Credentials": {"true"},
-					// 		"Access-Control-Allow-Headers":     {"Authorization"},
-					// 		"Access-Control-Allow-Methods":     {"PUT, PATCH, POST, GET, DELETE, OPTIONS"},
-					// 		"Vary":                             {"Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"},
-					// 	},
-					// 	ExpectedProxyResponseStatus: http.StatusNoContent,
-					// 	Standalone:                  true,
-					// },
-					// "plain http cors preflight request multiple request headers": {
-					// 	ProxyRequestMethod: "OPTIONS",
-					// 	ProxyRequestHeaders: map[string][]string{
-					// 		"Origin":                         {"https://domain.com"},
-					// 		"Access-Control-Request-Method":  {"GET"},
-					// 		"Access-Control-Request-Headers": {"Authorization, content-Type, header, second-header, THIRD-HEADER, Numb3r3d-H34d3r"},
-					// 		"Authorization":                  {"Bearer clusterSAToken"},
-					// 		"Impersonate-User":               {"smith2"},
-					// 	},
-					// 	ExpectedProxyResponseHeaders: map[string][]string{
-					// 		"Access-Control-Allow-Origin":      {"https://domain.com"},
-					// 		"Access-Control-Allow-Credentials": {"true"},
-					// 		"Access-Control-Allow-Headers":     {"Authorization, Content-Type, Header, Second-Header, Third-Header, Numb3r3d-H34d3r"},
-					// 		"Access-Control-Allow-Methods":     {"PUT, PATCH, POST, GET, DELETE, OPTIONS"},
-					// 		"Vary":                             {"Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"},
-					// 	},
-					// 	ExpectedProxyResponseStatus: http.StatusNoContent,
-					// 	Standalone:                  true,
-					// },
+					"plain http cors preflight request with no request method": {
+						ProxyRequestMethod: "OPTIONS",
+						ProxyRequestHeaders: map[string][]string{
+							"Origin":           {"https://domain.com"},
+							"Authorization":    {"Bearer clusterSAToken"},
+							"Impersonate-User": {"smith2"},
+						},
+						ExpectedProxyResponseHeaders: noCORSHeaders,
+						ExpectedProxyResponseStatus:  http.StatusUnauthorized,
+						Standalone:                   true,
+					},
+					"plain http cors preflight request with unknown request method": {
+						ProxyRequestMethod: "OPTIONS",
+						ProxyRequestHeaders: map[string][]string{
+							"Origin":                        {"https://domain.com"},
+							"Access-Control-Request-Method": {"UNKNOWN"},
+							"Authorization":                 {"Bearer clusterSAToken"},
+							"Impersonate-User":              {"smith2"},
+						},
+						ExpectedProxyResponseHeaders: noCORSHeaders,
+						ExpectedProxyResponseStatus:  http.StatusNoContent,
+						Standalone:                   true,
+					},
+					"plain http cors preflight request with no origin": {
+						ProxyRequestMethod: "OPTIONS",
+						ProxyRequestHeaders: map[string][]string{
+							"Access-Control-Request-Method": {"GET"},
+							"Authorization":                 {"Bearer clusterSAToken"},
+							"Impersonate-User":              {"smith2"},
+						},
+						ExpectedProxyResponseHeaders: noCORSHeaders,
+						ExpectedProxyResponseStatus:  http.StatusNoContent,
+						Standalone:                   true,
+					},
+					"plain http cors preflight request": {
+						ProxyRequestMethod: "OPTIONS",
+						ProxyRequestHeaders: map[string][]string{
+							"Origin":                         {"https://domain.com"},
+							"Access-Control-Request-Method":  {"GET"},
+							"Access-Control-Request-Headers": {"Authorization"},
+							"Authorization":                  {"Bearer clusterSAToken"},
+							"Impersonate-User":               {"smith2"},
+						},
+						ExpectedProxyResponseHeaders: map[string][]string{
+							"Access-Control-Allow-Origin":      {"https://domain.com"},
+							"Access-Control-Allow-Credentials": {"true"},
+							"Access-Control-Allow-Headers":     {"Authorization"},
+							"Access-Control-Allow-Methods":     {"PUT, PATCH, POST, GET, DELETE, OPTIONS"},
+							"Vary":                             {"Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"},
+						},
+						ExpectedProxyResponseStatus: http.StatusNoContent,
+						Standalone:                  true,
+					},
+					"plain http cors preflight request multiple request headers": {
+						ProxyRequestMethod: "OPTIONS",
+						ProxyRequestHeaders: map[string][]string{
+							"Origin":                         {"https://domain.com"},
+							"Access-Control-Request-Method":  {"GET"},
+							"Access-Control-Request-Headers": {"Authorization, content-Type, header, second-header, THIRD-HEADER, Numb3r3d-H34d3r"},
+							"Authorization":                  {"Bearer clusterSAToken"},
+							"Impersonate-User":               {"smith2"},
+						},
+						ExpectedProxyResponseHeaders: map[string][]string{
+							"Access-Control-Allow-Origin":      {"https://domain.com"},
+							"Access-Control-Allow-Credentials": {"true"},
+							"Access-Control-Allow-Headers":     {"Authorization, Content-Type, Header, Second-Header, Third-Header, Numb3r3d-H34d3r"},
+							"Access-Control-Allow-Methods":     {"PUT, PATCH, POST, GET, DELETE, OPTIONS"},
+							"Vary":                             {"Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"},
+						},
+						ExpectedProxyResponseStatus: http.StatusNoContent,
+						Standalone:                  true,
+					},
 					"plain http actual request": {
 						ProxyRequestMethod:  "GET",
 						ProxyRequestHeaders: map[string][]string{"Authorization": {"Bearer " + s.token(userID)}},
@@ -349,102 +355,119 @@ func (s *TestProxySuite) TestProxy() {
 						},
 						ExpectedProxyResponseStatus: http.StatusOK,
 					},
-					// "websockets": {
-					// 	ProxyRequestMethod: "GET",
-					// 	ProxyRequestHeaders: map[string][]string{
-					// 		"Connection":             {"upgrade"},
-					// 		"Upgrade":                {"websocket"},
-					// 		"Sec-Websocket-Protocol": {fmt.Sprintf("base64url.bearer.authorization.k8s.io.%s,dummy", encodedSSOToken)},
-					// 		"Impersonate-User":       {"smith2"},
-					// 	},
-					// 	ExpectedAPIServerRequestHeaders: map[string][]string{
-					// 		"Connection":             {"Upgrade"},
-					// 		"Upgrade":                {"websocket"},
-					// 		"Sec-Websocket-Protocol": {fmt.Sprintf("base64url.bearer.authorization.k8s.io.%s,dummy", encodedSAToken)},
-					// 		"Impersonate-User":       {"smith2"},
-					// 	},
-					// 	ExpectedProxyResponseHeaders: map[string][]string{
-					// 		"Access-Control-Allow-Origin":      {"*"},
-					// 		"Access-Control-Allow-Credentials": {"true"},
-					// 		"Access-Control-Expose-Headers":    {"Content-Length, Content-Encoding, Authorization"},
-					// 		"Vary":                             {"Origin"},
-					// 	},
-					// 	ExpectedProxyResponseStatus: http.StatusOK,
-					// },
+					"websockets": {
+						ProxyRequestMethod: "GET",
+						ProxyRequestHeaders: map[string][]string{
+							"Connection":             {"upgrade"},
+							"Upgrade":                {"websocket"},
+							"Sec-Websocket-Protocol": {fmt.Sprintf("base64url.bearer.authorization.k8s.io.%s,dummy", encodedSSOToken)},
+							"Impersonate-User":       {"smith2"},
+						},
+						ExpectedAPIServerRequestHeaders: map[string][]string{
+							"Connection":             {"Upgrade"},
+							"Upgrade":                {"websocket"},
+							"Sec-Websocket-Protocol": {fmt.Sprintf("base64url.bearer.authorization.k8s.io.%s,dummy", encodedSAToken)},
+							"Impersonate-User":       {"smith2"},
+						},
+						ExpectedProxyResponseHeaders: map[string][]string{
+							"Access-Control-Allow-Origin":      {"*"},
+							"Access-Control-Allow-Credentials": {"true"},
+							"Access-Control-Expose-Headers":    {"Content-Length, Content-Encoding, Authorization"},
+							"Vary":                             {"Origin"},
+						},
+						ExpectedProxyResponseStatus: http.StatusOK,
+					},
 				}
 
 				for k, tc := range tests {
 					s.Run(k, func() {
-						// given
-						req, err := http.NewRequest(tc.ProxyRequestMethod, "http://localhost:8081/workspaces/mycoolworkspace/api/pods", nil)
-						require.NoError(s.T(), err)
-						require.NotNil(s.T(), req)
 
-						for hk, hv := range tc.ProxyRequestHeaders {
-							for _, v := range hv {
-								req.Header.Add(hk, v)
-							}
-						}
+						for _, reqPath := range []string{
+							"http://localhost:8081/api/mycoolworkspace/pods",
+							"http://localhost:8081/workspaces/mycoolworkspace/api/pods",
+						} {
 
-						fakeApp.Err = nil
+							// given
+							req, err := http.NewRequest(tc.ProxyRequestMethod, reqPath, nil)
+							require.NoError(s.T(), err)
+							require.NotNil(s.T(), req)
 
-						if !tc.Standalone {
-							testServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-								w.Header().Set("Content-Type", "application/json")
-								// Set the Access-Control-Allow-Origin header to make sure it's overridden by the proxy response modifier
-								w.Header().Set("Access-Control-Allow-Origin", "dummy")
-								w.WriteHeader(http.StatusOK)
-								_, err := w.Write([]byte("my response"))
-								require.NoError(s.T(), err)
-								for hk, hv := range tc.ExpectedAPIServerRequestHeaders {
-									require.Len(s.T(), r.Header.Values(hk), len(hv))
-									for i := range hv {
-										assert.Equal(s.T(), hv[i], r.Header.Values(hk)[i])
-									}
+							for hk, hv := range tc.ProxyRequestHeaders {
+								for _, v := range hv {
+									req.Header.Add(hk, v)
 								}
-							})
+							}
 
-							fakeApp.SignupServiceMock = fake.NewSignupService(fake.Signup("someUserID", &signup.Signup{
-								APIEndpoint:       "https://api.endpoint.member-1.com:6443",
-								ClusterName:       "member-1",
-								CompliantUsername: "smith2",
-								Username:          "smith@",
-								Status: signup.Status{
-									Ready: true,
-								},
-							}), fake.Signup(userID.String(), &signup.Signup{
-								APIEndpoint:       testServer.URL,
-								ClusterName:       "member-2",
-								CompliantUsername: "smith2",
-								Username:          "smith@",
-								Status: signup.Status{
-									Ready: true,
-								},
-							}))
-							s.Application.MockSignupService(fakeApp.SignupServiceMock)
-							fakeApp.MemberClusterServiceMock = s.newMemberClusterServiceWithMembers(testServer.URL)
-						}
+							fakeApp.Err = nil
 
-						// when
-						client := http.Client{Timeout: 3 * time.Second}
-						resp, err := client.Do(req)
+							if !tc.Standalone {
+								testServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+									w.Header().Set("Content-Type", "application/json")
+									// Set the Access-Control-Allow-Origin header to make sure it's overridden by the proxy response modifier
+									w.Header().Set("Access-Control-Allow-Origin", "dummy")
+									w.WriteHeader(http.StatusOK)
+									_, err := w.Write([]byte("my response"))
+									require.NoError(s.T(), err)
+									for hk, hv := range tc.ExpectedAPIServerRequestHeaders {
+										require.Len(s.T(), r.Header.Values(hk), len(hv))
+										for i := range hv {
+											assert.Equal(s.T(), hv[i], r.Header.Values(hk)[i])
+										}
+									}
+								})
 
-						// then
-						require.NoError(s.T(), err)
-						require.NotNil(s.T(), resp)
-						assert.Equal(s.T(), tc.ExpectedProxyResponseStatus, resp.StatusCode)
-						if !tc.Standalone {
-							s.assertResponseBody(resp, "my response")
-						}
-						for hk, hv := range tc.ExpectedProxyResponseHeaders {
-							require.Len(s.T(), resp.Header.Values(hk), len(hv), fmt.Sprintf("Actual Header %s: %v", hk, resp.Header.Values(hk)))
-							for i := range hv {
-								assert.Equal(s.T(), hv[i], resp.Header.Values(hk)[i])
+								fakeApp.SignupServiceMock = fake.NewSignupService(fake.Signup("someUserID", &signup.Signup{
+									APIEndpoint:       "https://api.endpoint.member-1.com:6443",
+									ClusterName:       "member-1",
+									CompliantUsername: "smith2",
+									Username:          "smith@",
+									Status: signup.Status{
+										Ready: true,
+									},
+								}), fake.Signup(userID.String(), &signup.Signup{
+									APIEndpoint:       testServer.URL,
+									ClusterName:       "member-2",
+									CompliantUsername: "smith2",
+									Username:          "smith@",
+									Status: signup.Status{
+										Ready: true,
+									},
+								}))
+								s.Application.MockSignupService(fakeApp.SignupServiceMock)
+								inf := fake.NewFakeInformer()
+								inf.GetSpaceFunc = func(name string) (*toolchainv1alpha1.Space, error) {
+									switch name {
+									case "mycoolworkspace":
+										return fake.NewSpace("member-2", name), nil
+									}
+									return nil, fmt.Errorf("space not found error")
+								}
+								s.Application.MockInformerService(inf)
+								fakeApp.MemberClusterServiceMock = s.newMemberClusterServiceWithMembers(testServer.URL)
+							}
+
+							// when
+							client := http.Client{Timeout: 3 * time.Second}
+							resp, err := client.Do(req)
+
+							// then
+							require.NoError(s.T(), err)
+							require.NotNil(s.T(), resp)
+							assert.Equal(s.T(), tc.ExpectedProxyResponseStatus, resp.StatusCode)
+							if !tc.Standalone {
+								s.assertResponseBody(resp, "my response")
+							}
+							for hk, hv := range tc.ExpectedProxyResponseHeaders {
+								require.Len(s.T(), resp.Header.Values(hk), len(hv), fmt.Sprintf("Actual Header %s: %v", hk, resp.Header.Values(hk)))
+								for i := range hv {
+									assert.Equal(s.T(), hv[i], resp.Header.Values(hk)[i])
+								}
 							}
 						}
 					})
 				}
 			})
+
 		})
 	}
 }
@@ -506,6 +529,58 @@ func (s *TestProxySuite) TestSingleJoiningSlash() {
 	assert.Equal(s.T(), "proxy/api/namespace/pods", singleJoiningSlash("proxy", "api/namespace/pods"))
 	assert.Equal(s.T(), "proxy/subpath/api/namespace/pods", singleJoiningSlash("proxy/subpath", "api/namespace/pods"))
 	assert.Equal(s.T(), "/proxy/subpath/api/namespace/pods/", singleJoiningSlash("/proxy/subpath/", "/api/namespace/pods/"))
+}
+
+func (s *TestProxySuite) TestHandleWorkspaceContext() {
+	tests := map[string]struct {
+		path              string
+		expectedWorkspace string
+		expectedPath      string
+		expectedErr       string
+	}{
+		"valid workspace context": {
+			path:              "/workspaces/myworkspace/api",
+			expectedWorkspace: "myworkspace",
+			expectedPath:      "/api",
+			expectedErr:       "",
+		},
+		"invalid workspace context": {
+			path:              "/workspaces/myworkspace",
+			expectedWorkspace: "",
+			expectedPath:      "/workspaces/myworkspace",
+			expectedErr:       "workspace request path has too few segments '/workspaces/myworkspace'",
+		},
+		"no workspace context": {
+			path:              "/api/pods",
+			expectedWorkspace: "",
+			expectedPath:      "/api/pods",
+			expectedErr:       "",
+		},
+		"workspace instead of workspaces": {
+			path:              "/workspace/myworkspace/api",
+			expectedWorkspace: "",
+			expectedPath:      "/workspace/myworkspace/api",
+			expectedErr:       "",
+		},
+	}
+
+	for k, tc := range tests {
+		s.T().Run(k, func(t *testing.T) {
+			req := &http.Request{
+				URL: &url.URL{
+					Path: tc.path,
+				},
+			}
+			workspace, err := handleWorkspaceContext(req)
+			if tc.expectedErr == "" {
+				require.NoError(s.T(), err)
+			} else {
+				require.EqualError(s.T(), err, tc.expectedErr)
+			}
+			assert.Equal(s.T(), tc.expectedWorkspace, workspace)
+			assert.Equal(s.T(), tc.expectedPath, req.URL.Path)
+		})
+	}
 }
 
 func (s *TestProxySuite) request() (*http.Request, string) {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -551,7 +551,7 @@ func (s *TestProxySuite) TestHandleWorkspaceContext() {
 			path:              "/workspaces/myworkspace",
 			expectedWorkspace: "",
 			expectedPath:      "/workspaces/myworkspace",
-			expectedErr:       "workspace request path has too few segments '/workspaces/myworkspace'",
+			expectedErr:       "workspace request path has too few segments '/workspaces/myworkspace'; expected path format: /workspaces/<workspace_name>/api/...",
 		},
 		"no workspace context": {
 			path:              "/api/pods",

--- a/pkg/proxy/service/cluster_service.go
+++ b/pkg/proxy/service/cluster_service.go
@@ -8,13 +8,9 @@ import (
 	servicecontext "github.com/codeready-toolchain/registration-service/pkg/application/service/context"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 
 	errs "github.com/pkg/errors"
-
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 )
 
 type Option func(f *ServiceImpl)
@@ -87,37 +83,4 @@ func (s *ServiceImpl) accessForCluster(apiEndpoint, clusterName, username string
 	}
 
 	return nil, errs.New("no member cluster found for the user")
-}
-
-type selectorOption func(labels.Selector) (labels.Selector, error)
-
-func newSpaceBindingSelector(o ...selectorOption) (labels.Selector, error) {
-	selector := labels.NewSelector()
-	return selector, nil
-}
-
-func WithMurSelector(murName string) selectorOption {
-	// adds label selector toolchain.dev.openshift.com/masteruserrecord: murName
-	return func(selector labels.Selector) (labels.Selector, error) {
-		key := toolchainv1alpha1.LabelKeyPrefix + "masteruserrecord"
-		murLabel, err := labels.NewRequirement(key, selection.Equals, []string{murName})
-		if err != nil {
-			return nil, err
-		}
-		selector = selector.Add(*murLabel)
-		return selector, nil
-	}
-}
-
-func WithSpaceSelector(spaceName string) selectorOption {
-	// adds label selector toolchain.dev.openshift.com/space: spaceName
-	return func(selector labels.Selector) (labels.Selector, error) {
-		key := toolchainv1alpha1.LabelKeyPrefix + "space"
-		spaceLabel, err := labels.NewRequirement(key, selection.Equals, []string{spaceName})
-		if err != nil {
-			return nil, err
-		}
-		selector = selector.Add(*spaceLabel)
-		return selector, nil
-	}
 }

--- a/pkg/proxy/service/cluster_service.go
+++ b/pkg/proxy/service/cluster_service.go
@@ -7,9 +7,14 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/application/service/base"
 	servicecontext "github.com/codeready-toolchain/registration-service/pkg/application/service/context"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 
 	errs "github.com/pkg/errors"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 type Option func(f *ServiceImpl)
@@ -41,6 +46,27 @@ func (s *ServiceImpl) GetClusterAccess(userID, username string) (*access.Cluster
 		return nil, errs.New("user is not provisioned (yet)")
 	}
 
+	return s.accessForCluster(signup.APIEndpoint, signup.ClusterName, signup.CompliantUsername)
+}
+
+func (s *ServiceImpl) GetWorkspaceAccess(userID, username, workspace string) (*access.ClusterAccess, error) {
+	signup, err := s.Services().SignupService().GetSignupFromInformer(userID, username)
+	if err != nil {
+		return nil, err
+	}
+	if signup == nil || !signup.Status.Ready {
+		return nil, errs.New("user is not provisioned (yet)")
+	}
+
+	space, err := s.Services().InformerService().GetSpace(workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.accessForCluster(signup.APIEndpoint, space.Status.TargetCluster, signup.CompliantUsername)
+}
+
+func (s *ServiceImpl) accessForCluster(apiEndpoint, clusterName, username string) (*access.ClusterAccess, error) {
 	// Get the target member
 	members := s.GetMembersFunc()
 	if len(members) == 0 {
@@ -49,16 +75,49 @@ func (s *ServiceImpl) GetClusterAccess(userID, username string) (*access.Cluster
 	for _, member := range members {
 		// also check that the member cluster name matches because the api endpoint is the same for both members
 		// in the e2e tests because a single cluster is used for testing multi-member scenarios
-		if member.APIEndpoint == signup.APIEndpoint && member.Name == signup.ClusterName {
+		if member.APIEndpoint == apiEndpoint && member.Name == clusterName {
 			apiURL, err := url.Parse(member.APIEndpoint)
 			if err != nil {
 				return nil, err
 			}
 			// requests use impersonation so are made with member ToolchainCluster token, not user tokens
 			impersonatorToken := member.RestConfig.BearerToken
-			return access.NewClusterAccess(*apiURL, impersonatorToken, signup.CompliantUsername), nil
+			return access.NewClusterAccess(*apiURL, impersonatorToken, username), nil
 		}
 	}
 
 	return nil, errs.New("no member cluster found for the user")
+}
+
+type selectorOption func(labels.Selector) (labels.Selector, error)
+
+func newSpaceBindingSelector(o ...selectorOption) (labels.Selector, error) {
+	selector := labels.NewSelector()
+	return selector, nil
+}
+
+func WithMurSelector(murName string) selectorOption {
+	// adds label selector toolchain.dev.openshift.com/masteruserrecord: murName
+	return func(selector labels.Selector) (labels.Selector, error) {
+		key := toolchainv1alpha1.LabelKeyPrefix + "masteruserrecord"
+		murLabel, err := labels.NewRequirement(key, selection.Equals, []string{murName})
+		if err != nil {
+			return nil, err
+		}
+		selector = selector.Add(*murLabel)
+		return selector, nil
+	}
+}
+
+func WithSpaceSelector(spaceName string) selectorOption {
+	// adds label selector toolchain.dev.openshift.com/space: spaceName
+	return func(selector labels.Selector) (labels.Selector, error) {
+		key := toolchainv1alpha1.LabelKeyPrefix + "space"
+		spaceLabel, err := labels.NewRequirement(key, selection.Equals, []string{spaceName})
+		if err != nil {
+			return nil, err
+		}
+		selector = selector.Add(*spaceLabel)
+		return selector, nil
+	}
 }

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -89,7 +89,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 			}
 
 			// when
-			_, err := svc.GetClusterAccess("789-ready", "", "")
+			_, err := svc.GetClusterAccess(nil, "789-ready", "", "")
 
 			// then
 			require.EqualError(s.T(), err, "oopsi woopsi")
@@ -99,7 +99,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 
 		s.Run("userid is not found", func() {
 			// when
-			_, err := svc.GetClusterAccess("unknown_id", "", "")
+			_, err := svc.GetClusterAccess(nil, "unknown_id", "", "")
 
 			// then
 			require.EqualError(s.T(), err, "user is not provisioned (yet)")
@@ -107,7 +107,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 
 		s.Run("username is not found", func() {
 			// when
-			_, err := svc.GetClusterAccess("", "unknown_username", "")
+			_, err := svc.GetClusterAccess(nil, "", "unknown_username", "")
 
 			// then
 			require.EqualError(s.T(), err, "user is not provisioned (yet)")
@@ -115,7 +115,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 
 		s.Run("user is not provisioned yet", func() {
 			// when
-			_, err := svc.GetClusterAccess("456-not-ready", "", "")
+			_, err := svc.GetClusterAccess(nil, "456-not-ready", "", "")
 
 			// then
 			require.EqualError(s.T(), err, "user is not provisioned (yet)")
@@ -135,18 +135,19 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 			s.Application.MockInformerService(inf)
 
 			// when
-			_, err := svc.GetClusterAccess("789-ready", "", "smith2")
+			_, err := svc.GetClusterAccess(nil, "789-ready", "", "smith2")
 
 			// then
-			require.EqualError(s.T(), err, "oopsi woopsi")
+			// original error is only logged so that it doesn't reveal information about a space that may not belong to the requestor
+			require.EqualError(s.T(), err, "the requested space in not available")
 		})
 
 		s.Run("space not found", func() {
 			// when
-			_, err := svc.GetClusterAccess("789-ready", "", "unknown") // unknown workspace requested
+			_, err := svc.GetClusterAccess(nil, "789-ready", "", "unknown") // unknown workspace requested
 
 			// then
-			require.EqualError(s.T(), err, "space not found error")
+			require.EqualError(s.T(), err, "the requested space in not available")
 		})
 	})
 
@@ -165,7 +166,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 			)
 
 			// when
-			_, err := svc.GetClusterAccess("789-ready", "", "")
+			_, err := svc.GetClusterAccess(nil, "789-ready", "", "")
 
 			// then
 			require.EqualError(s.T(), err, "no member clusters found")
@@ -185,7 +186,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 			)
 
 			// when
-			_, err := svc.GetClusterAccess("012-ready-unknown-cluster", "", "")
+			_, err := svc.GetClusterAccess(nil, "012-ready-unknown-cluster", "", "")
 
 			// then
 			require.EqualError(s.T(), err, "no member cluster found for the user")
@@ -243,7 +244,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 			expectedToken := "abc123" // should match member 2 bearer token
 
 			// when
-			ca, err := svc.GetClusterAccess("789-ready", "", "")
+			ca, err := svc.GetClusterAccess(nil, "789-ready", "", "")
 
 			// then
 			require.NoError(s.T(), err)
@@ -256,7 +257,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 
 			s.Run("cluster access correct when username provided", func() {
 				// when
-				ca, err := svc.GetClusterAccess("", "smith@", "")
+				ca, err := svc.GetClusterAccess(nil, "", "smith@", "")
 
 				// then
 				require.NoError(s.T(), err)
@@ -269,7 +270,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 
 			s.Run("cluster access correct when workspace provided", func() {
 				// when
-				ca, err := svc.GetClusterAccess("789-ready", "", "smith2") // specific workspace requested
+				ca, err := svc.GetClusterAccess(nil, "789-ready", "", "smith2") // specific workspace requested
 
 				// then
 				require.NoError(s.T(), err)
@@ -281,7 +282,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 
 				s.Run("another workspace on another cluster", func() {
 					// when
-					ca, err := svc.GetClusterAccess("789-ready", "", "teamspace") // another workspace requested
+					ca, err := svc.GetClusterAccess(nil, "789-ready", "", "teamspace") // another workspace requested
 
 					// then
 					require.NoError(s.T(), err)

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 )
 
@@ -68,9 +67,9 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 	inf.GetSpaceFunc = func(name string) (*toolchainv1alpha1.Space, error) {
 		switch name {
 		case "noise1", "teamspace":
-			return newSpace("member-1", name), nil
+			return fake.NewSpace("member-1", name), nil
 		case "smith2":
-			return newSpace("member-2", name), nil
+			return fake.NewSpace("member-2", name), nil
 		}
 		return nil, fmt.Errorf("space not found error")
 	}
@@ -320,20 +319,4 @@ func (s *TestClusterServiceSuite) memberClusters() []*commoncluster.CachedToolch
 		})
 	}
 	return cls
-}
-
-func newSpace(targetCluster, compliantUserName string) *toolchainv1alpha1.Space {
-	space := &toolchainv1alpha1.Space{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: compliantUserName,
-		},
-		Spec: toolchainv1alpha1.SpaceSpec{
-			TargetCluster: targetCluster,
-			TierName:      "base1ns",
-		},
-		Status: toolchainv1alpha1.SpaceStatus{
-			TargetCluster: targetCluster,
-		},
-	}
-	return space
 }

--- a/test/fake/informer.go
+++ b/test/fake/informer.go
@@ -10,6 +10,7 @@ func NewFakeInformer() *Informer {
 
 type Informer struct {
 	GetMurFunc             func(name string) (*toolchainv1alpha1.MasterUserRecord, error)
+	GetSpaceFunc           func(name string) (*toolchainv1alpha1.Space, error)
 	GetToolchainStatusFunc func() (*toolchainv1alpha1.ToolchainStatus, error)
 	GetUserSignupFunc      func(name string) (*toolchainv1alpha1.UserSignup, error)
 }
@@ -19,6 +20,13 @@ func (f Informer) GetMasterUserRecord(name string) (*toolchainv1alpha1.MasterUse
 		return f.GetMurFunc(name)
 	}
 	panic("not supposed to call GetMasterUserRecord")
+}
+
+func (f Informer) GetSpace(name string) (*toolchainv1alpha1.Space, error) {
+	if f.GetSpaceFunc != nil {
+		return f.GetSpaceFunc(name)
+	}
+	panic("not supposed to call GetSpace")
 }
 
 func (f Informer) GetToolchainStatus() (*toolchainv1alpha1.ToolchainStatus, error) {

--- a/test/fake/informer.go
+++ b/test/fake/informer.go
@@ -2,6 +2,8 @@ package fake
 
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewFakeInformer() *Informer {
@@ -41,4 +43,20 @@ func (f Informer) GetUserSignup(name string) (*toolchainv1alpha1.UserSignup, err
 		return f.GetUserSignupFunc(name)
 	}
 	panic("not supposed to call GetUserSignup")
+}
+
+func NewSpace(targetCluster, compliantUserName string) *toolchainv1alpha1.Space {
+	space := &toolchainv1alpha1.Space{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: compliantUserName,
+		},
+		Spec: toolchainv1alpha1.SpaceSpec{
+			TargetCluster: targetCluster,
+			TierName:      "base1ns",
+		},
+		Status: toolchainv1alpha1.SpaceStatus{
+			TargetCluster: targetCluster,
+		},
+	}
+	return space
 }

--- a/test/fake/proxy.go
+++ b/test/fake/proxy.go
@@ -45,7 +45,7 @@ type fakeClusterService struct {
 	fakeApp *ProxyFakeApp
 }
 
-func (f *fakeClusterService) GetClusterAccess(userID, _, _ string) (*access.ClusterAccess, error) {
+func (f *fakeClusterService) GetClusterAccess(_ *gin.Context, userID, _, _ string) (*access.ClusterAccess, error) {
 	return f.fakeApp.Accesses[userID], f.fakeApp.Err
 }
 

--- a/test/fake/proxy.go
+++ b/test/fake/proxy.go
@@ -49,6 +49,10 @@ func (f *fakeClusterService) GetClusterAccess(userID, _ string) (*access.Cluster
 	return f.fakeApp.Accesses[userID], f.fakeApp.Err
 }
 
+func (f *fakeClusterService) GetWorkspaceAccess(userID, _, _ string) (*access.ClusterAccess, error) {
+	return f.fakeApp.Accesses[userID], f.fakeApp.Err
+}
+
 type SignupDef func() (string, *signup.Signup)
 
 func Signup(identifier string, userSignup *signup.Signup) SignupDef {

--- a/test/fake/proxy.go
+++ b/test/fake/proxy.go
@@ -45,11 +45,7 @@ type fakeClusterService struct {
 	fakeApp *ProxyFakeApp
 }
 
-func (f *fakeClusterService) GetClusterAccess(userID, _ string) (*access.ClusterAccess, error) {
-	return f.fakeApp.Accesses[userID], f.fakeApp.Err
-}
-
-func (f *fakeClusterService) GetWorkspaceAccess(userID, _, _ string) (*access.ClusterAccess, error) {
+func (f *fakeClusterService) GetClusterAccess(userID, _, _ string) (*access.ClusterAccess, error) {
 	return f.fakeApp.Accesses[userID], f.fakeApp.Err
 }
 


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRT-1637

Adds workspace context support to the proxy.

**Default workspace URL**
<proxy URL>/api/v1/namespaces/my-namespace/

**Workspace-specific URL**
<proxy URL>/workspaces/<workspace-name>/api/v1/namespaces/<namespace-name>/...

Related PRs:
- reg service deployment update: https://github.com/codeready-toolchain/host-operator/pull/732
- e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/655