### PR TITLE
allow for approved status false after user sign up deactivated

### DIFF
--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -438,7 +438,8 @@ func (s *ServiceImpl) DoGetSignup(ctx *gin.Context, provider ResourceProvider, u
 	// Check UserSignup status to determine whether user signup is complete
 	approvedCondition, approvedFound := condition.FindConditionByType(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupApproved)
 	completeCondition, completeFound := condition.FindConditionByType(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupComplete)
-	if !approvedFound || !completeFound || approvedCondition.Status != apiv1.ConditionTrue {
+	if !approvedFound || !completeFound ||
+		( approvedCondition.Status != apiv1.ConditionTrue && approvedCondition.Reason != toolchainv1alpha1.UserSignupUserDeactivatedReason) {
 		log.Info(nil, fmt.Sprintf("usersignup: %s is pending approval", userSignup.GetName()))
 		signupResponse.Status = signup.Status{
 			Reason:               toolchainv1alpha1.UserSignupPendingApprovalReason,

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -436,11 +436,13 @@ func (s *ServiceImpl) DoGetSignup(ctx *gin.Context, provider ResourceProvider, u
 	}
 
 	// Check UserSignup status to determine whether user signup is complete
-	approvedCondition, approvedFound := condition.FindConditionByType(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupApproved)
+	_, approvedFound := condition.FindConditionByType(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupApproved)
 	completeCondition, completeFound := condition.FindConditionByType(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupComplete)
 	if !approvedFound || !completeFound ||
-		(approvedCondition.Status != apiv1.ConditionTrue && approvedCondition.Reason != toolchainv1alpha1.UserSignupUserDeactivatedReason) {
+		condition.IsFalseWithReason(userSignup.Status.Conditions,
+			toolchainv1alpha1.UserSignupApproved, toolchainv1alpha1.UserSignupPendingApprovalReason) {
 		log.Info(nil, fmt.Sprintf("usersignup: %s is pending approval", userSignup.GetName()))
+
 		signupResponse.Status = signup.Status{
 			Reason:               toolchainv1alpha1.UserSignupPendingApprovalReason,
 			VerificationRequired: states.VerificationRequired(userSignup),

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -439,7 +439,7 @@ func (s *ServiceImpl) DoGetSignup(ctx *gin.Context, provider ResourceProvider, u
 	approvedCondition, approvedFound := condition.FindConditionByType(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupApproved)
 	completeCondition, completeFound := condition.FindConditionByType(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupComplete)
 	if !approvedFound || !completeFound ||
-		( approvedCondition.Status != apiv1.ConditionTrue && approvedCondition.Reason != toolchainv1alpha1.UserSignupUserDeactivatedReason) {
+		(approvedCondition.Status != apiv1.ConditionTrue && approvedCondition.Reason != toolchainv1alpha1.UserSignupUserDeactivatedReason) {
 		log.Info(nil, fmt.Sprintf("usersignup: %s is pending approval", userSignup.GetName()))
 		signupResponse.Status = signup.Status{
 			Reason:               toolchainv1alpha1.UserSignupPendingApprovalReason,

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -1093,7 +1093,8 @@ func (s *TestSignupServiceSuite) TestGetSignupDeactivated() {
 	// given
 	s.ServiceConfiguration(configuration.Namespace(), true, "", 5)
 
-	us := s.newUserSignupCompleteWithReason("Deactivated")
+	us := s.newUserSignupComplete()
+	us.Status.Conditions = deactivated()
 	err := s.FakeUserSignupClient.Tracker.Add(us)
 	require.NoError(s.T(), err)
 
@@ -2222,7 +2223,12 @@ func deactivated() []toolchainv1alpha1.Condition {
 		{
 			Type:   toolchainv1alpha1.UserSignupComplete,
 			Status: apiv1.ConditionTrue,
-			Reason: "Deactivated",
+			Reason: toolchainv1alpha1.UserSignupUserDeactivatedReason,
+		},
+		{
+			Type:   toolchainv1alpha1.UserSignupApproved,
+			Status: apiv1.ConditionFalse,
+			Reason: toolchainv1alpha1.UserSignupUserDeactivatedReason,
 		},
 	}
 }


### PR DESCRIPTION
Fix required for:  https://github.com/codeready-toolchain/host-operator/pull/868

it should not cause a regression because this condition:
```approvedCondition.Reason != toolchainv1alpha1.UserSignupUserDeactivatedReason```
can only be true without https://github.com/codeready-toolchain/host-operator/pull/868

This is the issue it fixes as a result of https://github.com/codeready-toolchain/host-operator/pull/868

```
=== NAME  TestSignupOK/test_activation-deactivation_workflow
    host.go:711: waiting for UserSignup 'testuser-e808fd7d-bf83-4cdc-abe8-1b72c80c1a9e' in namespace 'toolchain-host-05094958' to match criteria
    host.go:1982: waiting until Space 'testuser-e808fd7d-bf' in namespace 'toolchain-host-05094958' is deleted
    host.go:2028: waiting until SpaceBindings with labels 'map[toolchain.dev.openshift.com/space:testuser-e808fd7d-bf]' in namespace 'toolchain-host-05094958' are deleted
    regsvc.go:16: invoking http request: GET https://registration-service-toolchain-host-05094958.apps.martin-4.12-092615.qe.openshiftappsvc.org/api/v1/signup
    regsvc.go:26: response status code: 200
    regsvc.go:33: 
           Error Trace:   /Users/martinmulholland/codeready-toolchain/toolchain-e2e/testsupport/regsvc.go:33
                                   /Users/martinmulholland/codeready-toolchain/toolchain-e2e/test/e2e/parallel/registration_service_test.go:805
                                   /Users/martinmulholland/codeready-toolchain/toolchain-e2e/test/e2e/parallel/registration_service_test.go:381
           Error:         Not equal: 
                          expected: 404
                          actual  : 200
           Test:          TestSignupOK/test_activation-deactivation_workflow
           Messages:      unexpected response status with body: {"name":"testuser-e808fd7d-bf83-4cdc-abe8-1b72c80c1a9e","compliantUsername":"testuser-e808fd7d-bf","username":"testuser-e808fd7d-bf83-4cdc-abe8-1b72c80c1a9e","givenName":"","familyName":"","company":"","status":{"ready":false,"reason":"PendingApproval","verificationRequired":false}}
```