### PR TITLE
Add workspace type and object meta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20230208154642-e7b66da70ad4
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20230208193548-b1b52619bc11
+	github.com/codeready-toolchain/api v0.0.0-20230210095221-59de0ef9b59c
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20230213135025-a17b1e073489
 	github.com/go-logr/logr v1.2.0
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -106,7 +106,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20230209221426-e105f1909f4d
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20230209223004-7a75e35b587f

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
+	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
@@ -106,3 +106,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20230209221426-e105f1909f4d
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20230209223004-7a75e35b587f

--- a/go.sum
+++ b/go.sum
@@ -98,10 +98,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20230208154642-e7b66da70ad4 h1:TlRpu2U0KwVP2RA4Jp/svGPbpB98M2Wsu5e4cW+HoNA=
-github.com/codeready-toolchain/api v0.0.0-20230208154642-e7b66da70ad4/go.mod h1:4BhC+uBP9LbSKzQ1ggRAmKIl9pSj0uxdISj0s/HRwEw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20230208193548-b1b52619bc11 h1:gWPcMADEtjbJBz5buwDCHkJAYGr+oS99tBkTZiCuQJg=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20230208193548-b1b52619bc11/go.mod h1:PprxWHX3Frt+o2IFSYXwPrIRwS/W2yFvWq8XP4oauyI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
@@ -128,8 +124,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.12.0+incompatible h1:SIvoTSbsMEwuM3dzFirLwKc4BH6VXP5CNf+G1FfJVr4=
-github.com/emicklei/go-restful v2.12.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.16.0+incompatible h1:rgqiKNjTnFQA6kkhFe16D8epTksy9HQ1MyrbDXSdYhM=
+github.com/emicklei/go-restful v2.16.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -480,6 +476,10 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rajivnathan/api v0.0.0-20230209221426-e105f1909f4d h1:i7S9mpmkdrX1SM8rO99TVLgIRw09zX6uFSFar95orMM=
+github.com/rajivnathan/api v0.0.0-20230209221426-e105f1909f4d/go.mod h1:eOu09m3Vyr5/gmTKQ0w1z6bOmujX6l6PuaXqCx3whpw=
+github.com/rajivnathan/toolchain-common v0.0.0-20230209223004-7a75e35b587f h1:aUxsb87iW7qr7hR9Vb0sNy96ggDzmE2aUgw93AKj0ik=
+github.com/rajivnathan/toolchain-common v0.0.0-20230209223004-7a75e35b587f/go.mod h1:pj5PoVNUtB+XlsXKKdbytVxZQkWJ1vSPnr3O9IyVs/I=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,10 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20230210095221-59de0ef9b59c h1:CZXvsMJhWqa6U5kRqzc3h8+KFVEIOb16rdgDNt5RqhE=
+github.com/codeready-toolchain/api v0.0.0-20230210095221-59de0ef9b59c/go.mod h1:eOu09m3Vyr5/gmTKQ0w1z6bOmujX6l6PuaXqCx3whpw=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20230213135025-a17b1e073489 h1:xkSuQ2V31JPflyq5hCceDFobeEq8Qkk9Y6hKoxgpolQ=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20230213135025-a17b1e073489/go.mod h1:1jYyp0yNGSLTFDEAZz3XO4q6YEYw88GpjugBKCVICOA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
@@ -476,10 +480,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/api v0.0.0-20230209221426-e105f1909f4d h1:i7S9mpmkdrX1SM8rO99TVLgIRw09zX6uFSFar95orMM=
-github.com/rajivnathan/api v0.0.0-20230209221426-e105f1909f4d/go.mod h1:eOu09m3Vyr5/gmTKQ0w1z6bOmujX6l6PuaXqCx3whpw=
-github.com/rajivnathan/toolchain-common v0.0.0-20230209223004-7a75e35b587f h1:aUxsb87iW7qr7hR9Vb0sNy96ggDzmE2aUgw93AKj0ik=
-github.com/rajivnathan/toolchain-common v0.0.0-20230209223004-7a75e35b587f/go.mod h1:pj5PoVNUtB+XlsXKKdbytVxZQkWJ1vSPnr3O9IyVs/I=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/proxy/handlers/spacelister_test.go
+++ b/pkg/proxy/handlers/spacelister_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/codeready-toolchain/registration-service/pkg/application/service"
+	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	rcontext "github.com/codeready-toolchain/registration-service/pkg/context"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/handlers"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
@@ -15,11 +16,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	commonproxy "github.com/codeready-toolchain/toolchain-common/pkg/proxy"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -37,9 +38,28 @@ func TestHandleSpaceListRequest(t *testing.T) {
 		newSignup("usernospace", "user.nospace", true),
 		newSignup("racinglover", "racing.lover", false),
 	)
