### PR TITLE
fix: disable timeout at RoundTripper level & improve logging

### DIFF
--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -21,4 +21,6 @@ const (
 	OriginalSubKey = "originalSub"
 	// JWTClaimsKey is the context key for the claims struct
 	JWTClaimsKey = "jwtClaims"
+	// WorkspaceKey is the context key for the workspace name in echo.Context
+	WorkspaceKey = "workspace"
 )

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -358,15 +358,11 @@ func (p *Proxy) newReverseProxy(ctx echo.Context, target *access.ClusterAccess, 
 
 // TODO: use transport from the cached ToolchainCluster instance
 func noTimeoutDefaultTransport() *http.Transport {
-	return &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           noTimeoutDialerProxy,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
+	transport := http.DefaultTransport.(interface {
+		Clone() *http.Transport
+	}).Clone()
+	transport.DialContext = noTimeoutDialerProxy
+	return transport
 }
 
 var noTimeoutDialerProxy = func(ctx gocontext.Context, network, addr string) (net.Conn, error) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -387,7 +387,7 @@ func getTransport(reqHeader http.Header) *http.Transport {
 	if strings.HasPrefix(strings.ToLower(reqHeader.Get(httpstream.HeaderUpgrade)), "spdy/") {
 		// thus, we need to switch to http/1.1
 		transport.ForceAttemptHTTP2 = false
-		transport.TLSClientConfig = &tls.Config{
+		transport.TLSClientConfig = &tls.Config{ // nolint:gosec
 			NextProtos: []string{"http/1.1"},
 		}
 	}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1022,7 +1022,7 @@ func (s *TestProxySuite) TestGetTransport() {
 		transport.DialContext = noTimeoutDialerProxy
 
 		// then
-		assertTransport(t, noTimeoutDefaultTransport().Clone(), transport)
+		assertTransport(t, noTimeoutDefaultTransport(), transport)
 	})
 }
 


### PR DESCRIPTION
This PR fixes two things. Why two in the same PR? because they are related :stuck_out_tongue_winking_eye: 

First of all, the PR changes the way we define values for the RoundTripper. The `http.DefaultTransport` sets 30s timeout as part of the DialerContext by default, so we need to change that  and set it to zero. 

The second fix is related to logging. The original log (produced as part of the `middleware.RequestLoggerWithConfig`) was printed out only when the routing was finished, so we didn't see these watch calls in the logs. The reason is that they are just a long-running GET calls that open the stream and the routing is not really finished. Thus, I added another log that prints out when the request is received. As part of this, I also modified the format so we use standard logger and not `fmt.Printf`. There is still a room for an improvement of the standard logs as well - see my TODO comments - but let's do it in the next PR.

it's the second (and last step) to fix  https://issues.redhat.com/browse/SANDBOX-85

paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/753