### PR TITLE
rename metrics service label

### DIFF
--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -226,7 +226,7 @@ objects:
         run: proxy-metrics
     spec:
       ports:
-        - name: "8082"
+        - name: proxy-metrics
           protocol: TCP
           port: 80
           targetPort: metrics

--- a/deploy/registration-service.yaml
+++ b/deploy/registration-service.yaml
@@ -99,6 +99,7 @@ objects:
                 - containerPort: 8080
                 - containerPort: 8081
                 - containerPort: 8082
+                  name: metrics
               command:
                 - registration-service
               imagePullPolicy: IfNotPresent
@@ -222,13 +223,13 @@ objects:
       namespace: ${NAMESPACE}
       labels:
         provider: codeready-toolchain
-        run: registration-service
+        run: proxy-metrics
     spec:
       ports:
         - name: "8082"
           protocol: TCP
           port: 80
-          targetPort: 8082
+          targetPort: metrics
       selector:
         run: registration-service
       type: ClusterIP


### PR DESCRIPTION
having same labels for the 2 services may confuse Prometheus, thus renaming the label for metrics Service.
Also naming the port 8082 for metrics.
related PR: https://github.com/codeready-toolchain/host-operator/pull/890