### PR TITLE
ci: bump actions to silence node12 warnings

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
         go-version: 1.19.x
     
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: Test
       run: |
@@ -45,7 +45,7 @@ jobs:
         go-version: 1.19.x
         
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: Lint
       uses: golangci/golangci-lint-action@v3
@@ -60,10 +60,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: Generate SBOM
-      uses: CycloneDX/gh-gomod-generate-sbom@v1
+      uses: CycloneDX/gh-gomod-generate-sbom@v2
       with:
         version: v1
         args: mod -licenses -json -output -

--- a/.github/workflows/ci-check-gomod.yml
+++ b/.github/workflows/ci-check-gomod.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: check
       run: |

--- a/.github/workflows/operator-cd.yml
+++ b/.github/workflows/operator-cd.yml
@@ -17,24 +17,24 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles ('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 

--- a/.github/workflows/publish-operators-for-e2e-tests.yml
+++ b/.github/workflows/publish-operators-for-e2e-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     # Checkout from PR event - in that case the comment field is empty
     - name: Checkout code from PR event
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       if: ${{ github.event.comment == '' }}
       with:
         ref: ${{github.event.pull_request.head.ref}}
@@ -39,7 +39,7 @@ jobs:
     # Checkout the code based on the data retrieved from the previous step
     # Is executed only for comment events - in that case the pull_request field is empty
     - name: Checkout code from PR
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       if: ${{ github.event.pull_request == '' }}
       with:
         repository: ${{ fromJson(steps.request.outputs.data).head.repo.full_name }}
@@ -47,19 +47,19 @@ jobs:
         fetch-depth: 0
 
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles ('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 


### PR DESCRIPTION
As of [June 2023][1], GitHub no longer uses node v12 within its actions runner by default.  They have been encouraging action authors to switch to node v16 and [encouraging users][2] to use the new versions of the actions when they become available, with the intent on removing node v12 sometime in the near future.

Bump the versions of the affected actions to bring this in line.

[1]: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
[2]: https://github.com/codeready-toolchain/host-operator/actions/runs/6421632076