### PR TITLE
Removing the unused Parameters

### DIFF
--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -474,9 +474,6 @@ func (s *ServiceImpl) DoGetSignup(ctx *gin.Context, provider ResourceProvider, u
 		signupResponse.ProxyURL = status.Status.HostRoutes.ProxyURL
 		for _, member := range status.Status.Members {
 			if member.ClusterName == mur.Status.UserAccounts[0].Cluster.Name {
-				signupResponse.ConsoleURL = member.MemberStatus.Routes.ConsoleURL
-				signupResponse.CheDashboardURL = member.MemberStatus.Routes.CheDashboardURL
-				signupResponse.APIEndpoint = member.APIEndpoint
 				signupResponse.ClusterName = member.ClusterName
 				break
 			}


### PR DESCRIPTION
This is to drop unused parameters from the embedded MUR.Status.UserAccounts.Clusters type.

Related PRs
API - https://github.com/codeready-toolchain/api/pull/387
Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/925