### PR TITLE
Fix broken test

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -109,7 +109,10 @@ func startFakeProxy(t *testing.T) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/proxyhealth", fakehealth)
 
-	srv := &http.Server{Addr: ":8091", Handler: mux, ReadHeaderTimeout: 2 * time.Second}
+	// use an unique port for proxy to avoid collisions with `pkg/proxy`
+	// that's using the default one from pkg/proxy (i.e. proxy.ProxyPort 8081)
+	altProxyPort := "8091"
+	srv := &http.Server{Addr: ":" + altProxyPort, Handler: mux, ReadHeaderTimeout: 2 * time.Second}
 	go func() {
 		err := srv.ListenAndServe()
 		require.NoError(t, err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/h2non/gock.v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/codeready-toolchain/registration-service/pkg/proxy"
 	"github.com/codeready-toolchain/registration-service/pkg/server"
 	"github.com/codeready-toolchain/registration-service/test"
 
@@ -110,7 +109,7 @@ func startFakeProxy(t *testing.T) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/proxyhealth", fakehealth)
 
-	srv := &http.Server{Addr: ":" + proxy.ProxyPort, Handler: mux, ReadHeaderTimeout: 2 * time.Second}
+	srv := &http.Server{Addr: ":8091", Handler: mux, ReadHeaderTimeout: 2 * time.Second}
 	go func() {
 		err := srv.ListenAndServe()
 		require.NoError(t, err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -109,8 +109,8 @@ func startFakeProxy(t *testing.T) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/proxyhealth", fakehealth)
 
-	// use an unique port for proxy to avoid collisions with `pkg/proxy`
-	// that's using the default one from pkg/proxy (i.e. proxy.ProxyPort 8081)
+	// use an unique port for proxy to avoid collisions with tests in `pkg/proxy`
+	// that are using the pkg/proxy's default port (i.e. proxy.ProxyPort 8081)
 	altProxyPort := "8091"
 	srv := &http.Server{Addr: ":" + altProxyPort, Handler: mux, ReadHeaderTimeout: 2 * time.Second}
 	go func() {


### PR DESCRIPTION
related to #374

Seems to me the tests on `pkg/proxy/...` and `pkg/server/...` are requesting the same port for proxy server. That causes a collision as tests are executed in concurrent goroutines.

Signed-off-by: Francesco Ilario <filario@redhat.com>
