### PR TITLE
bugfix: proxy rejects calls when UserSignup is not in a ready state

### DIFF
--- a/pkg/proxy/service/cluster_service.go
+++ b/pkg/proxy/service/cluster_service.go
@@ -45,7 +45,8 @@ func (s *ServiceImpl) GetClusterAccess(userID, username, workspace, proxyPluginN
 	if err != nil {
 		return nil, err
 	}
-	if signup == nil || !signup.Status.Ready {
+	// if signup has the CompliantUsername set it means that MUR was created and useraccount is provisioned
+	if signup == nil || signup.CompliantUsername == "" {
 		cause := errs.New("user is not provisioned (yet)")
 		log.Error(nil, cause, fmt.Sprintf("signup object: %+v", signup))
 		return nil, cause

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -45,7 +45,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 			Ready: true,
 		},
 	}), fake.Signup("456-not-ready", &signup.Signup{
-		CompliantUsername: "john",
+		CompliantUsername: "",
 		Username:          "john@",
 		Status: signup.Status{
 			Ready: false,

--- a/pkg/signup/signup.go
+++ b/pkg/signup/signup.go
@@ -2,6 +2,7 @@ package signup
 
 import (
 	"fmt"
+
 	"github.com/codeready-toolchain/registration-service/pkg/log"
 	"github.com/gin-gonic/gin"
 )
@@ -25,7 +26,7 @@ type Signup struct {
 	ClusterName string `json:"clusterName,omitempty"`
 	// The user's default namespace
 	DefaultUserNamespace string `json:"defaultUserNamespace,omitempty"`
-	// The complaint username.  This may differ from the corresponding Identity Provider username, because of the the
+	// The complaint username.  This may differ from the corresponding Identity Provider username, because of the
 	// limited character set available for naming (see RFC1123) in K8s. If the username contains characters which are
 	// disqualified from the resource name, the username is transformed into an acceptable resource name instead.
 	// For example, johnsmith@redhat.com -> johnsmith


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/SANDBOX-375

NOTE: we could also check if there is a default namespace provisioned for the usersignup when the Complete status is not ready. I started on this path but figured out that it would require a bigger modification of the unit tests. 