### PR TITLE
Add new get user signup fields

### DIFF
--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -511,10 +511,11 @@ func getRHODSMember(signup signup.Signup) string {
 // for example for the "devspaces" app and api server "https://api.host.openshiftapps.com:6443"
 // it will return "https://devspaces.apps.host.openshiftapps.com"
 func getAppsURL(appRouteName string, signup signup.Signup) string {
-	if signup.ConsoleURL == "" {
+	index := strings.Index(signup.ConsoleURL, ".apps.")
+	if index == -1 {
 		return ""
 	}
 	// get the appsURL eg. .apps.host.openshiftapps.com
-	appsURL := signup.ConsoleURL[strings.Index(signup.ConsoleURL, ".apps"):]
+	appsURL := signup.ConsoleURL[index:]
 	return fmt.Sprintf("https://%s%s", appRouteName, appsURL)
 }

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -426,7 +426,7 @@ func (s *ServiceImpl) DoGetSignup(provider ResourceProvider, userID, username st
 		}
 
 		// set RHODS member URL
-		signupResponse.RHODSMemberURL = getRHODSMember(*signupResponse)
+		signupResponse.RHODSMemberURL = getRHODSMemberURL(*signupResponse)
 
 		// set default user namespace
 		signupResponse.DefaultUserNamespace = getDefaultUserNamespace(*signupResponse)
@@ -503,7 +503,7 @@ func getDefaultUserNamespace(signup signup.Signup) string {
 	return fmt.Sprintf("%s-dev", signup.CompliantUsername)
 }
 
-func getRHODSMember(signup signup.Signup) string {
+func getRHODSMemberURL(signup signup.Signup) string {
 	return getAppsURL("rhods-dashboard-redhat-ods-applications", signup)
 }
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -409,7 +409,7 @@ func (s *ServiceImpl) DoGetSignup(provider ResourceProvider, userID, username st
 		VerificationRequired: states.VerificationRequired(userSignup),
 	}
 	if mur.Status.UserAccounts != nil && len(mur.Status.UserAccounts) > 0 {
-		// Retrieve Console and Che dashboard URLs from the status of the corresponding member cluster
+		// Retrieve cluster-specific URLs from the status of the corresponding member cluster
 		status, err := provider.GetToolchainStatus()
 		if err != nil {
 			return nil, errs.Wrapf(err, "error when retrieving ToolchainStatus to set Che Dashboard for completed UserSignup %s", userSignup.GetName())
@@ -424,6 +424,12 @@ func (s *ServiceImpl) DoGetSignup(provider ResourceProvider, userID, username st
 				break
 			}
 		}
+
+		// set RHODS member URL
+		signupResponse.RHODSMemberURL = getRHODSMember(*signupResponse)
+
+		// set default user namespace
+		signupResponse.DefaultUserNamespace = getDefaultUserNamespace(*signupResponse)
 	}
 
 	return signupResponse, nil
@@ -491,4 +497,24 @@ func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, username, phoneNumberOrHas
 	}
 
 	return nil
+}
+
+func getDefaultUserNamespace(signup signup.Signup) string {
+	return fmt.Sprintf("%s-dev", signup.CompliantUsername)
+}
+
+func getRHODSMember(signup signup.Signup) string {
+	return getAppsURL("rhods-dashboard-redhat-ods-applications", signup)
+}
+
+// getAppsURL returns a URL for the specific app
+// for example for the "devspaces" app and api server "https://api.host.openshiftapps.com:6443"
+// it will return "https://devspaces.apps.host.openshiftapps.com"
+func getAppsURL(appRouteName string, signup signup.Signup) string {
+	if signup.ConsoleURL == "" {
+		return ""
+	}
+	// get the appsURL eg. .apps.host.openshiftapps.com
+	appsURL := signup.ConsoleURL[strings.Index(signup.ConsoleURL, ".apps"):]
+	return fmt.Sprintf("https://%s%s", appRouteName, appsURL)
 }

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -1064,7 +1064,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 					APIEndpoint: "http://api.devcluster.openshift.com",
 					MemberStatus: toolchainv1alpha1.MemberStatusStatus{
 						Routes: &toolchainv1alpha1.Routes{
-							ConsoleURL:      "https://console.member-1.com",
+							ConsoleURL:      "https://console.apps.member-1.com",
 							CheDashboardURL: "http://che-toolchain-che.member-1.com",
 						},
 					},
@@ -1074,7 +1074,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 					APIEndpoint: "http://api.devcluster.openshift.com",
 					MemberStatus: toolchainv1alpha1.MemberStatusStatus{
 						Routes: &toolchainv1alpha1.Routes{
-							ConsoleURL:      "https://console.member-123.com",
+							ConsoleURL:      "https://console.apps.member-123.com",
 							CheDashboardURL: "http://che-toolchain-che.member-123.com",
 						},
 					},
@@ -1102,13 +1102,13 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 	assert.Equal(s.T(), "mur_ready_reason", response.Status.Reason)
 	assert.Equal(s.T(), "mur_ready_message", response.Status.Message)
 	assert.False(s.T(), response.Status.VerificationRequired)
-	assert.Equal(s.T(), "https://console.member-123.com", response.ConsoleURL)
+	assert.Equal(s.T(), "https://console.apps.member-123.com", response.ConsoleURL)
 	assert.Equal(s.T(), "http://che-toolchain-che.member-123.com", response.CheDashboardURL)
 	assert.Equal(s.T(), "http://api.devcluster.openshift.com", response.APIEndpoint)
 	assert.Equal(s.T(), "member-123", response.ClusterName)
 	assert.Equal(s.T(), "https://proxy-url.com", response.ProxyURL)
 	assert.Equal(s.T(), "ted-dev", response.DefaultUserNamespace)
-	assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123", response.RHODSMemberURL)
+	assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123.com", response.RHODSMemberURL)
 
 	s.T().Run("informer", func(t *testing.T) {
 		// given
@@ -1150,13 +1150,13 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 		assert.Equal(s.T(), "mur_ready_reason", response.Status.Reason)
 		assert.Equal(s.T(), "mur_ready_message", response.Status.Message)
 		assert.False(s.T(), response.Status.VerificationRequired)
-		assert.Equal(s.T(), "https://console.member-123.com", response.ConsoleURL)
+		assert.Equal(s.T(), "https://console.apps.member-123.com", response.ConsoleURL)
 		assert.Equal(s.T(), "http://che-toolchain-che.member-123.com", response.CheDashboardURL)
 		assert.Equal(s.T(), "http://api.devcluster.openshift.com", response.APIEndpoint)
 		assert.Equal(s.T(), "member-123", response.ClusterName)
 		assert.Equal(s.T(), "https://proxy-url.com", response.ProxyURL)
 		assert.Equal(s.T(), "ted-dev", response.DefaultUserNamespace)
-		assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123", response.RHODSMemberURL)
+		assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123.com", response.RHODSMemberURL)
 	})
 }
 
