### PR TITLE
feat: Introduce SpaceBindingLister function in handleRequestAndRedirect

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -59,12 +59,10 @@ ifeq ($(E2E_REPO_PATH),"")
 		if [[ -n "${REMOTE_E2E_BRANCH}" ]]; then \
 			git config --global user.email "devtools@redhat.com"; \
 			git config --global user.name "Devtools"; \
-			# retrieve the branch name \
-			BRANCH_NAME=`echo ${BRANCH_REF} | awk -F'/' '{print $$3}'`; \
 			# add the user's fork as remote repo \
 			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} remote add external ${AUTHOR_LINK}/toolchain-e2e.git; \
-			# fetch the branch \
-			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} fetch external ${BRANCH_REF}; \
+		 	# fetch the branch \
+			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} fetch external ${REMOTE_E2E_BRANCH}; \
 			# merge the branch with master \
 			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} merge --allow-unrelated-histories --no-commit FETCH_HEAD; \
 		fi;

--- a/pkg/proxy/handlers/spacelister.go
+++ b/pkg/proxy/handlers/spacelister.go
@@ -2,30 +2,19 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"sort"
-
-	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/application"
 	"github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/context"
-	"github.com/codeready-toolchain/registration-service/pkg/log"
 	"github.com/codeready-toolchain/registration-service/pkg/metrics"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	commonproxy "github.com/codeready-toolchain/toolchain-common/pkg/proxy"
-	"github.com/codeready-toolchain/toolchain-common/pkg/spacebinding"
 	"github.com/gin-gonic/gin"
 
 	"github.com/labstack/echo/v4"
 	errs "github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/selection"
 )
 
 const (
@@ -51,191 +40,20 @@ func NewSpaceLister(app application.Application, proxyMetrics *metrics.ProxyMetr
 	}
 }
 
