### PR TITLE
Get default namespace from Space

### DIFF
--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -13,7 +13,7 @@ type InformerService interface {
 	GetSpace(name string) (*toolchainv1alpha1.Space, error)
 	GetToolchainStatus() (*toolchainv1alpha1.ToolchainStatus, error)
 	GetUserSignup(name string) (*toolchainv1alpha1.UserSignup, error)
-	ListSpaceBindings(reqs ...labels.Requirement) ([]*toolchainv1alpha1.SpaceBinding, error)
+	ListSpaceBindings(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error)
 	GetProxyPluginConfig(name string) (*toolchainv1alpha1.ProxyPlugin, error)
 }
 

--- a/pkg/informers/service/informer_service.go
+++ b/pkg/informers/service/informer_service.go
@@ -111,14 +111,14 @@ func (s *ServiceImpl) GetUserSignup(name string) (*toolchainv1alpha1.UserSignup,
 	return us, err
 }
 
-func (s *ServiceImpl) ListSpaceBindings(reqs ...labels.Requirement) ([]*toolchainv1alpha1.SpaceBinding, error) {
+func (s *ServiceImpl) ListSpaceBindings(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
 	selector := labels.NewSelector().Add(reqs...)
 	objs, err := s.informer.SpaceBinding.ByNamespace(configuration.Namespace()).List(selector)
 	if err != nil {
 		return nil, err
 	}
 
-	sbs := []*toolchainv1alpha1.SpaceBinding{}
+	sbs := []toolchainv1alpha1.SpaceBinding{}
 	for _, obj := range objs {
 		unobj := obj.(*unstructured.Unstructured)
 		sb := &toolchainv1alpha1.SpaceBinding{}
@@ -126,7 +126,7 @@ func (s *ServiceImpl) ListSpaceBindings(reqs ...labels.Requirement) ([]*toolchai
 			log.Errorf(nil, err, "failed to list SpaceBindings")
 			return nil, err
 		}
-		sbs = append(sbs, sb)
+		sbs = append(sbs, *sb)
 	}
 	return sbs, err
 }

--- a/pkg/kubeclient/client.go
+++ b/pkg/kubeclient/client.go
@@ -19,6 +19,8 @@ type V1Alpha1 interface {
 	BannedUsers() BannedUserInterface
 	ToolchainStatuses() ToolchainStatusInterface
 	SocialEvents() SocialEventInterface
+	Spaces() SpaceInterface
+	SpaceBindings() SpaceBindingInterface
 }
 
 // NewCRTRESTClient creates a new REST client for managing Codeready Toolchain resources via the Kubernetes API
@@ -64,6 +66,10 @@ func getRegisterObject() []runtime.Object {
 		&crtapi.BannedUserList{},
 		&crtapi.ToolchainStatus{},
 		&crtapi.ToolchainStatusList{},
+		&crtapi.Space{},
+		&crtapi.SpaceList{},
+		&crtapi.SpaceBinding{},
+		&crtapi.SpaceBindingList{},
 	}
 }
 