@@ -1186,7 +1186,7 @@ func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 					APIEndpoint: "http://api.devcluster.openshift.com",
 					MemberStatus: toolchainv1alpha1.MemberStatusStatus{
 						Routes: &toolchainv1alpha1.Routes{
-							ConsoleURL:      "https://console.member-1.com",
+							ConsoleURL:      "https://console.apps.member-1.com",
 							CheDashboardURL: "http://che-toolchain-che.member-1.com",
 						},
 					},
@@ -1196,7 +1196,7 @@ func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 					APIEndpoint: "http://api.devcluster.openshift.com",
 					MemberStatus: toolchainv1alpha1.MemberStatusStatus{
 						Routes: &toolchainv1alpha1.Routes{
-							ConsoleURL:      "https://console.member-123.com",
+							ConsoleURL:      "https://console.apps.member-123.com",
 							CheDashboardURL: "http://che-toolchain-che.member-123.com",
 						},
 					},
@@ -1224,13 +1224,13 @@ func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 	assert.Equal(s.T(), "mur_ready_reason", response.Status.Reason)
 	assert.Equal(s.T(), "mur_ready_message", response.Status.Message)
 	assert.False(s.T(), response.Status.VerificationRequired)
-	assert.Equal(s.T(), "https://console.member-123.com", response.ConsoleURL)
+	assert.Equal(s.T(), "https://console.apps.member-123.com", response.ConsoleURL)
 	assert.Equal(s.T(), "http://che-toolchain-che.member-123.com", response.CheDashboardURL)
 	assert.Equal(s.T(), "http://api.devcluster.openshift.com", response.APIEndpoint)
 	assert.Equal(s.T(), "member-123", response.ClusterName)
 	assert.Equal(s.T(), "https://proxy-url.com", response.ProxyURL)
 	assert.Equal(s.T(), "ted-dev", response.DefaultUserNamespace)