-func (s *SpaceLister) HandleSpaceListRequest(ctx echo.Context) error {
-	// list all user workspaces
-	requestReceivedTime := ctx.Get(context.RequestReceivedTime).(time.Time)
-	workspaces, err := s.ListUserWorkspaces(ctx, "")
-	if err != nil {
-		s.ProxyMetrics.RegServWorkspaceHistogramVec.WithLabelValues(fmt.Sprintf("%d", http.StatusInternalServerError), metrics.MetricsLabelVerbList).Observe(time.Since(requestReceivedTime).Seconds()) // using list as the default value for verb to minimize label combinations for prometheus to process
-		return errorResponse(ctx, apierrors.NewInternalError(err))
-	}
-	s.ProxyMetrics.RegServWorkspaceHistogramVec.WithLabelValues(fmt.Sprintf("%d", http.StatusOK), metrics.MetricsLabelVerbList).Observe(time.Since(requestReceivedTime).Seconds())
-	return listWorkspaceResponse(ctx, workspaces)
-}
-
-func (s *SpaceLister) HandleSpaceGetRequest(ctx echo.Context) error {
-	// get specific workspace
-	requestReceivedTime := ctx.Get(context.RequestReceivedTime).(time.Time)
-	workspace, err := s.GetUserWorkspace(ctx)
-	if err != nil {
-		s.ProxyMetrics.RegServWorkspaceHistogramVec.WithLabelValues(fmt.Sprintf("%d", http.StatusInternalServerError), metrics.MetricsLabelVerbGet).Observe(time.Since(requestReceivedTime).Seconds()) // using list as the default value for verb to minimize label combinations for prometheus to process
-		return errorResponse(ctx, apierrors.NewInternalError(err))
-	}
-	if workspace == nil {
-		// not found
-		s.ProxyMetrics.RegServWorkspaceHistogramVec.WithLabelValues(fmt.Sprintf("%d", http.StatusNotFound), metrics.MetricsLabelVerbGet).Observe(time.Since(requestReceivedTime).Seconds())
-		r := schema.GroupResource{Group: "toolchain.dev.openshift.com", Resource: "workspaces"}
-		return errorResponse(ctx, apierrors.NewNotFound(r, ctx.Param("workspace")))
-	}
-	s.ProxyMetrics.RegServWorkspaceHistogramVec.WithLabelValues(fmt.Sprintf("%d", http.StatusOK), metrics.MetricsLabelVerbGet).Observe(time.Since(requestReceivedTime).Seconds())
-	return getWorkspaceResponse(ctx, workspace)
-}
-
-func (s *SpaceLister) GetUserWorkspace(ctx echo.Context) (*toolchainv1alpha1.Workspace, error) {
+func (s *SpaceLister) GetProvisionedUserSignup(ctx echo.Context) (*signup.Signup, error) {
 	userID, _ := ctx.Get(context.SubKey).(string)
 	username, _ := ctx.Get(context.UsernameKey).(string)
-	workspaceName := ctx.Param("workspace")
 
 	userSignup, err := s.GetSignupFunc(nil, userID, username, false)
-	if err != nil {
-		cause := errs.Wrap(err, "error retrieving userSignup")
-		ctx.Logger().Error(cause)
-		return nil, cause
-	}
-	if userSignup == nil || userSignup.CompliantUsername == "" {
-		// account exists but the compliant username is not set yet, meaning it has not been fully provisioned yet
-		// return not found response when specific workspace request was issued
-		return nil, nil
-
-	}
-	space, err := s.GetInformerServiceFunc().GetSpace(workspaceName)
-	if err != nil {
-		ctx.Logger().Error(errs.Wrap(err, "unable to get space"))
-		return nil, nil
-	}
-
-	// recursively get all the spacebindings for the current workspace
-	listSpaceBindingsFunc := func(spaceName string) ([]toolchainv1alpha1.SpaceBinding, error) {
-		spaceSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingSpaceLabelKey, selection.Equals, []string{spaceName})
-		if err != nil {
-			return nil, err
-		}
-		return s.GetInformerServiceFunc().ListSpaceBindings(*spaceSelector)
-	}
-	spaceBindingLister := spacebinding.NewLister(listSpaceBindingsFunc, s.GetInformerServiceFunc().GetSpace)
-	allSpaceBindings, err := spaceBindingLister.ListForSpace(space, []toolchainv1alpha1.SpaceBinding{})
-	if err != nil {
-		ctx.Logger().Error(err, "failed to list space bindings")
-		return nil, err
-	}
-
-	// check if user has access to this workspace
-	userBinding := filterUserSpaceBinding(userSignup.CompliantUsername, allSpaceBindings)
-	if userBinding == nil {
-		//  let's only log the issue and consider this as not found
-		ctx.Logger().Error(fmt.Sprintf("unauthorized access - there is no SpaceBinding present for the user %s and the workspace %s", userSignup.CompliantUsername, workspaceName))
-		return nil, nil
-	}
-	// build the Bindings list with the available actions
-	// this field is populated only for the GET workspace request
-	bindings, err := generateWorkspaceBindings(space, allSpaceBindings)
-	if err != nil {
-		ctx.Logger().Error(errs.Wrap(err, "unable to generate bindings field"))
-		return nil, err
-	}
-
-	// add available roles, this field is populated only for the GET workspace request
-	nsTemplateTier, err := s.GetInformerServiceFunc().GetNSTemplateTier(space.Spec.TierName)
-	if err != nil {
-		ctx.Logger().Error(errs.Wrap(err, "unable to get nstemplatetier"))
-		return nil, err
-	}
-
-	return createWorkspaceObject(userSignup.Name, space, userBinding,
-		commonproxy.WithAvailableRoles(getRolesFromNSTemplateTier(nsTemplateTier)),
-		commonproxy.WithBindings(bindings),
-	), nil
-}
-
-// ListUserWorkspaces returns a list of Workspaces for the current user.
-// If a workspaceName is provided, it means the request was made for a specific workspace, the function will check if the user has access to that workspace, if not it will return 404 Unauthorized.
-// If no workspaceName is provided (workspaceName is an empty sting), the function will list all SpaceBindings for the user and return all the workspaces found from this list.
-func (s *SpaceLister) ListUserWorkspaces(ctx echo.Context, workspaceName string) ([]toolchainv1alpha1.Workspace, error) {
-	userID, _ := ctx.Get(context.SubKey).(string)
-	username, _ := ctx.Get(context.UsernameKey).(string)
-
-	signup, err := s.GetSignupFunc(nil, userID, username, false)
 	if err != nil {
 		ctx.Logger().Error(errs.Wrap(err, "error retrieving signup"))
 		return nil, err
 	}
-	if signup == nil || signup.CompliantUsername == "" {
+	if userSignup == nil || userSignup.CompliantUsername == "" {
 		// account exists but the compliant username is not set yet, meaning it has not been fully provisioned yet, so return an empty list
-		return []toolchainv1alpha1.Workspace{}, nil
-	}
-	murName := signup.CompliantUsername
-
-	if workspaceName != "" {
-		// if a workspace was provided
-		// recursively get all the spacebindings, starting from this workspace and going up to the parent workspaces till the "root" of the workspace tree.
-		return s.hierarchicalWorkspaceSearch(ctx, workspaceName, signup)
-	}
-
-	// get all spacebindings with given mur since no workspace was provided
-	spaceBindings, err := s.listSpaceBindingsForUser(murName)
-	if err != nil {
-		ctx.Logger().Error(errs.Wrap(err, "error listing space bindings"))
-		return nil, err
-	}
-	return s.workspacesFromSpaceBindings(signup.Name, spaceBindings), nil
-}
-
-// hierarchicalWorkspaceSearch lists all spacebindings starting from a space and going to it's parentSpaces
-// if any of those spaces contains a SpaceBinding for the given user, then a workspace object will be returned with the found role.
-func (s *SpaceLister) hierarchicalWorkspaceSearch(ctx echo.Context, workspaceName string, signup *signup.Signup) ([]toolchainv1alpha1.Workspace, error) {
-	listSpaceBindingsFunc := func(spaceName string) ([]toolchainv1alpha1.SpaceBinding, error) {
-		spaceSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingSpaceLabelKey, selection.Equals, []string{spaceName})
-		if err != nil {
-			return nil, err
-		}
-		return s.GetInformerServiceFunc().ListSpaceBindings(*spaceSelector)
-	}
-	spaceBindingLister := spacebinding.NewLister(listSpaceBindingsFunc, s.GetInformerServiceFunc().GetSpace)
-	space, err := s.GetInformerServiceFunc().GetSpace(workspaceName)
-	if err != nil {
-		ctx.Logger().Error(err, "failed to get space")
-		return nil, err
-	}
-	allSpaceBindings, err := spaceBindingLister.ListForSpace(space, []toolchainv1alpha1.SpaceBinding{})
-	if err != nil {
-		ctx.Logger().Error(err, "failed to list space bindings")
-		return nil, err
-	}
-	// check if user has access to this workspace
-	murName := signup.CompliantUsername
-	userBinding := filterUserSpaceBinding(murName, allSpaceBindings)
-	if userBinding == nil {
-		//  let's only log the issue and consider this as not found
-		ctx.Logger().Error(fmt.Sprintf("unauthorized access - there is no SpaceBinding present for the user %s and the workspace %s", murName, workspaceName))
 		return nil, nil
 	}
-	return []toolchainv1alpha1.Workspace{*createWorkspaceObject(signup.Name, space, userBinding)}, nil
-}
-
-func (s *SpaceLister) listSpaceBindingsForUser(murName string) ([]toolchainv1alpha1.SpaceBinding, error) {
-	murSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey, selection.Equals, []string{murName})
-	if err != nil {
-		return nil, err
-	}
-	requirements := []labels.Requirement{*murSelector}
-	return s.GetInformerServiceFunc().ListSpaceBindings(requirements...)
-}
-
-func (s *SpaceLister) workspacesFromSpaceBindings(signupName string, spaceBindings []toolchainv1alpha1.SpaceBinding) []toolchainv1alpha1.Workspace {
-	workspaces := []toolchainv1alpha1.Workspace{}
-	for i := range spaceBindings {
-		spacebinding := &spaceBindings[i]
-		space, err := s.getSpace(spacebinding)
-		if err != nil {
-			// log error and continue so that the api behaves in a best effort manner
-			// ie. if a space isn't listed something went wrong but we still want to return the other spaces if possible
-			log.Errorf(nil, err, "unable to get space", "space", spacebinding.Labels[toolchainv1alpha1.SpaceBindingSpaceLabelKey])
-			continue
-		}
-		workspace := createWorkspaceObject(signupName, space, spacebinding)
-		workspaces = append(workspaces, *workspace)
-	}
-	return workspaces
+	return userSignup, nil
 }
 
 func createWorkspaceObject(signupName string, space *toolchainv1alpha1.Space, spaceBinding *toolchainv1alpha1.SpaceBinding, wsAdditionalOptions ...commonproxy.WorkspaceOption) *toolchainv1alpha1.Workspace {
@@ -259,106 +77,9 @@ func createWorkspaceObject(signupName string, space *toolchainv1alpha1.Space, sp
 	return workspace
 }
 
-func (s *SpaceLister) getSpace(spaceBinding *toolchainv1alpha1.SpaceBinding) (*toolchainv1alpha1.Space, error) {
-	spaceName := spaceBinding.Labels[toolchainv1alpha1.SpaceBindingSpaceLabelKey]
-	if spaceName == "" { // space may not be initialized
-		// log error and continue so that the api behaves in a best effort manner
-		return nil, fmt.Errorf("spacebinding has no '%s' label", toolchainv1alpha1.SpaceBindingSpaceLabelKey)
-	}
-	return s.GetInformerServiceFunc().GetSpace(spaceName)
-}
-
-func getRolesFromNSTemplateTier(nstemplatetier *toolchainv1alpha1.NSTemplateTier) []string {
-	roles := make([]string, 0, len(nstemplatetier.Spec.SpaceRoles))
-	for k := range nstemplatetier.Spec.SpaceRoles {
-		roles = append(roles, k)
-	}
-	sort.Strings(roles)
-	return roles
-}
-
-func listWorkspaceResponse(ctx echo.Context, workspaces []toolchainv1alpha1.Workspace) error {
-	workspaceList := &toolchainv1alpha1.WorkspaceList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "WorkspaceList",
-			APIVersion: "toolchain.dev.openshift.com/v1alpha1",
-		},
-		Items: workspaces,
-	}
-
-	ctx.Response().Writer.Header().Set("Content-Type", "application/json")
-	ctx.Response().Writer.WriteHeader(http.StatusOK)
-	return json.NewEncoder(ctx.Response().Writer).Encode(workspaceList)
-}
-
-func getWorkspaceResponse(ctx echo.Context, workspace *toolchainv1alpha1.Workspace) error {
-	ctx.Response().Writer.Header().Set("Content-Type", "application/json")
-	ctx.Response().Writer.WriteHeader(http.StatusOK)
-	return json.NewEncoder(ctx.Response().Writer).Encode(workspace)
-}
-
 func errorResponse(ctx echo.Context, err *apierrors.StatusError) error {
 	ctx.Logger().Error(errs.Wrap(err, "workspace list error"))
 	ctx.Response().Writer.Header().Set("Content-Type", "application/json")
 	ctx.Response().Writer.WriteHeader(int(err.ErrStatus.Code))
 	return json.NewEncoder(ctx.Response().Writer).Encode(err.ErrStatus)
-}
-
-// filterUserSpaceBinding returns the spacebinding for a given username, or nil if not found
-func filterUserSpaceBinding(username string, allSpaceBindings []toolchainv1alpha1.SpaceBinding) *toolchainv1alpha1.SpaceBinding {
-	for _, binding := range allSpaceBindings {
-		if binding.Spec.MasterUserRecord == username {
-			return &binding
-		}
-	}
-	return nil
-}
-
-// generateWorkspaceBindings generates the bindings list starting from the spacebindings found on a given space resource and an all parent spaces.
-// The Bindings list  has the available actions for each entry in the list.
-func generateWorkspaceBindings(space *toolchainv1alpha1.Space, spaceBindings []toolchainv1alpha1.SpaceBinding) ([]toolchainv1alpha1.Binding, error) {
-	var bindings []toolchainv1alpha1.Binding
-	for _, spaceBinding := range spaceBindings {
-		binding := toolchainv1alpha1.Binding{
-			MasterUserRecord: spaceBinding.Spec.MasterUserRecord,
-			Role:             spaceBinding.Spec.SpaceRole,
-			AvailableActions: []string{},
-		}
-		spaceBindingSpaceName := spaceBinding.Labels[toolchainv1alpha1.SpaceBindingSpaceLabelKey]
-		sbrName, sbrNameFound := spaceBinding.Labels[toolchainv1alpha1.SpaceBindingRequestLabelKey]
-		sbrNamespace, sbrNamespaceFound := spaceBinding.Labels[toolchainv1alpha1.SpaceBindingRequestNamespaceLabelKey]
-		// check if spacebinding was generated from SBR on the current space and not on a parentSpace.
-		if (sbrNameFound || sbrNamespaceFound) && spaceBindingSpaceName == space.GetName() {
-			if sbrName == "" {
-				// small corner case where the SBR name for some reason is not present as labels on the sb.
-				return nil, fmt.Errorf("SpaceBindingRequest name not found on binding: %s", spaceBinding.GetName())
-			}
-			if sbrNamespace == "" {
-				// small corner case where the SBR namespace for some reason is not present as labels on the sb.
-				return nil, fmt.Errorf("SpaceBindingRequest namespace not found on binding: %s", spaceBinding.GetName())
-			}
-			// this is a binding that was created via SpaceBindingRequest, it can be updated or deleted
-			binding.AvailableActions = []string{UpdateBindingAction, DeleteBindingAction}
-			binding.BindingRequest = &toolchainv1alpha1.BindingRequest{
-				Name:      sbrName,
-				Namespace: sbrNamespace,
-			}
-		} else if spaceBindingSpaceName != space.GetName() {
-			// this is a binding that was inherited from a parent space, since the name on the spacebinding label doesn't match with the current space name.
-			// It can only be overridden by another SpaceBindingRequest containing the same MUR but different role.
-			binding.AvailableActions = []string{OverrideBindingAction}
-		} else {
-			// this is a system generated SpaceBinding, so it cannot be managed by workspace users.
-			binding.AvailableActions = []string{}
-		}
-		bindings = append(bindings, binding)
-	}
-
-	// let's sort the list based on username,
-	// in order to make it deterministic
-	sort.Slice(bindings, func(i, j int) bool {
-		return bindings[i].MasterUserRecord < bindings[j].MasterUserRecord
-	})
-
-	return bindings, nil
 }