@@ -139,6 +145,32 @@ func (c *V1Alpha1REST) ToolchainStatuses() ToolchainStatusInterface {
 // SocialEvents returns an interface which may be used to perform CRUD operations for SocialEvent resources
 func (c *V1Alpha1REST) SocialEvents() SocialEventInterface {
 	return &socialeventClient{
+		crtClient: crtClient{
+			client:   c.client.RestClient,
+			informer: c.client.Informer,
+			ns:       c.client.NS,
+			cfg:      c.client.Config,
+			scheme:   c.client.Scheme,
+		},
+	}
+}
+
+// Spaces returns an interface which may be used to perform CRUD operations for Space resources
+func (c *V1Alpha1REST) Spaces() SpaceInterface {
+	return &spaceClient{
+		crtClient: crtClient{
+			client:   c.client.RestClient,
+			informer: c.client.Informer,
+			ns:       c.client.NS,
+			cfg:      c.client.Config,
+			scheme:   c.client.Scheme,
+		},
+	}
+}
+
+// SpaceBindings returns an interface which may be used to perform CRUD operations for SpaceBinding resources
+func (c *V1Alpha1REST) SpaceBindings() SpaceBindingInterface {
+	return &spaceBindingClient{
 		crtClient: crtClient{
 			client:   c.client.RestClient,
 			informer: c.client.Informer,

--- a/pkg/kubeclient/mur.go
+++ b/pkg/kubeclient/mur.go
@@ -4,10 +4,7 @@ import (
 	"context"
 
 	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
-)
-
-const (
-	masterUserRecordResourcePlural = "masteruserrecords"
+	"github.com/codeready-toolchain/registration-service/pkg/kubeclient/resources"
 )
 
 type masterUserRecordClient struct {
@@ -23,7 +20,7 @@ func (c *masterUserRecordClient) Get(name string) (*crtapi.MasterUserRecord, err
 	result := &crtapi.MasterUserRecord{}
 	err := c.client.Get().
 		Namespace(c.ns).
-		Resource(masterUserRecordResourcePlural).
+		Resource(resources.MurResourcePlural).
 		Name(name).
 		Do(context.TODO()).
 		Into(result)

--- a/pkg/kubeclient/space.go
+++ b/pkg/kubeclient/space.go
@@ -1,0 +1,28 @@
+package kubeclient
+
+import (
+	"context"
+
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/registration-service/pkg/kubeclient/resources"
+)
+
+type spaceClient struct {
+	crtClient
+}
+
+type SpaceInterface interface {
+	Get(name string) (*crtapi.Space, error)
+}
+
+// List returns the Spaces that match for the provided selector, or an error if something went wrong while attempting to retrieve it
+func (c *spaceClient) Get(name string) (*crtapi.Space, error) {
+	result := &crtapi.Space{}
+	err := c.client.Get().
+		Namespace(c.ns).
+		Resource(resources.SpaceResourcePlural).
+		Name(name).
+		Do(context.TODO()).
+		Into(result)
+	return result, err
+}

--- a/pkg/kubeclient/spacebinding.go
+++ b/pkg/kubeclient/spacebinding.go
@@ -1,0 +1,47 @@
+package kubeclient
+
+import (
+	"context"
+
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/registration-service/pkg/kubeclient/resources"
+	"github.com/codeready-toolchain/registration-service/pkg/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+type spaceBindingClient struct {
+	crtClient
+}
+
+type SpaceBindingInterface interface {
+	ListSpaceBindings(reqs ...labels.Requirement) ([]crtapi.SpaceBinding, error)
+}
+
+// List returns the SpaceBindings that match for the provided selector, or an error if something went wrong while attempting to retrieve it
+func (c *spaceBindingClient) ListSpaceBindings(reqs ...labels.Requirement) ([]crtapi.SpaceBinding, error) {
+
+	intf, err := dynamic.NewForConfig(&c.cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	selector := labels.NewSelector().Add(reqs...)
+	r := schema.GroupVersionResource{Group: "toolchain.dev.openshift.com", Version: "v1alpha1", Resource: resources.SpaceBindingResourcePlural}
+	log.Infof(nil, "Listing SpaceBindings with selector: %v", selector.String())
+	listOptions := metav1.ListOptions{
+		LabelSelector: selector.String(),
+	}
+
+	list, err := intf.Resource(r).Namespace(c.ns).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &crtapi.SpaceBindingList{}
+
+	err = c.crtClient.scheme.Convert(list, result, nil)
+	return result.Items, err
+}

--- a/pkg/proxy/handlers/spacelister.go
+++ b/pkg/proxy/handlers/spacelister.go
@@ -80,7 +80,7 @@ func (s *SpaceLister) ListUserWorkspaces(ctx echo.Context) ([]toolchainv1alpha1.
 	return s.workspacesFromSpaceBindings(signup.Name, spaceBindings), nil
 }
 
-func (s *SpaceLister) listSpaceBindingsForUser(ctx echo.Context, murName string) ([]*toolchainv1alpha1.SpaceBinding, error) {
+func (s *SpaceLister) listSpaceBindingsForUser(ctx echo.Context, murName string) ([]toolchainv1alpha1.SpaceBinding, error) {
 
 	workspaceName := ctx.Param("workspace")
 	doGetWorkspace := len(workspaceName) > 0
@@ -104,7 +104,7 @@ func (s *SpaceLister) listSpaceBindingsForUser(ctx echo.Context, murName string)
 	return s.GetInformerServiceFunc().ListSpaceBindings(requirements...)
 }
 
-func (s *SpaceLister) workspacesFromSpaceBindings(signupName string, spaceBindings []*toolchainv1alpha1.SpaceBinding) []toolchainv1alpha1.Workspace {
+func (s *SpaceLister) workspacesFromSpaceBindings(signupName string, spaceBindings []toolchainv1alpha1.SpaceBinding) []toolchainv1alpha1.Workspace {
 	workspaces := []toolchainv1alpha1.Workspace{}
 	for _, spaceBinding := range spaceBindings {
 

--- a/pkg/proxy/handlers/spacelister_test.go
+++ b/pkg/proxy/handlers/spacelister_test.go
@@ -140,7 +140,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 				expectedErrCode: 500,
 				overrideInformerFunc: func() service.InformerService {
 					inf := fake.NewFakeInformer()
-					inf.ListSpaceBindingFunc = func(reqs ...labels.Requirement) ([]*toolchainv1alpha1.SpaceBinding, error) {
+					inf.ListSpaceBindingFunc = func(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
 						return nil, fmt.Errorf("list spacebindings error")
 					}
 					return inf
@@ -241,18 +241,14 @@ func getFakeInformerService(fakeClient client.Client) func() service.InformerSer
 			err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: name}, space)
 			return space, err
 		}
-		inf.ListSpaceBindingFunc = func(reqs ...labels.Requirement) ([]*toolchainv1alpha1.SpaceBinding, error) {
+		inf.ListSpaceBindingFunc = func(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
 			labelMatch := client.MatchingLabels{}
 			for _, r := range reqs {
 				labelMatch[r.Key()] = r.Values().List()[0]
 			}
 			sbList := &toolchainv1alpha1.SpaceBindingList{}
 			err := fakeClient.List(context.TODO(), sbList, labelMatch)
-			sbs := []*toolchainv1alpha1.SpaceBinding{}
-			for _, sb := range sbList.Items {
-				sbs = append(sbs, sb.DeepCopy())
-			}
-			return sbs, err
+			return sbList.Items, err
 		}
 		return inf
 	}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -551,12 +551,12 @@ func (s *TestProxySuite) TestProxy() {
 												}
 												return nil, fmt.Errorf("space not found error")
 											}
-											inf.ListSpaceBindingFunc = func(reqs ...labels.Requirement) ([]*toolchainv1alpha1.SpaceBinding, error) {
+											inf.ListSpaceBindingFunc = func(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
 												// always return a spacebinding for the purposes of the proxy tests, actual testing of the space lister is covered in the space lister tests
-												spaceBindings := []*toolchainv1alpha1.SpaceBinding{}
+												spaceBindings := []toolchainv1alpha1.SpaceBinding{}
 												for _, req := range reqs {
 													if req.Values().List()[0] == "smith2" {
-														spaceBindings = append(spaceBindings, fake.NewSpaceBinding("mycoolworkspace-smith2", "smith2", "mycoolworkspace", "admin"))
+														spaceBindings = append(spaceBindings, *fake.NewSpaceBinding("mycoolworkspace-smith2", "smith2", "mycoolworkspace", "admin"))
 													}
 												}
 												return spaceBindings, nil

--- a/pkg/signup/service/resource_provider.go
+++ b/pkg/signup/service/resource_provider.go
@@ -3,12 +3,15 @@ package service
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/kubeclient"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 type ResourceProvider interface {
 	GetMasterUserRecord(name string) (*toolchainv1alpha1.MasterUserRecord, error)
 	GetToolchainStatus() (*toolchainv1alpha1.ToolchainStatus, error)
 	GetUserSignup(name string) (*toolchainv1alpha1.UserSignup, error)
+	GetSpace(name string) (*toolchainv1alpha1.Space, error)
+	ListSpaceBindings(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error)
 }
 
 type crtClientProvider struct {
@@ -25,4 +28,12 @@ func (p crtClientProvider) GetToolchainStatus() (*toolchainv1alpha1.ToolchainSta
 
 func (p crtClientProvider) GetUserSignup(name string) (*toolchainv1alpha1.UserSignup, error) {
 	return p.cl.V1Alpha1().UserSignups().Get(name)
+}
+
+func (p crtClientProvider) GetSpace(name string) (*toolchainv1alpha1.Space, error) {
+	return p.cl.V1Alpha1().Spaces().Get(name)
+}
+
+func (p crtClientProvider) ListSpaceBindings(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
+	return p.cl.V1Alpha1().SpaceBindings().ListSpaceBindings(reqs...)
 }

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -533,10 +533,12 @@ func GetDefaultUserNamespace(provider ResourceProvider, signup signup.Signup) st
 			continue
 		}
 
-		for _, ns := range space.Status.ProvisionedNamespaces {
-			if ns.Type == "default" {
-				defaultNamespace = ns.Name
-				break
+		if space.Labels[toolchainv1alpha1.SpaceCreatorLabelKey] == signup.Name {
+			for _, ns := range space.Status.ProvisionedNamespaces {
+				if ns.Type == "default" {
+					defaultNamespace = ns.Name
+					break
+				}
 			}
 		}
 	}

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -25,7 +25,9 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 const (
@@ -54,6 +56,7 @@ type SignupServiceOption func(svc *ServiceImpl)
 
 // NewSignupService creates a service object for performing user signup-related activities.
 func NewSignupService(context servicecontext.ServiceContext, opts ...SignupServiceOption) service.SignupService {
+
 	s := &ServiceImpl{
 		BaseService:     base.NewBaseService(context),
 		defaultProvider: crtClientProvider{context.CRTClient()},
@@ -429,7 +432,7 @@ func (s *ServiceImpl) DoGetSignup(provider ResourceProvider, userID, username st
 		signupResponse.RHODSMemberURL = getRHODSMemberURL(*signupResponse)
 
 		// set default user namespace
-		signupResponse.DefaultUserNamespace = getDefaultUserNamespace(*signupResponse)
+		signupResponse.DefaultUserNamespace = GetDefaultUserNamespace(provider, *signupResponse)
 	}
 
 	return signupResponse, nil
@@ -499,8 +502,46 @@ func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, username, phoneNumberOrHas
 	return nil
 }
 
-func getDefaultUserNamespace(signup signup.Signup) string {
-	return fmt.Sprintf("%s-dev", signup.CompliantUsername)
+func GetDefaultUserNamespace(provider ResourceProvider, signup signup.Signup) string {
+	sbSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey, selection.Equals, []string{signup.CompliantUsername})
+	if err != nil {
+		log.Errorf(nil, err, "unable to create spacebindings selector for signup %s", signup.Name)
+		return ""
+	}
+
+	requirements := []labels.Requirement{*sbSelector}
+
+	sbs, err := provider.ListSpaceBindings(requirements...)
+	if err != nil {
+		log.Errorf(nil, err, "unable to list spacebindings for signup %s", signup.Name)
+		return ""
+	}
+
+	var defaultNamespace string
+	for _, sb := range sbs {
+		spaceName := sb.Labels[toolchainv1alpha1.SpaceBindingSpaceLabelKey]
+		if spaceName == "" { // space may not be initialized
+			// log error and continue so that the api behaves in a best effort manner
+			log.Errorf(nil, fmt.Errorf("spacebinding has no '%s' label", toolchainv1alpha1.SpaceBindingSpaceLabelKey), "unable to get space '%s'", spaceName)
+			continue
+		}
+		space, err := provider.GetSpace(spaceName)
+		if err != nil {
+			// log error and continue so that the api behaves in a best effort manner
+			// ie. if a space isn't listed something went wrong but we still want to return the other spaces if possible
+			log.Errorf(nil, err, "unable to get space '%s'", spaceName)
+			continue
+		}
+
+		for _, ns := range space.Status.ProvisionedNamespaces {
+			if ns.Type == "default" {
+				defaultNamespace = ns.Name
+				break
+			}
+		}
+	}
+
+	return defaultNamespace
 }
 
 func getRHODSMemberURL(signup signup.Signup) string {

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -39,10 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-const (
-	TestNamespace = "test-namespace-123"
-)
-
 type TestSignupServiceSuite struct {
 	test.UnitTestSuite
 }
@@ -64,7 +60,7 @@ func (s *TestSignupServiceSuite) ServiceConfiguration(namespace string, verifica
 }
 
 func (s *TestSignupServiceSuite) TestSignup() {
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 	// given
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
@@ -284,7 +280,7 @@ func (s *TestSignupServiceSuite) TestGetSignupFailsWithNotFoundThenOtherError() 
 }
 
 func (s *TestSignupServiceSuite) TestSignupNoSpaces() {
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	// given
 	userID, err := uuid.NewV4()
@@ -324,7 +320,7 @@ func (s *TestSignupServiceSuite) TestSignupNoSpaces() {
 }
 
 func (s *TestSignupServiceSuite) TestSignupWithCaptchaEnabled() {
-	test2.SetEnvVarAndRestore(s.T(), commonconfig.WatchNamespaceEnvVar, TestNamespace)
+	test2.SetEnvVarAndRestore(s.T(), commonconfig.WatchNamespaceEnvVar, configuration.Namespace())
 
 	// captcha is enabled
 	serviceOption := func(svc *service.ServiceImpl) {
@@ -382,7 +378,7 @@ func (s *TestSignupServiceSuite) TestSignupWithCaptchaEnabled() {
 }
 
 func (s *TestSignupServiceSuite) TestUserSignupWithInvalidSubjectPrefix() {
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	// given
 	userID, err := uuid.NewV4()
@@ -459,7 +455,7 @@ func (s *TestSignupServiceSuite) TestEncodeUserID() {
 }
 
 func (s *TestSignupServiceSuite) TestUserWithExcludedDomainEmailSignsUp() {
-	s.ServiceConfiguration(TestNamespace, true, "redhat.com", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "redhat.com", 5)
 
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
@@ -481,7 +477,7 @@ func (s *TestSignupServiceSuite) TestUserWithExcludedDomainEmailSignsUp() {
 	require.NoError(s.T(), err)
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 
-	values, err := s.FakeUserSignupClient.Tracker.List(gvr, gvk, TestNamespace)
+	values, err := s.FakeUserSignupClient.Tracker.List(gvr, gvk, configuration.Namespace())
 	require.NoError(s.T(), err)
 
 	userSignups := values.(*toolchainv1alpha1.UserSignupList)
@@ -493,7 +489,7 @@ func (s *TestSignupServiceSuite) TestUserWithExcludedDomainEmailSignsUp() {
 }
 
 func (s *TestSignupServiceSuite) TestCRTAdminUserSignup() {
-	s.ServiceConfiguration(TestNamespace, true, "redhat.com", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "redhat.com", 5)
 
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
@@ -513,7 +509,7 @@ func (s *TestSignupServiceSuite) TestCRTAdminUserSignup() {
 }
 
 func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
@@ -521,7 +517,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 			Annotations: map[string]string{
 				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "john@gmail.com",
 			},
@@ -543,7 +539,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserSignupNameAlreadyExists() {
 }
 
 func (s *TestSignupServiceSuite) TestFailsIfUserBanned() {
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	// given
 	userID, err := uuid.NewV4()
@@ -556,7 +552,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserBanned() {
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      bannedUserID.String(),
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 			Labels: map[string]string{
 				toolchainv1alpha1.BannedUserEmailHashLabelKey: "a7b1b413c1cbddbcd19a51222ef8e20a",
 			},
@@ -586,7 +582,7 @@ func (s *TestSignupServiceSuite) TestFailsIfUserBanned() {
 }
 
 func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseBannedUser() {
-	s.ServiceConfiguration(TestNamespace, true, "redhat.com", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "redhat.com", 5)
 
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
@@ -598,7 +594,7 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseBannedUser() {
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      bannedUserID.String(),
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 			Labels: map[string]string{
 				toolchainv1alpha1.BannedUserEmailHashLabelKey:       "a7b1b413c1cbddbcd19a51222ef8e20a",
 				toolchainv1alpha1.BannedUserPhoneNumberHashLabelKey: "fd276563a8232d16620da8ec85d0575f",
@@ -620,7 +616,7 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseBannedUser() {
 }
 
 func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseUserSignup() {
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
@@ -629,7 +625,7 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseUserSignup() {
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 			Labels: map[string]string{
 				toolchainv1alpha1.UserSignupUserEmailHashLabelKey: "a7b1b413c1cbddbcd19a51222ef8e20a",
 				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "fd276563a8232d16620da8ec85d0575f",
@@ -651,7 +647,7 @@ func (s *TestSignupServiceSuite) TestPhoneNumberAlreadyInUseUserSignup() {
 }
 
 func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
@@ -663,7 +659,7 @@ func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      bannedUserID.String(),
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 			Labels: map[string]string{
 				toolchainv1alpha1.BannedUserEmailHashLabelKey: "1df66fbb427ff7e64ac46af29cc74b71",
 			},
@@ -687,7 +683,7 @@ func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
 	require.NoError(s.T(), err)
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 
-	values, err := s.FakeUserSignupClient.Tracker.List(gvr, gvk, TestNamespace)
+	values, err := s.FakeUserSignupClient.Tracker.List(gvr, gvk, configuration.Namespace())
 	require.NoError(s.T(), err)
 
 	userSignups := values.(*toolchainv1alpha1.UserSignupList)
@@ -695,7 +691,7 @@ func (s *TestSignupServiceSuite) TestOKIfOtherUserBanned() {
 	require.Len(s.T(), userSignups.Items, 1)
 
 	val := userSignups.Items[0]
-	require.Equal(s.T(), TestNamespace, val.Namespace)
+	require.Equal(s.T(), configuration.Namespace(), val.Namespace)
 	require.Equal(s.T(), "jsmith", val.Name)
 	require.Equal(s.T(), "jsmith", val.Spec.Username)
 	require.Equal(s.T(), userID.String(), val.Spec.Userid)
@@ -785,7 +781,7 @@ func (s *TestSignupServiceSuite) TestGetSignupNotFound() {
 
 func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	userID, err := uuid.NewV4()
 	require.NoError(s.T(), err)
@@ -794,7 +790,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 		},
 		Spec: toolchainv1alpha1.UserSignupSpec{
 			Username: "bill",
@@ -886,7 +882,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusNotComplete() {
 
 func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	noCondition := toolchainv1alpha1.UserSignupStatus{}
 	pendingApproval := toolchainv1alpha1.UserSignupStatus{
@@ -921,7 +917,7 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 			TypeMeta: v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      userID.String(),
-				Namespace: TestNamespace,
+				Namespace: configuration.Namespace(),
 			},
 			Spec: toolchainv1alpha1.UserSignupSpec{
 				Username: "bill",
@@ -1001,7 +997,7 @@ func (s *TestSignupServiceSuite) TestGetSignupNoStatusNotCompleteCondition() {
 
 func (s *TestSignupServiceSuite) TestGetSignupDeactivated() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	us := s.newUserSignupCompleteWithReason("Deactivated")
 	err := s.FakeUserSignupClient.Tracker.Add(us)
@@ -1043,7 +1039,7 @@ func (s *TestSignupServiceSuite) TestGetSignupDeactivated() {
 
 func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	us := s.newUserSignupComplete()
 	err := s.FakeUserSignupClient.Tracker.Add(us)
@@ -1057,7 +1053,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "toolchain-status",
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 		},
 		Status: toolchainv1alpha1.ToolchainStatusStatus{
 			Members: []toolchainv1alpha1.Member{
@@ -1090,12 +1086,12 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 	err = s.FakeToolchainStatusClient.Tracker.Add(toolchainStatus)
 	require.NoError(s.T(), err)
 
-	spacebinding := s.newSpaceBindingForMUR(mur.Name)
-	err = s.FakeSpaceBindingClient.Tracker.Add(spacebinding)
+	space := s.newSpaceForMUR(mur.Name, us.Name)
+	err = s.FakeSpaceClient.Tracker.Add(space)
 	require.NoError(s.T(), err)
 
-	space := s.newSpaceForMUR(mur.Name)
-	err = s.FakeSpaceClient.Tracker.Add(space)
+	spacebinding := s.newSpaceBinding(mur.Name, space.Name)
+	err = s.FakeSpaceBindingClient.Tracker.Add(spacebinding)
 	require.NoError(s.T(), err)
 
 	// when
@@ -1178,7 +1174,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusOK() {
 
 func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	us := s.newUserSignupComplete()
 	us.Name = service.EncodeUserIdentifier(us.Spec.Username)
@@ -1189,19 +1185,19 @@ func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 	err = s.FakeMasterUserRecordClient.Tracker.Add(mur)
 	require.NoError(s.T(), err)
 
-	spacebinding := s.newSpaceBindingForMUR(mur.Name)
-	err = s.FakeSpaceBindingClient.Tracker.Add(spacebinding)
+	space := s.newSpaceForMUR(mur.Name, us.Name)
+	err = s.FakeSpaceClient.Tracker.Add(space)
 	require.NoError(s.T(), err)
 
-	space := s.newSpaceForMUR(mur.Name)
-	err = s.FakeSpaceClient.Tracker.Add(space)
+	spacebinding := s.newSpaceBinding(mur.Name, space.Name)
+	err = s.FakeSpaceBindingClient.Tracker.Add(spacebinding)
 	require.NoError(s.T(), err)
 
 	toolchainStatus := &toolchainv1alpha1.ToolchainStatus{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "toolchain-status",
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 		},
 		Status: toolchainv1alpha1.ToolchainStatusStatus{
 			Members: []toolchainv1alpha1.Member{
@@ -1315,7 +1311,7 @@ func (s *TestSignupServiceSuite) TestGetSignupByUsernameOK() {
 
 func (s *TestSignupServiceSuite) TestGetSignupStatusFailGetToolchainStatus() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	us := s.newUserSignupComplete()
 	err := s.FakeUserSignupClient.Tracker.Add(us)
@@ -1368,7 +1364,7 @@ func (s *TestSignupServiceSuite) TestGetSignupStatusFailGetToolchainStatus() {
 
 func (s *TestSignupServiceSuite) TestGetSignupMURGetFails() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	us := s.newUserSignupComplete()
 	err := s.FakeUserSignupClient.Tracker.Add(us)
@@ -1422,7 +1418,7 @@ func (s *TestSignupServiceSuite) TestGetSignupMURGetFails() {
 
 func (s *TestSignupServiceSuite) TestGetSignupUnknownStatus() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	us := s.newUserSignupComplete()
 	err := s.FakeUserSignupClient.Tracker.Add(us)
@@ -1432,7 +1428,7 @@ func (s *TestSignupServiceSuite) TestGetSignupUnknownStatus() {
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "ted",
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 		},
 		Spec: toolchainv1alpha1.MasterUserRecordSpec{
 			UserAccounts: []toolchainv1alpha1.UserAccountEmbedded{{TargetCluster: "member-123"}},
@@ -1489,21 +1485,20 @@ func (s *TestSignupServiceSuite) TestGetSignupUnknownStatus() {
 
 func (s *TestSignupServiceSuite) TestGetDefaultUserNamespace() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
-	compliantUsername := "dave"
-
-	spacebinding := s.newSpaceBindingForMUR(compliantUsername)
-	err := s.FakeSpaceBindingClient.Tracker.Add(spacebinding)
-	require.NoError(s.T(), err)
-
-	space := s.newSpaceForMUR(compliantUsername)
-	err = s.FakeSpaceClient.Tracker.Add(space)
-	require.NoError(s.T(), err)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	signup := signup.Signup{
-		Name:              "dave",
+		Name:              "dave#123",
 		CompliantUsername: "dave",
 	}
+
+	space := s.newSpaceForMUR(signup.CompliantUsername, signup.Name)
+	err := s.FakeSpaceClient.Tracker.Add(space)
+	require.NoError(s.T(), err)
+
+	spacebinding := s.newSpaceBinding(signup.CompliantUsername, space.Name)
+	err = s.FakeSpaceBindingClient.Tracker.Add(spacebinding)
+	require.NoError(s.T(), err)
 
 	// when
 	defaultUserNamespace := service.GetDefaultUserNamespace(s, signup)
@@ -1529,19 +1524,84 @@ func (s *TestSignupServiceSuite) TestGetDefaultUserNamespace() {
 	})
 }
 
-func (s *TestSignupServiceSuite) TestGetDefaultUserNamespaceFailNoSpaceBinding() {
+// TestGetDefaultUserNamespaceMultiSpace tests that when there are multiple spaces, only the Space created by the user should be considered
+func (s *TestSignupServiceSuite) TestGetDefaultUserNamespaceMultiSpace() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
-	compliantUsername := "dave"
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
-	space := s.newSpaceForMUR(compliantUsername)
-	err := s.FakeSpaceClient.Tracker.Add(space)
-	require.NoError(s.T(), err)
+	signupA := signup.Signup{
+		Name:              "trent#123",
+		CompliantUsername: "trent",
+	}
 
-	signup := signup.Signup{
-		Name:              "dave",
+	signupB := signup.Signup{
+		Name:              "dave#123",
 		CompliantUsername: "dave",
 	}
+
+	// space created by userA
+	space1 := s.newSpaceForMUR(signupA.CompliantUsername, signupA.Name)
+	err := s.FakeSpaceClient.Tracker.Add(space1)
+	require.NoError(s.T(), err)
+
+	// space shared with signupB
+	spacebinding1 := s.newSpaceBinding(signupB.CompliantUsername, space1.Name)
+	err = s.FakeSpaceBindingClient.Tracker.Add(spacebinding1)
+	require.NoError(s.T(), err)
+
+	// space created by userB
+	space2 := s.newSpaceForMUR(signupB.CompliantUsername, signupB.Name)
+	err = s.FakeSpaceClient.Tracker.Add(space2)
+	require.NoError(s.T(), err)
+
+	// space created by userB
+	spacebinding2 := s.newSpaceBinding(signupB.CompliantUsername, space2.Name)
+	err = s.FakeSpaceBindingClient.Tracker.Add(spacebinding2)
+	require.NoError(s.T(), err)
+
+	// when
+	defaultUserNamespace := service.GetDefaultUserNamespace(s, signupB)
+
+	// then
+	assert.Equal(s.T(), "dave-dev", defaultUserNamespace)
+
+	s.T().Run("informer", func(t *testing.T) {
+		// given
+		inf := fake.NewFakeInformer()
+		inf.GetSpaceFunc = func(name string) (*toolchainv1alpha1.Space, error) {
+			switch name {
+			case space1.Name:
+				return space1, nil
+			case space2.Name:
+				return space2, nil
+			default:
+				return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+			}
+		}
+		inf.ListSpaceBindingFunc = func(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
+			return []toolchainv1alpha1.SpaceBinding{*spacebinding1, *spacebinding2}, nil
+		}
+
+		// when
+		defaultUserNamespace := service.GetDefaultUserNamespace(inf, signupB)
+
+		// then
+		assert.Equal(s.T(), "dave-dev", defaultUserNamespace)
+	})
+}
+
+func (s *TestSignupServiceSuite) TestGetDefaultUserNamespaceFailNoSpaceBinding() {
+	// given
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
+
+	signup := signup.Signup{
+		Name:              "dave#123",
+		CompliantUsername: "dave",
+	}
+
+	space := s.newSpaceForMUR(signup.CompliantUsername, signup.Name)
+	err := s.FakeSpaceClient.Tracker.Add(space)
+	require.NoError(s.T(), err)
 
 	// when
 	defaultUserNamespace := service.GetDefaultUserNamespace(s, signup)
@@ -1569,17 +1629,16 @@ func (s *TestSignupServiceSuite) TestGetDefaultUserNamespaceFailNoSpaceBinding()
 
 func (s *TestSignupServiceSuite) TestGetDefaultUserNamespaceFailNoSpace() {
 	// given
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
-	compliantUsername := "dave"
-
-	spacebinding := s.newSpaceBindingForMUR(compliantUsername)
-	err := s.FakeSpaceBindingClient.Tracker.Add(spacebinding)
-	require.NoError(s.T(), err)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	signup := signup.Signup{
 		Name:              "dave",
 		CompliantUsername: "dave",
 	}
+
+	spacebinding := s.newSpaceBinding(signup.CompliantUsername, signup.Name)
+	err := s.FakeSpaceBindingClient.Tracker.Add(spacebinding)
+	require.NoError(s.T(), err)
 
 	// when
 	defaultUserNamespace := service.GetDefaultUserNamespace(s, signup)
@@ -1606,7 +1665,7 @@ func (s *TestSignupServiceSuite) TestGetDefaultUserNamespaceFailNoSpace() {
 }
 
 func (s *TestSignupServiceSuite) TestGetUserSignup() {
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	s.Run("getusersignup ok", func() {
 		us := s.newUserSignupComplete()
@@ -1638,7 +1697,7 @@ func (s *TestSignupServiceSuite) TestGetUserSignup() {
 }
 
 func (s *TestSignupServiceSuite) TestUpdateUserSignup() {
-	s.ServiceConfiguration(TestNamespace, true, "", 5)
+	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
 	us := s.newUserSignupComplete()
 	err := s.FakeUserSignupClient.Tracker.Add(us)
@@ -1671,7 +1730,7 @@ func (s *TestSignupServiceSuite) TestUpdateUserSignup() {
 }
 
 func (s *TestSignupServiceSuite) TestIsPhoneVerificationRequired() {
-	test2.SetEnvVarAndRestore(s.T(), commonconfig.WatchNamespaceEnvVar, TestNamespace)
+	test2.SetEnvVarAndRestore(s.T(), commonconfig.WatchNamespaceEnvVar, configuration.Namespace())
 
 	s.Run("phone verification is required", func() {
 		s.Run("captcha verification is disabled", func() {
@@ -1790,7 +1849,7 @@ func (s *TestSignupServiceSuite) newUserSignupCompleteWithReason(reason string) 
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      userID.String(),
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 			Annotations: map[string]string{
 				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "ted@domain.com",
 			},
@@ -1821,7 +1880,7 @@ func (s *TestSignupServiceSuite) newProvisionedMUR() *toolchainv1alpha1.MasterUs
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "ted",
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
 		},
 		Spec: toolchainv1alpha1.MasterUserRecordSpec{
 			UserAccounts: []toolchainv1alpha1.UserAccountEmbedded{{TargetCluster: "member-123"}},
@@ -1842,12 +1901,15 @@ func (s *TestSignupServiceSuite) newProvisionedMUR() *toolchainv1alpha1.MasterUs
 	}
 }
 
-func (s *TestSignupServiceSuite) newSpaceForMUR(murName string) *toolchainv1alpha1.Space {
+func (s *TestSignupServiceSuite) newSpaceForMUR(murName, creator string) *toolchainv1alpha1.Space {
 	return &toolchainv1alpha1.Space{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      murName,
-			Namespace: TestNamespace,
+			Namespace: configuration.Namespace(),
+			Labels: map[string]string{
+				toolchainv1alpha1.SpaceCreatorLabelKey: creator,
+			},
 		},
 		Spec: toolchainv1alpha1.SpaceSpec{
 			TargetCluster:      "member-123",
@@ -1866,20 +1928,23 @@ func (s *TestSignupServiceSuite) newSpaceForMUR(murName string) *toolchainv1alph
 	}
 }
 
-func (s *TestSignupServiceSuite) newSpaceBindingForMUR(murName string) *toolchainv1alpha1.SpaceBinding {
+func (s *TestSignupServiceSuite) newSpaceBinding(murName, spaceName string) *toolchainv1alpha1.SpaceBinding {
+	name, err := uuid.NewV4()
+	require.NoError(s.T(), err)
+
 	return &toolchainv1alpha1.SpaceBinding{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      murName,
-			Namespace: TestNamespace,
+			Name:      name.String(),
+			Namespace: configuration.Namespace(),
 			Labels: map[string]string{
-				toolchainv1alpha1.SpaceBindingSpaceLabelKey:            murName,
+				toolchainv1alpha1.SpaceBindingSpaceLabelKey:            spaceName,
 				toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: murName,
 			},
 		},
 		Spec: toolchainv1alpha1.SpaceBindingSpec{
 			MasterUserRecord: murName,
-			Space:            murName,
+			Space:            spaceName,
 			SpaceRole:        "admin",
 		},
 	}

--- a/test/fake/informer.go
+++ b/test/fake/informer.go
@@ -17,7 +17,7 @@ type Informer struct {
 	GetSpaceFunc             func(name string) (*toolchainv1alpha1.Space, error)
 	GetToolchainStatusFunc   func() (*toolchainv1alpha1.ToolchainStatus, error)
 	GetUserSignupFunc        func(name string) (*toolchainv1alpha1.UserSignup, error)
-	ListSpaceBindingFunc     func(req ...labels.Requirement) ([]*toolchainv1alpha1.SpaceBinding, error)
+	ListSpaceBindingFunc     func(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error)
 	GetProxyPluginConfigFunc func(name string) (*toolchainv1alpha1.ProxyPlugin, error)
 }
 
@@ -56,7 +56,7 @@ func (f Informer) GetUserSignup(name string) (*toolchainv1alpha1.UserSignup, err
 	panic("not supposed to call GetUserSignup")
 }
 
-func (f Informer) ListSpaceBindings(req ...labels.Requirement) ([]*toolchainv1alpha1.SpaceBinding, error) {
+func (f Informer) ListSpaceBindings(req ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
 	if f.ListSpaceBindingFunc != nil {
 		return f.ListSpaceBindingFunc(req...)
 	}

--- a/test/fake/space_client.go
+++ b/test/fake/space_client.go
@@ -1,0 +1,71 @@
+package fake
+
+import (
+	"encoding/json"
+	"testing"
+
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/registration-service/pkg/kubeclient"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+type FakeSpaceClient struct { // nolint:revive
+	Tracker   kubetesting.ObjectTracker
+	Scheme    *runtime.Scheme
+	namespace string
+	MockGet   func(name string) (*crtapi.Space, error)
+}
+
+var _ kubeclient.SpaceInterface = &FakeSpaceClient{}
+
+func NewFakeSpaceClient(t *testing.T, namespace string, initObjs ...runtime.Object) *FakeSpaceClient {
+	clientScheme := runtime.NewScheme()
+	err := crtapi.SchemeBuilder.AddToScheme(clientScheme)
+	require.NoError(t, err, "Error adding to scheme")
+	crtapi.SchemeBuilder.Register(&crtapi.Space{}, &crtapi.SpaceList{})
+
+	tracker := kubetesting.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
+	for _, obj := range initObjs {
+		err := tracker.Add(obj)
+		require.NoError(t, err, "failed to add object %v to fake spacebinding client", obj)
+	}
+	return &FakeSpaceClient{
+		Tracker:   tracker,
+		Scheme:    clientScheme,
+		namespace: namespace,
+	}
+}
+
+func (c *FakeSpaceClient) Get(name string) (*crtapi.Space, error) {
+
+	if c.MockGet != nil {
+		return c.MockGet(name)
+	}
+
+	obj := &crtapi.Space{}
+	gvr, err := getGVRFromObject(obj, c.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := c.Tracker.Get(gvr, c.namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/test/fake/spacebinding_client.go
+++ b/test/fake/spacebinding_client.go
@@ -1,0 +1,68 @@
+package fake
+
+import (
+	"testing"
+
+	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/registration-service/pkg/kubeclient"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+type FakeSpaceBindingClient struct { // nolint:revive
+	Tracker   kubetesting.ObjectTracker
+	Scheme    *runtime.Scheme
+	namespace string
+	MockList  func(reqs ...labels.Requirement) ([]crtapi.SpaceBinding, error)
+}
+
+var _ kubeclient.SpaceBindingInterface = &FakeSpaceBindingClient{}
+
+func NewFakeSpaceBindingClient(t *testing.T, namespace string, initObjs ...runtime.Object) *FakeSpaceBindingClient {
+	clientScheme := runtime.NewScheme()
+	err := crtapi.SchemeBuilder.AddToScheme(clientScheme)
+	require.NoError(t, err, "Error adding to scheme")
+	crtapi.SchemeBuilder.Register(&crtapi.SpaceBinding{}, &crtapi.SpaceBindingList{})
+
+	tracker := kubetesting.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
+	for _, obj := range initObjs {
+		err := tracker.Add(obj)
+		require.NoError(t, err, "failed to add object %v to fake spacebinding client", obj)
+	}
+	return &FakeSpaceBindingClient{
+		Tracker:   tracker,
+		Scheme:    clientScheme,
+		namespace: namespace,
+	}
+}
+
+func (c *FakeSpaceBindingClient) ListSpaceBindings(reqs ...labels.Requirement) ([]crtapi.SpaceBinding, error) {
+
+	if c.MockList != nil {
+		return c.MockList(reqs...)
+	}
+
+	obj := &crtapi.SpaceBinding{}
+	gvr, err := getGVRFromObject(obj, c.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := c.Tracker.List(gvr, gvk, c.namespace)
+	if err != nil {
+		return nil, err
+	}
+	list := o.(*crtapi.SpaceBindingList)
+
+	return list.Items, nil
+}

--- a/test/testsuite.go
+++ b/test/testsuite.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -33,6 +34,8 @@ type UnitTestSuite struct {
 	FakeBannedUserClient       *fake.FakeBannedUserClient
 	FakeToolchainStatusClient  *fake.FakeToolchainStatusClient
 	FakeSocialEventClient      *fake.FakeSocialEventClient
+	FakeSpaceClient            *fake.FakeSpaceClient
+	FakeSpaceBindingClient     *fake.FakeSpaceBindingClient
 	factoryOptions             []factory.Option
 }
 
@@ -56,6 +59,8 @@ func (s *UnitTestSuite) SetupDefaultApplication() {
 	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(s.T(), configuration.Namespace())
 	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(s.T(), configuration.Namespace())
 	s.FakeSocialEventClient = fake.NewFakeSocialEventClient(s.T(), configuration.Namespace())
+	s.FakeSpaceClient = fake.NewFakeSpaceClient(s.T(), configuration.Namespace())
+	s.FakeSpaceBindingClient = fake.NewFakeSpaceBindingClient(s.T(), configuration.Namespace())
 	s.Application = fake.NewMockableApplication(s, s.factoryOptions...)
 }
 
@@ -65,6 +70,7 @@ func (s *UnitTestSuite) OverrideApplicationDefault(opts ...testconfig.ToolchainC
 	s.FakeMasterUserRecordClient = fake.NewFakeMasterUserRecordClient(s.T(), configuration.Namespace())
 	s.FakeBannedUserClient = fake.NewFakeBannedUserClient(s.T(), configuration.Namespace())
 	s.FakeToolchainStatusClient = fake.NewFakeToolchainStatusClient(s.T(), configuration.Namespace())
+	s.FakeSpaceBindingClient = fake.NewFakeSpaceBindingClient(s.T(), configuration.Namespace())
 	s.Application = fake.NewMockableApplication(s, s.factoryOptions...)
 }
 
@@ -137,6 +143,8 @@ func (s *UnitTestSuite) TearDownSuite() {
 	s.FakeMasterUserRecordClient = nil
 	s.FakeBannedUserClient = nil
 	s.FakeToolchainStatusClient = nil
+	s.FakeSpaceClient = nil
+	s.FakeSpaceBindingClient = nil
 }
 
 func (s *UnitTestSuite) V1Alpha1() kubeclient.V1Alpha1 {
@@ -161,4 +169,32 @@ func (s *UnitTestSuite) ToolchainStatuses() kubeclient.ToolchainStatusInterface 
 
 func (s *UnitTestSuite) SocialEvents() kubeclient.SocialEventInterface {
 	return s.FakeSocialEventClient
+}
+
+func (s *UnitTestSuite) Spaces() kubeclient.SpaceInterface {
+	return s.FakeSpaceClient
+}
+
+func (s *UnitTestSuite) SpaceBindings() kubeclient.SpaceBindingInterface {
+	return s.FakeSpaceBindingClient
+}
+
+func (s *UnitTestSuite) GetMasterUserRecord(name string) (*toolchainv1alpha1.MasterUserRecord, error) {
+	return s.MasterUserRecords().Get(name)
+}
+
+func (s *UnitTestSuite) GetToolchainStatus() (*toolchainv1alpha1.ToolchainStatus, error) {
+	return s.ToolchainStatuses().Get()
+}
+
+func (s *UnitTestSuite) GetUserSignup(name string) (*toolchainv1alpha1.UserSignup, error) {
+	return s.UserSignups().Get(name)
+}
+
+func (s *UnitTestSuite) GetSpace(name string) (*toolchainv1alpha1.Space, error) {
+	return s.Spaces().Get(name)
+}
+
+func (s *UnitTestSuite) ListSpaceBindings(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
+	return s.SpaceBindings().ListSpaceBindings(reqs...)
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SANDBOX-288

This is a follow-up to https://github.com/codeready-toolchain/registration-service/pull/334 that hardcoded the default namespace. It's now updated to get the default namespace directly from the user's Space.

e2e tests unchanged from https://github.com/codeready-toolchain/toolchain-e2e/pull/757