+
+	// space that is not provisioned yet
+	spaceNotProvisionedYet := fake.NewSpace("member-2", "pandalover")
+	spaceNotProvisionedYet.Labels[toolchainv1alpha1.SpaceCreatorLabelKey] = ""
+
+	fakeClient := initFakeClient(t,
+		// spaces
+		fake.NewSpace("member-1", "dancelover"),
+		fake.NewSpace("member-1", "movielover"),
+		fake.NewSpace("member-2", "racinglover"),
+		spaceNotProvisionedYet,
+
+		//spacebindings
+		fake.NewSpaceBinding("dancer-sb1", "dancelover", "dancelover", "admin"),
+		fake.NewSpaceBinding("dancer-sb2", "dancelover", "movielover", "other"),
+		fake.NewSpaceBinding("moviegoer-sb", "movielover", "movielover", "admin"),
+		fake.NewSpaceBinding("racer-sb", "racinglover", "racinglover", "admin"),
+	)
+
 	s := &handlers.SpaceLister{
 		GetSignupFunc:          fakeSignupService.GetSignupFromInformer,
-		GetInformerServiceFunc: getFakeInformerService(t),
+		GetInformerServiceFunc: getFakeInformerService(t, fakeClient),
 	}
 
 	tests := map[string]struct {
@@ -52,22 +72,22 @@ func TestHandleSpaceListRequest(t *testing.T) {
 		"dancelover lists spaces": {
 			username: "dance.lover",
 			expected: []toolchainv1alpha1.Workspace{
-				workspaceFor("dancelover", "admin"),
-				workspaceFor("movielover", "other"),
+				workspaceFor(t, fakeClient, "dancelover", "admin", true),
+				workspaceFor(t, fakeClient, "movielover", "other", false),
 			},
 			expectedErr: "",
 		},
 		"movielover lists spaces": {
 			username: "movie.lover",
 			expected: []toolchainv1alpha1.Workspace{
-				workspaceFor("movielover", "admin"),
+				workspaceFor(t, fakeClient, "movielover", "admin", true),
 			},
 			expectedErr: "",
 		},
 		"dancelover gets dancelover space": {
 			username: "dance.lover",
 			expected: []toolchainv1alpha1.Workspace{
-				workspaceFor("dancelover", "admin"),
+				workspaceFor(t, fakeClient, "dancelover", "admin", true),
 			},
 			expectedErr:       "",
 			expectedWorkspace: "dancelover",
@@ -75,7 +95,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 		"dancelover gets movielover space": {
 			username: "dance.lover",
 			expected: []toolchainv1alpha1.Workspace{
-				workspaceFor("movielover", "other"),
+				workspaceFor(t, fakeClient, "movielover", "other", false),
 			},
 			expectedErr:       "",
 			expectedWorkspace: "movielover",
@@ -83,7 +103,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 		"movielover gets movielover space": {
 			username: "movie.lover",
 			expected: []toolchainv1alpha1.Workspace{
-				workspaceFor("movielover", "admin"),
+				workspaceFor(t, fakeClient, "movielover", "admin", true),
 			},
 			expectedErr:       "",
 			expectedWorkspace: "movielover",
@@ -143,7 +163,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 					// get workspace case
 					workspace, decodeErr := decodeResponseToWorkspace(rec.Body.Bytes())
 					require.NoError(t, decodeErr)
-					require.Equal(t, 1, len(tc.expected), "test case should have exactly one expected item")
+					require.Equal(t, 1, len(tc.expected), "test case should have exactly one expected item since it's a get request")
 					for i := range tc.expected {
 						assert.Equal(t, tc.expected[i].Name, workspace.Name)
 						assert.Equal(t, tc.expected[i].Status, workspace.Status)
@@ -165,6 +185,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 
 func newSignup(signupName, username string, ready bool) fake.SignupDef {
 	return fake.Signup(signupName, &signup.Signup{
+		Name:              signupName,
 		CompliantUsername: signupName,
 		Username:          username,
 		Status: signup.Status{
@@ -173,25 +194,8 @@ func newSignup(signupName, username string, ready bool) fake.SignupDef {
 	})
 }
 
-func getFakeInformerService(t *testing.T) func() service.InformerService {
-
-	spaceNotProvisionedYet := fake.NewSpace("member-2", "pandalover")
-	spaceNotProvisionedYet.Labels[toolchainv1alpha1.SpaceCreatorLabelKey] = ""
-
+func getFakeInformerService(t *testing.T, fakeClient client.Client) func() service.InformerService {
 	return func() service.InformerService {
-		fakeClient := initFakeClient(t,
-			// spaces
-			fake.NewSpace("member-1", "dancelover"),
-			fake.NewSpace("member-1", "movielover"),
-			fake.NewSpace("member-2", "racinglover"),
-			spaceNotProvisionedYet,
-
-			//spacebindings
-			fake.NewSpaceBinding("dancer-sb1", "dancelover", "dancelover", "admin"),
-			fake.NewSpaceBinding("dancer-sb2", "dancelover", "movielover", "other"),
-			fake.NewSpaceBinding("moviegoer-sb", "movielover", "movielover", "admin"),
-			fake.NewSpaceBinding("racer-sb", "racinglover", "racinglover", "admin"),
-		)
 
 		inf := fake.NewFakeInformer()
 		inf.GetSpaceFunc = func(name string) (*toolchainv1alpha1.Space, error) {
@@ -247,20 +251,27 @@ func decodeResponseToWorkspaceList(data []byte) (*toolchainv1alpha1.WorkspaceLis
 	return obj, nil
 }
 
-func workspaceFor(name, role string) toolchainv1alpha1.Workspace {
-	return toolchainv1alpha1.Workspace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Status: toolchainv1alpha1.WorkspaceStatus{
-			Owner: name,
-			Role:  role,
-			Namespaces: []toolchainv1alpha1.SpaceNamespace{
-				{
-					Name: name + "-tenant",
-					Type: "default",
-				},
+func workspaceFor(t *testing.T, fakeClient client.Client, name, role string, isHomeWorkspace bool) toolchainv1alpha1.Workspace {
+	// get the space for the user
+	space := &toolchainv1alpha1.Space{}
+	err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: configuration.Namespace()}, space)
+	require.NoError(t, err)
+
+	// create the workspace based on the space
+	ws := commonproxy.NewWorkspace(name,
+		commonproxy.WithObjectMetaFrom(space.ObjectMeta),
+		commonproxy.WithNamespaces([]toolchainv1alpha1.SpaceNamespace{
+			{
+				Name: name + "-tenant",
+				Type: "default",
 			},
-		},
+		}),
+		commonproxy.WithOwner(name),
+		commonproxy.WithRole(role),
+	)
+	// if the user is the same as the one who created the workspace, then expect type should be "home"
+	if isHomeWorkspace {
+		ws.Status.Type = "home"
 	}
+	return *ws
 }

--- a/pkg/proxy/handlers/spacelister_test.go
+++ b/pkg/proxy/handlers/spacelister_test.go
@@ -194,7 +194,7 @@ func newSignup(signupName, username string, ready bool) fake.SignupDef {
 	})
 }
 
-func getFakeInformerService(t *testing.T, fakeClient client.Client) func() service.InformerService {
+func getFakeInformerService(fakeClient client.Client) func() service.InformerService {
 	return func() service.InformerService {
 
 		inf := fake.NewFakeInformer()

--- a/pkg/proxy/handlers/spacelister_test.go
+++ b/pkg/proxy/handlers/spacelister_test.go
@@ -59,7 +59,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 
 	s := &handlers.SpaceLister{
 		GetSignupFunc:          fakeSignupService.GetSignupFromInformer,
-		GetInformerServiceFunc: getFakeInformerService(t, fakeClient),
+		GetInformerServiceFunc: getFakeInformerService(fakeClient),
 	}
 
 	tests := map[string]struct {

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -265,6 +265,7 @@ func (s *ServiceImpl) DoGetSignup(provider ResourceProvider, userID, username st
 	}
 
 	signupResponse := &signup.Signup{
+		Name:     userSignup.GetName(),
 		Username: userSignup.Spec.Username,
 	}
 	if userSignup.Status.CompliantUsername != "" {

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -757,6 +757,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), response)
 
+	require.Equal(s.T(), userID.String(), response.Name)
 	require.Equal(s.T(), "bill", response.Username)
 	require.Equal(s.T(), "", response.CompliantUsername)
 	require.False(s.T(), response.Status.Ready)
@@ -794,6 +795,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), response)
 
+		require.Equal(s.T(), userID.String(), response.Name)
 		require.Equal(s.T(), "bill", response.Username)
 		require.Equal(s.T(), "", response.CompliantUsername)
 		require.False(s.T(), response.Status.Ready)
@@ -865,6 +867,7 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), response)
 
+		require.Equal(s.T(), userID.String(), response.Name)
 		require.Equal(s.T(), "bill", response.Username)
 		require.Equal(s.T(), "", response.CompliantUsername)
 		require.False(s.T(), response.Status.Ready)
@@ -902,6 +905,7 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 			require.NoError(s.T(), err)
 			require.NotNil(s.T(), response)
 
+			require.Equal(s.T(), userID.String(), response.Name)
 			require.Equal(s.T(), "bill", response.Username)
 			require.Equal(s.T(), "", response.CompliantUsername)
 			require.False(s.T(), response.Status.Ready)
@@ -1015,6 +1019,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), response)
 
+	require.Equal(s.T(), us.Name, response.Name)
 	require.Equal(s.T(), "ted@domain.com", response.Username)
 	require.Equal(s.T(), "ted", response.CompliantUsername)
 	assert.True(s.T(), response.Status.Ready)
@@ -1132,6 +1137,7 @@ func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), response)
 
+	require.Equal(s.T(), us.Name, response.Name)
 	require.Equal(s.T(), "ted@domain.com", response.Username)
 	require.Equal(s.T(), "ted", response.CompliantUsername)
 	assert.True(s.T(), response.Status.Ready)
@@ -1178,6 +1184,7 @@ func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), response)
 
+		require.Equal(s.T(), us.Name, response.Name)
 		require.Equal(s.T(), "ted@domain.com", response.Username)
 		require.Equal(s.T(), "ted", response.CompliantUsername)
 		assert.True(s.T(), response.Status.Ready)

--- a/pkg/signup/signup.go
+++ b/pkg/signup/signup.go
@@ -3,6 +3,8 @@ package signup
 // Signup represents Signup resource which is a wrapper of K8s UserSignup
 // and the corresponding MasterUserRecord resources.
 type Signup struct {
+	// The UserSignup resource name
+	Name string `json:"name"`
 	// The Web Console URL of the cluster which the user was provisioned to
 	ConsoleURL string `json:"consoleURL,omitempty"`
 	// The Che Dashboard URL of the cluster which the user was provisioned to

--- a/test/fake/informer.go
+++ b/test/fake/informer.go
@@ -2,6 +2,7 @@ package fake
 
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -57,7 +58,8 @@ func (f Informer) ListSpaceBindings(req ...labels.Requirement) ([]*toolchainv1al
 func NewSpace(targetCluster, compliantUserName string) *toolchainv1alpha1.Space {
 	space := &toolchainv1alpha1.Space{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: compliantUserName,
+			Name:      compliantUserName,
+			Namespace: configuration.Namespace(),
 			Labels: map[string]string{
 				toolchainv1alpha1.SpaceCreatorLabelKey: compliantUserName,
 			},


### PR DESCRIPTION
For https://issues.redhat.com/browse/ASC-286

Adds `type` for each Workspace returned from the space lister. Type can currently be "home" or "" (empty). Only one can be the "home" Workspace for a user. This is the Workspace that HAC and the proxy will use when no Workspace context is provided.

Also, Workspaces returned will inherit the following object metadata properties from the corresponding Space resources:
- `ResourceVersion`
- `UID`
- `Generation`
- `CreationTimestamp`

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/666