--- a/pkg/proxy/handlers/spacelister.go
+++ b/pkg/proxy/handlers/spacelister.go
@@ -147,6 +147,9 @@ func (s *SpaceLister) GetUserWorkspace(ctx echo.Context) (*toolchainv1alpha1.Wor
 	), nil
 }
 
+// ListUserWorkspaces returns a list of Workspaces for the current user.
+// If a workspaceName is provided, it means the request was made for a specific workspace, the function will check if the user has access to that workspace, if not it will return 404 Unauthorized.
+// If no workspaceName is provided, the function will list all SpaceBindings for the user and return all the workspaces found from this list.
 func (s *SpaceLister) ListUserWorkspaces(ctx echo.Context, workspaceName string) ([]toolchainv1alpha1.Workspace, error) {
 	userID, _ := ctx.Get(context.SubKey).(string)
 	username, _ := ctx.Get(context.UsernameKey).(string)

--- a/pkg/proxy/handlers/spacelister_get.go
+++ b/pkg/proxy/handlers/spacelister_get.go
@@ -41,9 +41,7 @@ func (s *SpaceLister) HandleSpaceGetRequest(ctx echo.Context) error {
 func (s *SpaceLister) GetUserWorkspace(ctx echo.Context, workspaceName string) (*toolchainv1alpha1.Workspace, error) {
 	userSignup, err := s.GetProvisionedUserSignup(ctx)
 	if err != nil {
-		cause := errs.Wrap(err, "error retrieving userSignup")
-		ctx.Logger().Error(cause)
-		return nil, cause
+		return nil, err
 	}
 	// signup is not ready
 	if userSignup == nil {

--- a/pkg/proxy/handlers/spacelister_get.go
+++ b/pkg/proxy/handlers/spacelister_get.go
@@ -1,0 +1,173 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/registration-service/pkg/context"
+	"github.com/codeready-toolchain/registration-service/pkg/metrics"
+	commonproxy "github.com/codeready-toolchain/toolchain-common/pkg/proxy"
+	"github.com/codeready-toolchain/toolchain-common/pkg/spacebinding"
+	"github.com/labstack/echo/v4"
+	errs "github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+func (s *SpaceLister) HandleSpaceGetRequest(ctx echo.Context) error {
+	// get specific workspace
+	requestReceivedTime := ctx.Get(context.RequestReceivedTime).(time.Time)
+	workspace, err := s.GetUserWorkspace(ctx, ctx.Param("workspace"))
+	if err != nil {
+		s.ProxyMetrics.RegServWorkspaceHistogramVec.WithLabelValues(fmt.Sprintf("%d", http.StatusInternalServerError), metrics.MetricsLabelVerbGet).Observe(time.Since(requestReceivedTime).Seconds()) // using list as the default value for verb to minimize label combinations for prometheus to process
+		return errorResponse(ctx, apierrors.NewInternalError(err))
+	}
+	if workspace == nil {
+		// not found
+		s.ProxyMetrics.RegServWorkspaceHistogramVec.WithLabelValues(fmt.Sprintf("%d", http.StatusNotFound), metrics.MetricsLabelVerbGet).Observe(time.Since(requestReceivedTime).Seconds())
+		r := schema.GroupResource{Group: "toolchain.dev.openshift.com", Resource: "workspaces"}
+		return errorResponse(ctx, apierrors.NewNotFound(r, ctx.Param("workspace")))
+	}
+	s.ProxyMetrics.RegServWorkspaceHistogramVec.WithLabelValues(fmt.Sprintf("%d", http.StatusOK), metrics.MetricsLabelVerbGet).Observe(time.Since(requestReceivedTime).Seconds())
+	return getWorkspaceResponse(ctx, workspace)
+}
+
+func (s *SpaceLister) GetUserWorkspace(ctx echo.Context, workspaceName string) (*toolchainv1alpha1.Workspace, error) {
+	userSignup, err := s.GetProvisionedUserSignup(ctx)
+	if err != nil {
+		cause := errs.Wrap(err, "error retrieving userSignup")
+		ctx.Logger().Error(cause)
+		return nil, cause
+	}
+	// signup is not ready
+	if userSignup == nil {
+		return nil, nil
+	}
+	space, err := s.GetInformerServiceFunc().GetSpace(workspaceName)
+	if err != nil {
+		ctx.Logger().Error(errs.Wrap(err, "unable to get space"))
+		return nil, nil
+	}
+
+	// recursively get all the spacebindings for the current workspace
+	listSpaceBindingsFunc := func(spaceName string) ([]toolchainv1alpha1.SpaceBinding, error) {
+		spaceSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingSpaceLabelKey, selection.Equals, []string{spaceName})
+		if err != nil {
+			return nil, err
+		}
+		return s.GetInformerServiceFunc().ListSpaceBindings(*spaceSelector)
+	}
+	spaceBindingLister := spacebinding.NewLister(listSpaceBindingsFunc, s.GetInformerServiceFunc().GetSpace)
+	allSpaceBindings, err := spaceBindingLister.ListForSpace(space, []toolchainv1alpha1.SpaceBinding{})
+	if err != nil {
+		ctx.Logger().Error(err, "failed to list space bindings")
+		return nil, err
+	}
+
+	// check if user has access to this workspace
+	userBinding := filterUserSpaceBinding(userSignup.CompliantUsername, allSpaceBindings)
+	if userBinding == nil {
+		//  let's only log the issue and consider this as not found
+		ctx.Logger().Error(fmt.Sprintf("unauthorized access - there is no SpaceBinding present for the user %s and the workspace %s", userSignup.CompliantUsername, workspaceName))
+		return nil, nil
+	}
+	// build the Bindings list with the available actions
+	// this field is populated only for the GET workspace request
+	bindings, err := generateWorkspaceBindings(space, allSpaceBindings)
+	if err != nil {
+		ctx.Logger().Error(errs.Wrap(err, "unable to generate bindings field"))
+		return nil, err
+	}
+
+	// add available roles, this field is populated only for the GET workspace request
+	nsTemplateTier, err := s.GetInformerServiceFunc().GetNSTemplateTier(space.Spec.TierName)
+	if err != nil {
+		ctx.Logger().Error(errs.Wrap(err, "unable to get nstemplatetier"))
+		return nil, err
+	}
+
+	return createWorkspaceObject(userSignup.Name, space, userBinding,
+		commonproxy.WithAvailableRoles(getRolesFromNSTemplateTier(nsTemplateTier)),
+		commonproxy.WithBindings(bindings),
+	), nil
+}
+
+func getRolesFromNSTemplateTier(nstemplatetier *toolchainv1alpha1.NSTemplateTier) []string {
+	roles := make([]string, 0, len(nstemplatetier.Spec.SpaceRoles))
+	for k := range nstemplatetier.Spec.SpaceRoles {
+		roles = append(roles, k)
+	}
+	sort.Strings(roles)
+	return roles
+}
+
+// filterUserSpaceBinding returns the spacebinding for a given username, or nil if not found
+func filterUserSpaceBinding(username string, allSpaceBindings []toolchainv1alpha1.SpaceBinding) *toolchainv1alpha1.SpaceBinding {
+	for _, binding := range allSpaceBindings {
+		if binding.Spec.MasterUserRecord == username {
+			return &binding
+		}
+	}
+	return nil
+}
+
+// generateWorkspaceBindings generates the bindings list starting from the spacebindings found on a given space resource and an all parent spaces.
+// The Bindings list  has the available actions for each entry in the list.
+func generateWorkspaceBindings(space *toolchainv1alpha1.Space, spaceBindings []toolchainv1alpha1.SpaceBinding) ([]toolchainv1alpha1.Binding, error) {
+	var bindings []toolchainv1alpha1.Binding
+	for _, spaceBinding := range spaceBindings {
+		binding := toolchainv1alpha1.Binding{
+			MasterUserRecord: spaceBinding.Spec.MasterUserRecord,
+			Role:             spaceBinding.Spec.SpaceRole,
+			AvailableActions: []string{},
+		}
+		spaceBindingSpaceName := spaceBinding.Labels[toolchainv1alpha1.SpaceBindingSpaceLabelKey]
+		sbrName, sbrNameFound := spaceBinding.Labels[toolchainv1alpha1.SpaceBindingRequestLabelKey]
+		sbrNamespace, sbrNamespaceFound := spaceBinding.Labels[toolchainv1alpha1.SpaceBindingRequestNamespaceLabelKey]
+		// check if spacebinding was generated from SBR on the current space and not on a parentSpace.
+		if (sbrNameFound || sbrNamespaceFound) && spaceBindingSpaceName == space.GetName() {
+			if sbrName == "" {
+				// small corner case where the SBR name for some reason is not present as labels on the sb.
+				return nil, fmt.Errorf("SpaceBindingRequest name not found on binding: %s", spaceBinding.GetName())
+			}
+			if sbrNamespace == "" {
+				// small corner case where the SBR namespace for some reason is not present as labels on the sb.
+				return nil, fmt.Errorf("SpaceBindingRequest namespace not found on binding: %s", spaceBinding.GetName())
+			}
+			// this is a binding that was created via SpaceBindingRequest, it can be updated or deleted
+			binding.AvailableActions = []string{UpdateBindingAction, DeleteBindingAction}
+			binding.BindingRequest = &toolchainv1alpha1.BindingRequest{
+				Name:      sbrName,
+				Namespace: sbrNamespace,
+			}
+		} else if spaceBindingSpaceName != space.GetName() {
+			// this is a binding that was inherited from a parent space, since the name on the spacebinding label doesn't match with the current space name.
+			// It can only be overridden by another SpaceBindingRequest containing the same MUR but different role.
+			binding.AvailableActions = []string{OverrideBindingAction}
+		} else {
+			// this is a system generated SpaceBinding, so it cannot be managed by workspace users.
+			binding.AvailableActions = []string{}
+		}
+		bindings = append(bindings, binding)
+	}
+
+	// let's sort the list based on username,
+	// in order to make it deterministic
+	sort.Slice(bindings, func(i, j int) bool {
+		return bindings[i].MasterUserRecord < bindings[j].MasterUserRecord
+	})
+
+	return bindings, nil
+}
+
+func getWorkspaceResponse(ctx echo.Context, workspace *toolchainv1alpha1.Workspace) error {
+	ctx.Response().Writer.Header().Set("Content-Type", "application/json")
+	ctx.Response().Writer.WriteHeader(http.StatusOK)
+	return json.NewEncoder(ctx.Response().Writer).Encode(workspace)
+}

--- a/pkg/proxy/handlers/spacelister_list.go
+++ b/pkg/proxy/handlers/spacelister_list.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/registration-service/pkg/context"
+	"github.com/codeready-toolchain/registration-service/pkg/metrics"
+	"github.com/labstack/echo/v4"
+	errs "github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// ListUserWorkspaces returns a list of Workspaces for the current user.
+// The function lists all SpaceBindings for the user and return all the workspaces found from this list.
+func (s *SpaceLister) ListUserWorkspaces(ctx echo.Context) ([]toolchainv1alpha1.Workspace, error) {
+	signup, err := s.GetProvisionedUserSignup(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// signup is not ready
+	if signup == nil {
+		return []toolchainv1alpha1.Workspace{}, nil
+	}
+	murName := signup.CompliantUsername
+
+	// get all spacebindings with given mur since no workspace was provided
+	spaceBindings, err := s.listSpaceBindingsForUser(murName)
+	if err != nil {
+		ctx.Logger().Error(errs.Wrap(err, "error listing space bindings"))
+		return nil, err
+	}
+	return s.workspacesFromSpaceBindings(ctx, signup.Name, spaceBindings), nil
+}
+
+func (s *SpaceLister) HandleSpaceListRequest(ctx echo.Context) error {
+	// list all user workspaces
+	requestReceivedTime := ctx.Get(context.RequestReceivedTime).(time.Time)
+	workspaces, err := s.ListUserWorkspaces(ctx)
+	if err != nil {
+		s.ProxyMetrics.RegServWorkspaceHistogramVec.WithLabelValues(fmt.Sprintf("%d", http.StatusInternalServerError), metrics.MetricsLabelVerbList).Observe(time.Since(requestReceivedTime).Seconds()) // using list as the default value for verb to minimize label combinations for prometheus to process
+		return errorResponse(ctx, apierrors.NewInternalError(err))
+	}
+	s.ProxyMetrics.RegServWorkspaceHistogramVec.WithLabelValues(fmt.Sprintf("%d", http.StatusOK), metrics.MetricsLabelVerbList).Observe(time.Since(requestReceivedTime).Seconds())
+	return listWorkspaceResponse(ctx, workspaces)
+}
+
+func listWorkspaceResponse(ctx echo.Context, workspaces []toolchainv1alpha1.Workspace) error {
+	workspaceList := &toolchainv1alpha1.WorkspaceList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "WorkspaceList",
+			APIVersion: "toolchain.dev.openshift.com/v1alpha1",
+		},
+		Items: workspaces,
+	}
+
+	ctx.Response().Writer.Header().Set("Content-Type", "application/json")
+	ctx.Response().Writer.WriteHeader(http.StatusOK)
+	return json.NewEncoder(ctx.Response().Writer).Encode(workspaceList)
+}
+
+func (s *SpaceLister) listSpaceBindingsForUser(murName string) ([]toolchainv1alpha1.SpaceBinding, error) {
+	murSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey, selection.Equals, []string{murName})
+	if err != nil {
+		return nil, err
+	}
+	requirements := []labels.Requirement{*murSelector}
+	return s.GetInformerServiceFunc().ListSpaceBindings(requirements...)
+}
+
+func (s *SpaceLister) workspacesFromSpaceBindings(ctx echo.Context, signupName string, spaceBindings []toolchainv1alpha1.SpaceBinding) []toolchainv1alpha1.Workspace {
+	workspaces := []toolchainv1alpha1.Workspace{}
+	for i := range spaceBindings {
+		spacebinding := &spaceBindings[i]
+		space, err := s.getSpace(spacebinding)
+		if err != nil {
+			// log error and continue so that the api behaves in a best effort manner
+			// ie. if a space isn't listed something went wrong but we still want to return the other spaces if possible
+			ctx.Logger().Error(nil, err, "unable to get space", "space", spacebinding.Labels[toolchainv1alpha1.SpaceBindingSpaceLabelKey])
+			continue
+		}
+		workspace := createWorkspaceObject(signupName, space, spacebinding)
+		workspaces = append(workspaces, *workspace)
+	}
+	return workspaces
+}
+
+func (s *SpaceLister) getSpace(spaceBinding *toolchainv1alpha1.SpaceBinding) (*toolchainv1alpha1.Space, error) {
+	spaceName := spaceBinding.Labels[toolchainv1alpha1.SpaceBindingSpaceLabelKey]
+	if spaceName == "" { // space may not be initialized
+		// log error and continue so that the api behaves in a best effort manner
+		return nil, fmt.Errorf("spacebinding has no '%s' label", toolchainv1alpha1.SpaceBindingSpaceLabelKey)
+	}
+	return s.GetInformerServiceFunc().GetSpace(spaceName)
+}