-	assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123", response.RHODSMemberURL)
+	assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123.com", response.RHODSMemberURL)
 
 	s.T().Run("informer", func(t *testing.T) {
 		// given
@@ -1273,13 +1273,13 @@ func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 		assert.Equal(s.T(), "mur_ready_reason", response.Status.Reason)
 		assert.Equal(s.T(), "mur_ready_message", response.Status.Message)
 		assert.False(s.T(), response.Status.VerificationRequired)
-		assert.Equal(s.T(), "https://console.member-123.com", response.ConsoleURL)
+		assert.Equal(s.T(), "https://console.apps.member-123.com", response.ConsoleURL)
 		assert.Equal(s.T(), "http://che-toolchain-che.member-123.com", response.CheDashboardURL)
 		assert.Equal(s.T(), "http://api.devcluster.openshift.com", response.APIEndpoint)
 		assert.Equal(s.T(), "member-123", response.ClusterName)
 		assert.Equal(s.T(), "https://proxy-url.com", response.ProxyURL)
 		assert.Equal(s.T(), "ted-dev", response.DefaultUserNamespace)
-		assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123", response.RHODSMemberURL)
+		assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123.com", response.RHODSMemberURL)
 	})
 }
 

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -837,6 +837,8 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 	require.Equal(s.T(), "", response.APIEndpoint)
 	require.Equal(s.T(), "", response.ClusterName)
 	require.Equal(s.T(), "", response.ProxyURL)
+	assert.Equal(s.T(), "", response.DefaultUserNamespace)
+	assert.Equal(s.T(), "", response.RHODSMemberURL)
 
 	s.T().Run("informer", func(t *testing.T) {
 		// given
@@ -875,6 +877,8 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 		require.Equal(s.T(), "", response.APIEndpoint)
 		require.Equal(s.T(), "", response.ClusterName)
 		require.Equal(s.T(), "", response.ProxyURL)
+		assert.Equal(s.T(), "", response.DefaultUserNamespace)
+		assert.Equal(s.T(), "", response.RHODSMemberURL)
 	})
 }
 
@@ -947,6 +951,8 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 		require.Equal(s.T(), "", response.APIEndpoint)
 		require.Equal(s.T(), "", response.ClusterName)
 		require.Equal(s.T(), "", response.ProxyURL)
+		assert.Equal(s.T(), "", response.DefaultUserNamespace)
+		assert.Equal(s.T(), "", response.RHODSMemberURL)
 
 		s.T().Run("informer", func(t *testing.T) {
 			// given
@@ -985,6 +991,8 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 			require.Equal(s.T(), "", response.APIEndpoint)
 			require.Equal(s.T(), "", response.ClusterName)
 			require.Equal(s.T(), "", response.ProxyURL)
+			assert.Equal(s.T(), "", response.DefaultUserNamespace)
+			assert.Equal(s.T(), "", response.RHODSMemberURL)
 		})
 	}
 }
@@ -1099,6 +1107,8 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 	assert.Equal(s.T(), "http://api.devcluster.openshift.com", response.APIEndpoint)
 	assert.Equal(s.T(), "member-123", response.ClusterName)
 	assert.Equal(s.T(), "https://proxy-url.com", response.ProxyURL)
+	assert.Equal(s.T(), "ted-dev", response.DefaultUserNamespace)
+	assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123", response.RHODSMemberURL)
 
 	s.T().Run("informer", func(t *testing.T) {
 		// given
@@ -1145,6 +1155,8 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 		assert.Equal(s.T(), "http://api.devcluster.openshift.com", response.APIEndpoint)
 		assert.Equal(s.T(), "member-123", response.ClusterName)
 		assert.Equal(s.T(), "https://proxy-url.com", response.ProxyURL)
+		assert.Equal(s.T(), "ted-dev", response.DefaultUserNamespace)
+		assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123", response.RHODSMemberURL)
 	})
 }
 
