### PR TITLE
Allow recaptcha token header

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -63,7 +63,7 @@ func New(application application.Application) *RegistrationServer {
 		cors.New(cors.Config{
 			AllowAllOrigins:  true,
 			AllowMethods:     []string{"PUT", "PATCH", "POST", "GET", "DELETE", "OPTIONS"},
-			AllowHeaders:     []string{"Content-Length", "Content-Type", "Authorization", "Accept"},
+			AllowHeaders:     []string{"Content-Length", "Content-Type", "Authorization", "Accept", "Recaptcha-Token"},
 			ExposeHeaders:    []string{"Content-Length", "Authorization"},
 			AllowCredentials: true,
 		}),

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -98,7 +98,7 @@ func (s *TestServerSuite) TestServer() {
 		defer resp.Body.Close()
 
 		require.Equal(s.T(), 204, resp.StatusCode)
-		require.Equal(s.T(), "Content-Length,Content-Type,Authorization,Accept", resp.Header.Get("Access-Control-Allow-Headers"))
+		require.Equal(s.T(), "Content-Length,Content-Type,Authorization,Accept,Recaptcha-Token", resp.Header.Get("Access-Control-Allow-Headers"))
 		require.Equal(s.T(), "PUT,PATCH,POST,GET,DELETE,OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
 		require.Equal(s.T(), "*", resp.Header.Get("Access-Control-Allow-Origin"))
 		require.Equal(s.T(), "true", resp.Header.Get("Access-Control-Allow-Credentials"))


### PR DESCRIPTION
Needed so that RHD can include the recaptcha token in the signup request header.