--- a/pkg/proxy/handlers/spacelister_test.go
+++ b/pkg/proxy/handlers/spacelister_test.go
@@ -164,15 +164,6 @@ func TestSpaceLister(t *testing.T) {
 					return nil, fmt.Errorf("signup error")
 				},
 			},
-			"parent lists spaces": {
-				username: "parentspace",
-				expectedWs: []toolchainv1alpha1.Workspace{
-					workspaceFor(t, fakeClient, "parentspace", "admin", true),
-					workspaceFor(t, fakeClient, "childspace", "admin", false),
-					workspaceFor(t, fakeClient, "grandchildspace", "admin", false),
-				},
-				expectedErr: "",
-			},
 		}
 
 		for k, tc := range tests {

--- a/pkg/proxy/handlers/spacelister_test.go
+++ b/pkg/proxy/handlers/spacelister_test.go
@@ -208,7 +208,7 @@ func TestSpaceLister(t *testing.T) {
 				ctx.Set(rcontext.RequestReceivedTime, time.Now())
 
 				// when
-				err := s.HandleSpaceListRequest(ctx)
+				err := handlers.HandleSpaceListRequest(s)(ctx)
 
 				// then
 				if tc.expectedErr != "" {
@@ -703,7 +703,7 @@ func TestSpaceLister(t *testing.T) {
 				ctx.SetParamValues(tc.expectedWorkspace)
 
 				// when
-				err := s.HandleSpaceGetRequest(ctx)
+				err := handlers.HandleSpaceGetRequest(s)(ctx)
 
 				// then
 				if tc.expectedErr != "" {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -171,7 +171,7 @@ func (p *Proxy) processRequest(ctx echo.Context) (string, *access.ClusterAccess,
 	}
 
 	// before proxying the request, verify that the user has a spacebinding for the workspace and that the namespace (if any) belongs to the workspace
-	workspaces, err := p.spaceLister.ListUserWorkspaces(ctx)
+	workspaces, err := p.spaceLister.ListUserWorkspaces(ctx, workspace)
 	if err != nil {
 		return "", nil, crterrors.NewInternalError(errs.New("unable to retrieve user workspaces"), err.Error())
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -165,7 +165,6 @@ func (p *Proxy) processRequest(ctx echo.Context) (string, *access.ClusterAccess,
 	}
 
 	ctx.Set(context.WorkspaceKey, workspaceName) // set workspace context for logging
-	cluster, err := p.app.MemberClusterService().GetClusterAccess(userID, username, workspaceName, proxyPluginName)
 	if err != nil {
 		return "", nil, crterrors.NewInternalError(errs.New("unable to get target cluster"), err.Error())
 	}
@@ -197,6 +196,7 @@ func (p *Proxy) processRequest(ctx echo.Context) (string, *access.ClusterAccess,
 		return "", nil, crterrors.NewForbiddenError("invalid workspace request", err.Error())
 	}
 
+	cluster, err := p.app.MemberClusterService().GetClusterAccess(userID, username, workspaceName, proxyPluginName)
 	return proxyPluginName, cluster, nil
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -159,27 +159,44 @@ func (p *Proxy) health(ctx echo.Context) error {
 func (p *Proxy) processRequest(ctx echo.Context) (string, *access.ClusterAccess, error) {
 	userID, _ := ctx.Get(context.SubKey).(string)
 	username, _ := ctx.Get(context.UsernameKey).(string)
-	proxyPluginName, workspace, err := getWorkspaceContext(ctx.Request())
+	proxyPluginName, workspaceName, err := getWorkspaceContext(ctx.Request())
 	if err != nil {
 		return "", nil, crterrors.NewBadRequest("unable to get workspace context", err.Error())
 	}
 
-	ctx.Set(context.WorkspaceKey, workspace) // set workspace context for logging
-	cluster, err := p.app.MemberClusterService().GetClusterAccess(userID, username, workspace, proxyPluginName)
+	ctx.Set(context.WorkspaceKey, workspaceName) // set workspace context for logging
+	cluster, err := p.app.MemberClusterService().GetClusterAccess(userID, username, workspaceName, proxyPluginName)
 	if err != nil {
 		return "", nil, crterrors.NewInternalError(errs.New("unable to get target cluster"), err.Error())
 	}
 
 	// before proxying the request, verify that the user has a spacebinding for the workspace and that the namespace (if any) belongs to the workspace
-	workspaces, err := p.spaceLister.ListUserWorkspaces(ctx, workspace)
-	if err != nil {
-		return "", nil, crterrors.NewInternalError(errs.New("unable to retrieve user workspaces"), err.Error())
+	var workspaces []toolchainv1alpha1.Workspace
+	if workspaceName != "" {
+		// when a workspace name was provided
+		// recursively get all the spacebindings, starting from this workspace and going up to the parent workspaces till the "root" of the workspace tree.
+		workspace, err := p.spaceLister.GetUserWorkspace(ctx, workspaceName)
+		if err != nil {
+			return "", nil, crterrors.NewInternalError(errs.New("unable to retrieve user workspaces"), err.Error())
+		}
+		if workspace == nil {
+			// not found
+			return "", nil, crterrors.NewForbiddenError("invalid workspace request", fmt.Sprintf("access to workspace '%s' is forbidden", workspaceName))
+		}
+		// workspace was found means we can forward the request
+		workspaces = []toolchainv1alpha1.Workspace{*workspace}
+	} else {
+		// list all workspaces
+		workspaces, err = p.spaceLister.ListUserWorkspaces(ctx)
+		if err != nil {
+			return "", nil, crterrors.NewInternalError(errs.New("unable to retrieve user workspaces"), err.Error())
+		}
 	}
-
 	requestedNamespace := namespaceFromCtx(ctx)
-	if err := validateWorkspaceRequest(workspace, requestedNamespace, workspaces); err != nil {
+	if err := validateWorkspaceRequest(workspaceName, requestedNamespace, workspaces); err != nil {
 		return "", nil, crterrors.NewForbiddenError("invalid workspace request", err.Error())
 	}
+
 	return proxyPluginName, cluster, nil
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -174,7 +174,7 @@ func (p *Proxy) processRequest(ctx echo.Context) (string, *access.ClusterAccess,
 	var workspaces []toolchainv1alpha1.Workspace
 	if workspaceName != "" {
 		// when a workspace name was provided
-		// recursively get all the spacebindings, starting from this workspace and going up to the parent workspaces till the "root" of the workspace tree.
+		// validate that the user has access to the workspace by getting all spacebindings recursively, starting from this workspace and going up to the parent workspaces till the "root" of the workspace tree.
 		workspace, err := p.spaceLister.GetUserWorkspace(ctx, workspaceName)
 		if err != nil {
 			return "", nil, crterrors.NewInternalError(errs.New("unable to retrieve user workspaces"), err.Error())

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -7,8 +7,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/codeready-toolchain/registration-service/pkg/metrics"
-	"github.com/prometheus/client_golang/prometheus"
 	"io"
 	"log"
 	"net/http"
@@ -18,6 +16,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/codeready-toolchain/registration-service/pkg/metrics"
+	spacetest "github.com/codeready-toolchain/toolchain-common/pkg/test/space"
+	"github.com/prometheus/client_golang/prometheus"
 
 	appservice "github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
@@ -494,6 +496,7 @@ func (s *TestProxySuite) TestProxy() {
 								for workspaceContext, reqPath := range map[string]string{
 									"default workspace":    "http://localhost:8081/api/mycoolworkspace/pods",
 									"workspace context":    "http://localhost:8081/workspaces/mycoolworkspace/api/mycoolworkspace/pods",
+									"subworkspace context": "http://localhost:8081/workspaces/mycoolsubworkspace/api/mycoolsubworkspace/pods",
 									"proxy plugin context": "http://localhost:8081/plugins/myplugin/workspaces/mycoolworkspace/api/mycoolworkspace/pods",
 								} {
 									s.Run(workspaceContext, func() {
@@ -567,6 +570,8 @@ func (s *TestProxySuite) TestProxy() {
 												switch name {
 												case "mycoolworkspace":
 													return fake.NewSpace("mycoolworkspace", "member-2", "smith2"), nil
+												case "mycoolsubworkspace":
+													return fake.NewSpace("mycoolsubworkspace", "member-2", "smith2", spacetest.WithSpecParentSpace("mycoolworkspace")), nil
 												}
 												return nil, fmt.Errorf("space not found error")
 											}
@@ -574,7 +579,7 @@ func (s *TestProxySuite) TestProxy() {
 												// always return a spacebinding for the purposes of the proxy tests, actual testing of the space lister is covered in the space lister tests
 												spaceBindings := []toolchainv1alpha1.SpaceBinding{}
 												for _, req := range reqs {
-													if req.Values().List()[0] == "smith2" {
+													if req.Values().List()[0] == "smith2" || req.Values().List()[0] == "mycoolworkspace" {
 														spaceBindings = append(spaceBindings, *fake.NewSpaceBinding("mycoolworkspace-smith2", "smith2", "mycoolworkspace", "admin"))
 													}
 												}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/codeready-toolchain/registration-service/pkg/metrics"
-	spacetest "github.com/codeready-toolchain/toolchain-common/pkg/test/space"
 	"github.com/prometheus/client_golang/prometheus"
 
 	appservice "github.com/codeready-toolchain/registration-service/pkg/application/service"
@@ -496,7 +495,6 @@ func (s *TestProxySuite) TestProxy() {
 								for workspaceContext, reqPath := range map[string]string{
 									"default workspace":    "http://localhost:8081/api/mycoolworkspace/pods",
 									"workspace context":    "http://localhost:8081/workspaces/mycoolworkspace/api/mycoolworkspace/pods",
-									"subworkspace context": "http://localhost:8081/workspaces/mycoolsubworkspace/api/mycoolsubworkspace/pods",
 									"proxy plugin context": "http://localhost:8081/plugins/myplugin/workspaces/mycoolworkspace/api/mycoolworkspace/pods",
 								} {
 									s.Run(workspaceContext, func() {
@@ -570,8 +568,6 @@ func (s *TestProxySuite) TestProxy() {
 												switch name {
 												case "mycoolworkspace":
 													return fake.NewSpace("mycoolworkspace", "member-2", "smith2"), nil
-												case "mycoolsubworkspace":
-													return fake.NewSpace("mycoolsubworkspace", "member-2", "smith2", spacetest.WithSpecParentSpace("mycoolworkspace")), nil
 												}
 												return nil, fmt.Errorf("space not found error")
 											}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -17,17 +17,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/registration-service/pkg/metrics"
-	"github.com/prometheus/client_golang/prometheus"
-
 	appservice "github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
+	"github.com/codeready-toolchain/registration-service/pkg/metrics"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/handlers"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/service"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/test"
 	"github.com/codeready-toolchain/registration-service/test/fake"
+	"github.com/prometheus/client_golang/prometheus"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
@@ -599,6 +598,9 @@ func (s *TestProxySuite) TestProxy() {
 													}, nil
 												}
 												return nil, fmt.Errorf("proxy plugin not found")
+											}
+											inf.GetNSTemplateTierFunc = func(tier string) (*toolchainv1alpha1.NSTemplateTier, error) {
+												return fake.NewBase1NSTemplateTier(), nil
 											}
 											s.Application.MockInformerService(inf)
 											fakeApp.MemberClusterServiceMock = s.newMemberClusterServiceWithMembers(testServer.URL)


### PR DESCRIPTION
This PR : 
- adds the [spacebinding lister ](https://github.com/codeready-toolchain/toolchain-common/blob/master/pkg/spacebinding/spacebindinglister.go) to the `handleRequestAndRedirect` proxy handler. This enables users to issue requests for subSpaces.
- splits spacelister get and list handlers into separate files

TODO (in next PR):
 - split `spacelister_test.go` into `spacelister_get_test.go` and `spacelister_list_test.go`



Jira: https://issues.redhat.com/browse/ASC-437 