### PR TITLE
fix: ldflags commit id and build time in github

### DIFF
--- a/make/build.mk
+++ b/make/build.mk
@@ -1,5 +1,5 @@
 # By default the project should be build under GOPATH/src/github.com/<orgname>/<reponame>
-GO_PACKAGE_ORG_NAME ?= $(shell basename $$(dirname $$PWD))
+GO_PACKAGE_ORG_NAME ?= codeready-toolchain
 GO_PACKAGE_REPO_NAME ?= $(shell basename $$PWD)
 GO_PACKAGE_PATH ?= github.com/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}
 


### PR DESCRIPTION
When building the operator in Github jobs the module path was not correctly populated see: https://github.com/codeready-toolchain/registration-service/actions/runs/4886564041/jobs/8722069398#step:7:47 causing the version and build time to be empty.

Also it's fine to have the org name "hard coded" since the module name is the same when building the operator locally and in Github.

This is prerequisite for monitoring the deployed versions of the sandbox operators.

Jira story: https://issues.redhat.com/browse/SANDBOX-53