### PR TITLE
Moved PollUpdateSignup function to common package

### DIFF
--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -608,7 +608,7 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 		require.Equal(s.T(), "there was an error while updating your account - please wait a moment before "+
 			"trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for "+
 			"assistance: error while verifying phone code", bodyParams["message"])
-		require.Equal(s.T(), "error while verifying phone code", bodyParams["details"])
+		require.Equal(s.T(), "unexpected error while verifying phone code", bodyParams["details"])
 	})
 
 	s.Run("verifycode returns status error", func() {

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -594,7 +594,8 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 			Key:   "code",
 			Value: "555555",
 		}
-		rr := initPhoneVerification(s.T(), handler, param, nil, userID, "", http.MethodGet, "/api/v1/signup/verification/555555")
+		rr := initPhoneVerification(s.T(), handler, param, nil, userID, "", http.MethodGet,
+			"/api/v1/signup/verification/555555")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusInternalServerError, rr.Code)

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -187,7 +187,10 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID, username, e164P
 
 	updateErr := signuppkg.PollUpdateSignup(ctx, doUpdate)
 	if updateErr != nil {
-		return updateErr
+		log.Error(ctx, updateErr, "error updating UserSignup")
+		return errors.New("there was an error while updating your account - please wait a moment before " +
+			"trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for " +
+			"assistance: error while verifying phone code")
 	}
 
 	return initError
@@ -314,7 +317,10 @@ func (s *ServiceImpl) VerifyPhoneCode(ctx *gin.Context, userID, username, code s
 
 	updateErr := signuppkg.PollUpdateSignup(ctx, doUpdate)
 	if updateErr != nil {
-		return updateErr
+		log.Error(ctx, updateErr, "error updating UserSignup")
+		return errors.New("there was an error while updating your account - please wait a moment before " +
+			"trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com for " +
+			"assistance: error while verifying phone code")
 	}
 
 	return

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	signup2 "github.com/codeready-toolchain/registration-service/pkg/signup"
+	signuppkg "github.com/codeready-toolchain/registration-service/pkg/signup"
 	"net/http"
 	"strconv"
 	"time"
@@ -185,7 +185,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, userID, username, e164P
 		return nil
 	}
 
-	updateErr := signup2.PollUpdateSignup(ctx, doUpdate)
+	updateErr := signuppkg.PollUpdateSignup(ctx, doUpdate)
 	if updateErr != nil {
 		return updateErr
 	}
@@ -312,7 +312,7 @@ func (s *ServiceImpl) VerifyPhoneCode(ctx *gin.Context, userID, username, code s
 		return nil
 	}
 
-	updateErr := signup2.PollUpdateSignup(ctx, doUpdate)
+	updateErr := signuppkg.PollUpdateSignup(ctx, doUpdate)
 	if updateErr != nil {
 		return updateErr
 	}
@@ -367,7 +367,7 @@ func (s *ServiceImpl) VerifyActivationCode(ctx *gin.Context, userID, username, c
 
 			return nil
 		}
-		if err := signup2.PollUpdateSignup(ctx, doUpdate); err != nil {
+		if err := signuppkg.PollUpdateSignup(ctx, doUpdate); err != nil {
 			log.Errorf(ctx, err, "unable to update user signup after validating activation code")
 		}
 	}()

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -317,7 +317,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 
 		// Cause the client UPDATE call to fail always
 		s.FakeUserSignupClient.MockUpdate = func(userSignup *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
-			return nil, errors.New("update failed")
+			return nil, errors.New("there was an error while updating your account - please wait a moment before trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com \"+\n\t\t\t\"for assistance: error while verifying phone code")
 		}
 		defer func() { s.FakeUserSignupClient.MockUpdate = nil }()
 


### PR DESCRIPTION
This PR simply consolidates the two duplicate `pollUpdateSignup` functions from the signup and verification services into a single place where it is reused by both.