### PR TITLE
remove TransformUsername from registration-service

### DIFF
--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -20,8 +20,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
-	"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
-
 	"github.com/gin-gonic/gin"
 	errs "github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
@@ -72,8 +70,7 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 	userID := ctx.GetString(context.UserIDKey)
 	accountID := ctx.GetString(context.AccountIDKey)
 
-	username = usersignup.TransformUsername(username)
-	if strings.HasSuffix(username, "crtadmin") {
+	if isCRTAdmin(username) {
 		log.Info(ctx, fmt.Sprintf("A crtadmin user '%s' just tried to signup - the UserID is: '%s'", ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey)))
 		return nil, apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("failed to create usersignup for %s", username))
 	}
@@ -134,6 +131,14 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 	}
 
 	return userSignup, nil
+}
+
+func isCRTAdmin(username string) bool {
+	newUsername := regexp.MustCompile("[^A-Za-z0-9]").ReplaceAllString(strings.Split(username, "@")[0], "-")
+	if strings.HasSuffix(newUsername, "crtadmin") {
+		return true
+	}
+	return false
 }
 
 /*

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -135,10 +135,7 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 
 func isCRTAdmin(username string) bool {
 	newUsername := regexp.MustCompile("[^A-Za-z0-9]").ReplaceAllString(strings.Split(username, "@")[0], "-")
-	if strings.HasSuffix(newUsername, "crtadmin") {
-		return true
-	}
-	return false
+	return strings.HasSuffix(newUsername, "crtadmin")
 }
 
 /*


### PR DESCRIPTION
character-limit restriction introduced in TransformUsername in https://github.com/codeready-toolchain/toolchain-common/pull/309 breaks the functionality that limits crtadmin usersignups to be created from registration-service. 
Example :
Username : `johny-long-username-crtadmin` would be reduced to `johny-long-username` using TransformUsername, letting the usersignup with the actual username `johny-long-username-crtadmin` be created.

Since the registration-service only uses TransformUsername to check if the username has a suffix `crtadmin`, a new function is introduces which checks just that, and remove dependency on transformUsername.