### PR TITLE
set 24h timeout for api Route

### DIFF
--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -198,6 +198,8 @@ objects:
       labels:
         provider: codeready-toolchain
         run: registration-service
+      annotations:
+        haproxy.router.openshift.io/timeout: 24h
       name: api
       namespace: ${NAMESPACE}
     spec:


### PR DESCRIPTION
first PR to fix https://issues.redhat.com/browse/SANDBOX-85
The second PR will update timeout for the RoundTripper. I need to split them so I can pair e2e tests with the final fix in reg-service to make the test work.