@@ -1217,6 +1229,8 @@ func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 	assert.Equal(s.T(), "http://api.devcluster.openshift.com", response.APIEndpoint)
 	assert.Equal(s.T(), "member-123", response.ClusterName)
 	assert.Equal(s.T(), "https://proxy-url.com", response.ProxyURL)
+	assert.Equal(s.T(), "ted-dev", response.DefaultUserNamespace)
+	assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123", response.RHODSMemberURL)
 
 	s.T().Run("informer", func(t *testing.T) {
 		// given
@@ -1264,6 +1278,8 @@ func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 		assert.Equal(s.T(), "http://api.devcluster.openshift.com", response.APIEndpoint)
 		assert.Equal(s.T(), "member-123", response.ClusterName)
 		assert.Equal(s.T(), "https://proxy-url.com", response.ProxyURL)
+		assert.Equal(s.T(), "ted-dev", response.DefaultUserNamespace)
+		assert.Equal(s.T(), "https://rhods-dashboard-redhat-ods-applications.apps.member-123", response.RHODSMemberURL)
 	})
 }
 

--- a/pkg/signup/signup.go
+++ b/pkg/signup/signup.go
@@ -12,7 +12,7 @@ type Signup struct {
 	// The proxy URL of the cluster
 	ProxyURL string `json:"proxyURL,omitempty"`
 	// The RHODS URL for the user's cluster
-	RHODSMemberURL string `json:"rhodsMember,omitempty"`
+	RHODSMemberURL string `json:"rhodsMemberURL,omitempty"`
 	// The server api URL of the cluster which the user was provisioned to
 	APIEndpoint string `json:"apiEndpoint,omitempty"`
 	// The name of the cluster which the user was provisioned to

--- a/pkg/signup/signup.go
+++ b/pkg/signup/signup.go
@@ -11,10 +11,14 @@ type Signup struct {
 	CheDashboardURL string `json:"cheDashboardURL,omitempty"`
 	// The proxy URL of the cluster
 	ProxyURL string `json:"proxyURL,omitempty"`
+	// The RHODS URL for the user's cluster
+	RHODSMemberURL string `json:"rhodsMember,omitempty"`
 	// The server api URL of the cluster which the user was provisioned to
 	APIEndpoint string `json:"apiEndpoint,omitempty"`
 	// The name of the cluster which the user was provisioned to
 	ClusterName string `json:"clusterName,omitempty"`
+	// The user's default namespace
+	DefaultUserNamespace string `json:"defaultUserNamespace,omitempty"`
 	// The complaint username.  This may differ from the corresponding Identity Provider username, because of the the
 	// limited character set available for naming (see RFC1123) in K8s. If the username contains characters which are
 	// disqualified from the resource name, the username is transformed into an acceptable resource name instead.


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/SANDBOX-168

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/757

This PR adds the `rhodsMemberURL` and `defaultUserNamespace` to the GET /api/v1/signup endpoint response.

Example:
```
{
    "name": "rajiv",
    "consoleURL": "https://console-openshift-console.apps.rajiv.openshift.com/",
    "proxyURL": "https://api-toolchain-host-operator.apps.rajiv.openshift.com",
    "rhodsMemberURL": "https://rhods-dashboard-redhat-ods-applications.apps.rajiv.openshift.com/",
    "apiEndpoint": "https://api.rajiv.openshift.com:6443",
    "clusterName": "member-rajiv.openshift.com",
    "defaultUserNamespace": "rajiv-dev",
    "compliantUsername": "rajiv",
    "username": "rajiv",
    "givenName": "",
    "familyName": "",
    "company": "",
    "status": {
        "ready": true,
        "reason": "Provisioned",
        "verificationRequired": false
    }
}
```

This PR will make the endpoint functional ASAP so that the UI can start using it. There will be a followup PR to properly get the `defaultUserNamespace` value.