### PR TITLE
Fix logger bug

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -257,6 +258,9 @@ func addRequestInfo(req *http.Request) []interface{} {
 		}
 		fields = append(fields, "req_payload")
 		fields = append(fields, newStr)
+		// Once req.Body is read, it is empty. Restore its contents by
+		// assigning a new reader with the same contents.
+		req.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
 	}
 
 	return fields

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/context"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -32,7 +33,7 @@ func TestLog(t *testing.T) {
 		value := buf.String()
 		assert.Contains(t, value, `"logger":"logger_tests"`)
 		assert.Contains(t, value, `"msg":"test logger with no formatting"`)
-		assert.Contains(t, value, `"user_id":"test"`)
+		assert.Contains(t, value, `"user_id":"test"`) // subject -> user_id
 		assert.Contains(t, value, `"username":"usernametest"`)
 		assert.Contains(t, value, `"level":"info"`)
 		assert.Contains(t, value, `"timestamp":"`)
@@ -50,7 +51,7 @@ func TestLog(t *testing.T) {
 		value := buf.String()
 		assert.Contains(t, value, `"logger":"logger_tests"`)
 		assert.Contains(t, value, `"msg":"test info"`)
-		assert.Contains(t, value, `"user_id":"test"`)
+		assert.Contains(t, value, `"user_id":"test"`) // subject -> user_id
 		assert.Contains(t, value, `"username":"usernametest"`)
 		assert.Contains(t, value, `"level":"info"`)
 		assert.Contains(t, value, `"timestamp":"`)
@@ -149,6 +150,10 @@ func TestLog(t *testing.T) {
 		assert.Contains(t, value, `"Accept":["application/json"]`)
 		assert.Contains(t, value, `"Authorization":"*****"`)
 		assert.Contains(t, value, `"req_payload":"{\"testing-body\":\"test\"}"`)
+		buf := new(bytes.Buffer)
+		_, err := buf.ReadFrom(req.Body)
+		require.NoError(t, err, "it should still be possible to read the body after it was passed to the logs")
+		assert.Equal(t, `{"testing-body":"test"}`, buf.String(), "body contents should be unchanged")
 	})
 
 	t.Run("log infof withValues", func(t *testing.T) {


### PR DESCRIPTION
I ran into an issue when trying to process a request with some contents in its body. The body was always empty but I could see in the browser the body had contents when it was sent. This was quite puzzling.

It turned out there's a bug in the logger where the request body in `ctx` is lost if logger.Info is called because when we read the body contents the `io.ReadCloser` is emptied. So later when the request is being processed `req.Body` is empty. The fix is to restore its contents after reading it in the logger.

Note: I tried making a copy of the request at the entrypoint of the logger.Info function but that didn't work because we'd still need to read from req.Body to copy it so it was effectively the same thing but a little more messy.