### PR TITLE
make required captcha score configurable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,4 +146,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20231129203450-dc2ae3576268
+replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20231130092744-3a55662f5fe9

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/aws/aws-sdk-go v1.44.100
 	github.com/codeready-toolchain/api v0.0.0-20231129193441-f6c9b7feee01
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20231117145902-3e7430ae48bb
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20231206125932-41dd47e8aa56
 	github.com/go-logr/logr v1.2.3
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -145,5 +145,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20231130092744-3a55662f5fe9

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20231122125952-9e6527f5e746
+	github.com/codeready-toolchain/api v0.0.0-20231129193441-f6c9b7feee01
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20231117145902-3e7430ae48bb
 	github.com/go-logr/logr v1.2.3
 	github.com/gofrs/uuid v4.2.0+incompatible
@@ -146,6 +146,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20231128224705-94a8f68f5394
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20231128231135-7fe970a2712b
+replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20231129203450-dc2ae3576268

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20231107202930-b028ae440a26
+	github.com/codeready-toolchain/api v0.0.0-20231122125952-9e6527f5e746
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20231117145902-3e7430ae48bb
 	github.com/go-logr/logr v1.2.3
 	github.com/gofrs/uuid v4.2.0+incompatible
@@ -145,3 +145,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20231128224705-94a8f68f5394
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20231128231135-7fe970a2712b

--- a/go.sum
+++ b/go.sum
@@ -115,10 +115,6 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/codeready-toolchain/api v0.0.0-20231107202930-b028ae440a26 h1:7l/9jcykzh/Qq93EnPYQYpaejPkWaaHB6BLCwTKngJE=
-github.com/codeready-toolchain/api v0.0.0-20231107202930-b028ae440a26/go.mod h1:bImSKnxrpNmCmW/YEGiiZnZqJm3kAmfP5hW4YndK0hE=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20231117145902-3e7430ae48bb h1:TVgy4tO2oy2YwWTZXXYytY9soshylURDzmdkY6ch1+o=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20231117145902-3e7430ae48bb/go.mod h1:fmMAvkwt/OfANx8l/BDbuaHkjInlRJ3uYmIjjVmjd9w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -379,6 +375,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mfrancisc/api v0.0.0-20231128224705-94a8f68f5394 h1:bQ3Mt8E6qmdps3jqDW66VbtlI9PRRdo46qbUKaph4I4=
+github.com/mfrancisc/api v0.0.0-20231128224705-94a8f68f5394/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
+github.com/mfrancisc/toolchain-common v0.0.0-20231128231135-7fe970a2712b h1:X3C5wssyp3vlV+05vZuJMUKeGCQ2nUQ9MC4mIab1vFM=
+github.com/mfrancisc/toolchain-common v0.0.0-20231128231135-7fe970a2712b/go.mod h1:Ll32or9835Iq6v8MLxnnNjF7/wB/UiNtkRHIwPee7Iw=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/codeready-toolchain/api v0.0.0-20231129193441-f6c9b7feee01 h1:Pl8UIl/m2/n9C4pXzaR6A3vxRFX+4QRw90x8RDhCdXw=
+github.com/codeready-toolchain/api v0.0.0-20231129193441-f6c9b7feee01/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -375,10 +377,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mfrancisc/api v0.0.0-20231128224705-94a8f68f5394 h1:bQ3Mt8E6qmdps3jqDW66VbtlI9PRRdo46qbUKaph4I4=
-github.com/mfrancisc/api v0.0.0-20231128224705-94a8f68f5394/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
-github.com/mfrancisc/toolchain-common v0.0.0-20231128231135-7fe970a2712b h1:X3C5wssyp3vlV+05vZuJMUKeGCQ2nUQ9MC4mIab1vFM=
-github.com/mfrancisc/toolchain-common v0.0.0-20231128231135-7fe970a2712b/go.mod h1:Ll32or9835Iq6v8MLxnnNjF7/wB/UiNtkRHIwPee7Iw=
+github.com/mfrancisc/toolchain-common v0.0.0-20231129203450-dc2ae3576268 h1:5uWab0qSXG0PnEABfG6A8Is3WTUgX+T1qywbS57BW/4=
+github.com/mfrancisc/toolchain-common v0.0.0-20231129203450-dc2ae3576268/go.mod h1:p26SbkWy2Fo8/YUQcvElRDE2VIthvqCoy7ia6EDcN1M=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mfrancisc/toolchain-common v0.0.0-20231129203450-dc2ae3576268 h1:5uWab0qSXG0PnEABfG6A8Is3WTUgX+T1qywbS57BW/4=
-github.com/mfrancisc/toolchain-common v0.0.0-20231129203450-dc2ae3576268/go.mod h1:p26SbkWy2Fo8/YUQcvElRDE2VIthvqCoy7ia6EDcN1M=
+github.com/mfrancisc/toolchain-common v0.0.0-20231130092744-3a55662f5fe9 h1:ucPVk1V/cf99Bb70U1W5MYcDBeaeZR+ilcPAgI/raWw=
+github.com/mfrancisc/toolchain-common v0.0.0-20231130092744-3a55662f5fe9/go.mod h1:cEkJH2jz88KIZt5W8wSnK3Gz6OfszzXv74OIndbTlRE=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codeready-toolchain/api v0.0.0-20231129193441-f6c9b7feee01 h1:Pl8UIl/m2/n9C4pXzaR6A3vxRFX+4QRw90x8RDhCdXw=
 github.com/codeready-toolchain/api v0.0.0-20231129193441-f6c9b7feee01/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20231206125932-41dd47e8aa56 h1:W/VrNwL++P6TRw6BqhPfnzaq3YmytBIvestbLDvVv1E=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20231206125932-41dd47e8aa56/go.mod h1:cEkJH2jz88KIZt5W8wSnK3Gz6OfszzXv74OIndbTlRE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -377,8 +379,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mfrancisc/toolchain-common v0.0.0-20231130092744-3a55662f5fe9 h1:ucPVk1V/cf99Bb70U1W5MYcDBeaeZR+ilcPAgI/raWw=
-github.com/mfrancisc/toolchain-common v0.0.0-20231130092744-3a55662f5fe9/go.mod h1:cEkJH2jz88KIZt5W8wSnK3Gz6OfszzXv74OIndbTlRE=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -281,9 +281,9 @@ func (r VerificationConfig) CaptchaScoreThreshold() float32 {
 	return float32(thresholdFloat)
 }
 
-func (r VerificationConfig) AutomaticVerificationThreshold() float32 {
+func (r VerificationConfig) CaptchaRequiredScore() float32 {
 	const defaultAutomaticVerificationThreshold float32 = 0.6
-	threshold := commonconfig.GetString(r.c.Captcha.AutomaticVerificationThreshold, "0.6")
+	threshold := commonconfig.GetString(r.c.Captcha.RequiredScore, "0.6")
 	thresholdFloat, err := strconv.ParseFloat(threshold, 32)
 	if err != nil {
 
@@ -293,6 +293,10 @@ func (r VerificationConfig) AutomaticVerificationThreshold() float32 {
 		return defaultAutomaticVerificationThreshold
 	}
 	return float32(thresholdFloat)
+}
+
+func (r VerificationConfig) CaptchaAllowLowScoreReactivation() bool {
+	return commonconfig.GetBool(r.c.Captcha.AllowLowScoreReactivation, true)
 }
 
 func (r VerificationConfig) CaptchaSiteKey() string {

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -281,6 +281,20 @@ func (r VerificationConfig) CaptchaScoreThreshold() float32 {
 	return float32(thresholdFloat)
 }
 
+func (r VerificationConfig) AutomaticVerificationThreshold() float32 {
+	const defaultAutomaticVerificationThreshold float32 = 0.6
+	threshold := commonconfig.GetString(r.c.Captcha.AutomaticVerificationThreshold, "0.6")
+	thresholdFloat, err := strconv.ParseFloat(threshold, 32)
+	if err != nil {
+
+		if threshold != "" {
+			log.Error(nil, err, fmt.Sprintf("unable to parse automatic verification threshold, using default value '%.1f'", defaultAutomaticVerificationThreshold))
+		}
+		return defaultAutomaticVerificationThreshold
+	}
+	return float32(thresholdFloat)
+}
+
 func (r VerificationConfig) CaptchaSiteKey() string {
 	return commonconfig.GetString(r.c.Captcha.SiteKey, "")
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -282,8 +282,8 @@ func (r VerificationConfig) CaptchaScoreThreshold() float32 {
 }
 
 func (r VerificationConfig) CaptchaRequiredScore() float32 {
-	const defaultAutomaticVerificationThreshold float32 = 0.6
-	threshold := commonconfig.GetString(r.c.Captcha.RequiredScore, "0.6")
+	const defaultAutomaticVerificationThreshold float32 = 0
+	threshold := commonconfig.GetString(r.c.Captcha.RequiredScore, "0")
 	thresholdFloat, err := strconv.ParseFloat(threshold, 32)
 	if err != nil {
 

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -63,7 +63,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.Empty(t, regServiceCfg.Verification().CaptchaProjectID())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaSiteKey())
 		assert.Equal(t, float32(0.9), regServiceCfg.Verification().CaptchaScoreThreshold())
-		assert.Equal(t, float32(0.6), regServiceCfg.Verification().CaptchaRequiredScore())
+		assert.Equal(t, float32(0), regServiceCfg.Verification().CaptchaRequiredScore())
 		assert.Equal(t, true, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 	})

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -63,7 +63,8 @@ func TestRegistrationService(t *testing.T) {
 		assert.Empty(t, regServiceCfg.Verification().CaptchaProjectID())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaSiteKey())
 		assert.Equal(t, float32(0.9), regServiceCfg.Verification().CaptchaScoreThreshold())
-		assert.Equal(t, float32(0.6), regServiceCfg.Verification().AutomaticVerificationThreshold())
+		assert.Equal(t, float32(0.6), regServiceCfg.Verification().CaptchaRequiredScore())
+		assert.Equal(t, true, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 	})
 	t.Run("non-default", func(t *testing.T) {
@@ -90,7 +91,8 @@ func TestRegistrationService(t *testing.T) {
 			Verification().CaptchaProjectID("test-project").
 			Verification().CaptchaSiteKey("site-key").
 			Verification().CaptchaScoreThreshold("0.7").
-			Verification().AutomaticVerificationThreshold("0.5").
+			Verification().CaptchaRequiredScore("0.5").
+			Verification().CaptchaAllowLowScoreReactivation(false).
 			Verification().Secret().Ref("verification-secrets").
 			TwilioAccountSID("twilio.sid").
 			TwilioAuthToken("twilio.token").
@@ -140,7 +142,8 @@ func TestRegistrationService(t *testing.T) {
 		assert.Equal(t, "test-project", regServiceCfg.Verification().CaptchaProjectID())
 		assert.Equal(t, "site-key", regServiceCfg.Verification().CaptchaSiteKey())
 		assert.Equal(t, float32(0.7), regServiceCfg.Verification().CaptchaScoreThreshold())
-		assert.Equal(t, float32(0.5), regServiceCfg.Verification().AutomaticVerificationThreshold())
+		assert.Equal(t, float32(0.5), regServiceCfg.Verification().CaptchaRequiredScore())
+		assert.Equal(t, false, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Equal(t, "example-content", regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 	})
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -63,6 +63,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.Empty(t, regServiceCfg.Verification().CaptchaProjectID())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaSiteKey())
 		assert.Equal(t, float32(0.9), regServiceCfg.Verification().CaptchaScoreThreshold())
+		assert.Equal(t, float32(0.6), regServiceCfg.Verification().AutomaticVerificationThreshold())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 	})
 	t.Run("non-default", func(t *testing.T) {
@@ -89,6 +90,7 @@ func TestRegistrationService(t *testing.T) {
 			Verification().CaptchaProjectID("test-project").
 			Verification().CaptchaSiteKey("site-key").
 			Verification().CaptchaScoreThreshold("0.7").
+			Verification().AutomaticVerificationThreshold("0.5").
 			Verification().Secret().Ref("verification-secrets").
 			TwilioAccountSID("twilio.sid").
 			TwilioAuthToken("twilio.token").
@@ -138,6 +140,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.Equal(t, "test-project", regServiceCfg.Verification().CaptchaProjectID())
 		assert.Equal(t, "site-key", regServiceCfg.Verification().CaptchaSiteKey())
 		assert.Equal(t, float32(0.7), regServiceCfg.Verification().CaptchaScoreThreshold())
+		assert.Equal(t, float32(0.5), regServiceCfg.Verification().AutomaticVerificationThreshold())
 		assert.Equal(t, "example-content", regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 	})
 }

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -353,10 +353,12 @@ func (s *ServiceImpl) VerifyPhoneCode(ctx *gin.Context, userID, username, code s
 
 func checkRequiredCaptchaScore(ctx *gin.Context, signup *toolchainv1alpha1.UserSignup, cfg configuration.RegistrationServiceConfig) error {
 	captchaScore, found := signup.Annotations[toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey]
-	fscore, parseErr := strconv.ParseFloat(captchaScore, 32)
-	if found && parseErr == nil && float32(fscore) < cfg.Verification().CaptchaRequiredScore() {
-		log.Error(ctx, errors.New("captcha score too low"), "automatic verification disabled, manual approval required for user")
-		return crterrors.NewForbiddenError("verification failed", "verification is not available at this time")
+	if found {
+		fscore, parseErr := strconv.ParseFloat(captchaScore, 32)
+		if parseErr == nil && float32(fscore) < cfg.Verification().CaptchaRequiredScore() {
+			log.Info(ctx, "captcha score %v is too low, automatic verification disabled, manual approval required for user", float32(fscore))
+			return crterrors.NewForbiddenError("verification failed", "verification is not available at this time")
+		}
 	}
 	return nil
 }

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -244,7 +244,7 @@ func (s *ServiceImpl) VerifyPhoneCode(ctx *gin.Context, userID, username, code s
 			}
 		}
 	} else {
-		// when allowLowScoreReactivation is not enabled
+		// when allowLowScoreReactivation is not enabled or no activation counter found
 		// require manual approval if captcha score below automatic verification threshold for all users
 		if err := checkRequiredCaptchaScore(ctx, signup, cfg); err != nil {
 			return err

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -355,6 +355,11 @@ func checkRequiredCaptchaScore(ctx *gin.Context, signup *toolchainv1alpha1.UserS
 	captchaScore, found := signup.Annotations[toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey]
 	if found {
 		fscore, parseErr := strconv.ParseFloat(captchaScore, 32)
+		if parseErr != nil {
+			// let's just log the parsing error and return
+			log.Error(ctx, parseErr, fmt.Sprintf("error while parsing captchaScore"))
+			return nil
+		}
 		if parseErr == nil && float32(fscore) < cfg.Verification().CaptchaRequiredScore() {
 			log.Info(ctx, fmt.Sprintf("captcha score %v is too low, automatic verification disabled, manual approval required for user", float32(fscore)))
 			return crterrors.NewForbiddenError("verification failed", "verification is not available at this time")

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -356,7 +356,7 @@ func checkRequiredCaptchaScore(ctx *gin.Context, signup *toolchainv1alpha1.UserS
 	if found {
 		fscore, parseErr := strconv.ParseFloat(captchaScore, 32)
 		if parseErr == nil && float32(fscore) < cfg.Verification().CaptchaRequiredScore() {
-			log.Info(ctx, "captcha score %v is too low, automatic verification disabled, manual approval required for user", float32(fscore))
+			log.Info(ctx, fmt.Sprintf("captcha score %v is too low, automatic verification disabled, manual approval required for user", float32(fscore)))
 			return crterrors.NewForbiddenError("verification failed", "verification is not available at this time")
 		}
 	}

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -231,7 +231,7 @@ func (s *ServiceImpl) VerifyPhoneCode(ctx *gin.Context, userID, username, code s
 	// require manual approval if captcha score below automatic verification threshold
 	captchaScore, found := signup.Annotations[toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey]
 	fscore, parseErr := strconv.ParseFloat(captchaScore, 32)
-	if found && parseErr == nil && fscore < 0.6 {
+	if found && parseErr == nil && float32(fscore) < cfg.Verification().AutomaticVerificationThreshold() {
 		log.Error(ctx, errors.New("captcha score too low"), "automatic verification disabled, manual approval required for user")
 		return crterrors.NewForbiddenError("verification failed", "verification is not available at this time")
 	}

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -357,7 +357,7 @@ func checkRequiredCaptchaScore(ctx *gin.Context, signup *toolchainv1alpha1.UserS
 		fscore, parseErr := strconv.ParseFloat(captchaScore, 32)
 		if parseErr != nil {
 			// let's just log the parsing error and return
-			log.Error(ctx, parseErr, fmt.Sprintf("error while parsing captchaScore"))
+			log.Error(ctx, parseErr, "error while parsing captchaScore")
 			return nil
 		}
 		if parseErr == nil && float32(fscore) < cfg.Verification().CaptchaRequiredScore() {

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -896,41 +896,279 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		require.EqualError(s.T(), err, "parsing time \"ABC\" as \"2006-01-02T15:04:05.000Z07:00\": cannot parse \"ABC\" as \"2006\": error parsing expiry timestamp", err.Error())
 	})
 
-	s.T().Run("when captcha score below automatic verification threshold", func(t *testing.T) {
+	s.T().Run("when allow low score configuration is enabled", func(t *testing.T) {
 
-		userSignup := &toolchainv1alpha1.UserSignup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "123",
-				Namespace: configuration.Namespace(),
-				Annotations: map[string]string{
-					toolchainv1alpha1.UserSignupUserEmailAnnotationKey:        "sbryzak@redhat.com",
-					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:     "0.5",
-					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+		t.Run("captcha score below required score but it's a reactivation", func(t *testing.T) {
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "123",
+					Namespace: configuration.Namespace(),
+					Annotations: map[string]string{
+						toolchainv1alpha1.UserSignupUserEmailAnnotationKey:         "sbryzak@redhat.com",
+						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "2", // user is reactivating
+						toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:    "0",
+						toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:      "0.5", // and captcha score is low
+						toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:  "123456",
+						toolchainv1alpha1.UserVerificationExpiryAnnotationKey:      now.Add(10 * time.Minute).Format(verificationservice.TimestampLayout),
+					},
+					Labels: map[string]string{
+						toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					},
 				},
-				Labels: map[string]string{
-					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username: "sbryzak@redhat.com",
 				},
-			},
-			Spec: toolchainv1alpha1.UserSignupSpec{
-				Username: "sbryzak@redhat.com",
-			},
-		}
-		states.SetVerificationRequired(userSignup, true)
+			}
+			states.SetVerificationRequired(userSignup, true)
 
-		err := s.FakeUserSignupClient.Delete(userSignup.Name, nil)
-		require.NoError(s.T(), err)
+			err := s.FakeUserSignupClient.Delete(userSignup.Name, nil)
+			require.NoError(s.T(), err)
 
-		err = s.FakeUserSignupClient.Tracker.Add(userSignup)
-		require.NoError(s.T(), err)
+			err = s.FakeUserSignupClient.Tracker.Add(userSignup)
+			require.NoError(s.T(), err)
 
-		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err = s.Application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
-		require.EqualError(s.T(), err, "verification failed: verification is not available at this time")
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			err = s.Application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
+			require.NoError(s.T(), err)
 
-		_, err = s.FakeUserSignupClient.Get(userSignup.Name)
-		require.NoError(s.T(), err)
+			userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
+			require.NoError(s.T(), err)
+
+			require.False(s.T(), states.VerificationRequired(userSignup))
+		})
+
+		t.Run("captcha score below required score but it's not a reactivation", func(t *testing.T) {
+
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "123",
+					Namespace: configuration.Namespace(),
+					Annotations: map[string]string{
+						toolchainv1alpha1.UserSignupUserEmailAnnotationKey:         "sbryzak@redhat.com",
+						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "1", // first time user
+						toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:    "0",
+						toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:      "0.5", // and captcha score is low
+						toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:  "123456",
+						toolchainv1alpha1.UserVerificationExpiryAnnotationKey:      now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					},
+					Labels: map[string]string{
+						toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					},
+				},
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username: "sbryzak@redhat.com",
+				},
+			}
+			states.SetVerificationRequired(userSignup, true)
+
+			err := s.FakeUserSignupClient.Delete(userSignup.Name, nil)
+			require.NoError(s.T(), err)
+
+			err = s.FakeUserSignupClient.Tracker.Add(userSignup)
+			require.NoError(s.T(), err)
+
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			err = s.Application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
+			require.EqualError(s.T(), err, "verification failed: verification is not available at this time")
+
+			_, err = s.FakeUserSignupClient.Get(userSignup.Name)
+			require.NoError(s.T(), err)
+		})
+
+		t.Run("activation counter is invalid and captcha score is low", func(t *testing.T) {
+
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "123",
+					Namespace: configuration.Namespace(),
+					Annotations: map[string]string{
+						toolchainv1alpha1.UserSignupUserEmailAnnotationKey:         "sbryzak@redhat.com",
+						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "x", // something wrong happend
+						toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:    "0",
+						toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:      "0.5", // and captcha score is low
+						toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:  "123456",
+						toolchainv1alpha1.UserVerificationExpiryAnnotationKey:      now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					},
+					Labels: map[string]string{
+						toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					},
+				},
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username: "sbryzak@redhat.com",
+				},
+			}
+			states.SetVerificationRequired(userSignup, true)
+
+			err := s.FakeUserSignupClient.Delete(userSignup.Name, nil)
+			require.NoError(s.T(), err)
+
+			err = s.FakeUserSignupClient.Tracker.Add(userSignup)
+			require.NoError(s.T(), err)
+
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			err = s.Application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
+			require.EqualError(s.T(), err, "verification failed: verification is not available at this time")
+
+			_, err = s.FakeUserSignupClient.Get(userSignup.Name)
+			require.NoError(s.T(), err)
+		})
+
+		t.Run("activation counter is invalid and captcha score is ok", func(t *testing.T) {
+
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "123",
+					Namespace: configuration.Namespace(),
+					Annotations: map[string]string{
+						toolchainv1alpha1.UserSignupUserEmailAnnotationKey:         "sbryzak@redhat.com",
+						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "x", // something wrong happend
+						toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:    "0",
+						toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:      "0.6", // and captcha score is ok
+						toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:  "123456",
+						toolchainv1alpha1.UserVerificationExpiryAnnotationKey:      now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					},
+					Labels: map[string]string{
+						toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					},
+				},
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username: "sbryzak@redhat.com",
+				},
+			}
+			states.SetVerificationRequired(userSignup, true)
+
+			err := s.FakeUserSignupClient.Delete(userSignup.Name, nil)
+			require.NoError(s.T(), err)
+
+			err = s.FakeUserSignupClient.Tracker.Add(userSignup)
+			require.NoError(s.T(), err)
+
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			err = s.Application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
+			require.NoError(s.T(), err)
+
+			userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
+			require.NoError(s.T(), err)
+
+			require.False(s.T(), states.VerificationRequired(userSignup))
+		})
+	})
+
+	s.T().Run("when allow low score configuration is disabled", func(t *testing.T) {
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().Verification().CaptchaAllowLowScoreReactivation(false),
+		)
+
+		t.Run("captcha score below required score and it's a reactivation", func(t *testing.T) {
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "123",
+					Namespace: configuration.Namespace(),
+					Annotations: map[string]string{
+						toolchainv1alpha1.UserSignupUserEmailAnnotationKey:         "sbryzak@redhat.com",
+						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "2", // user is reactivating
+						toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:    "0",
+						toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:      "0.5", // and captcha score is low
+						toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:  "123456",
+						toolchainv1alpha1.UserVerificationExpiryAnnotationKey:      now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					},
+					Labels: map[string]string{
+						toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					},
+				},
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username: "sbryzak@redhat.com",
+				},
+			}
+			states.SetVerificationRequired(userSignup, true)
+
+			err := s.FakeUserSignupClient.Tracker.Add(userSignup)
+			require.NoError(s.T(), err)
+
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			err = s.Application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
+			require.EqualError(s.T(), err, "verification failed: verification is not available at this time")
+
+			_, err = s.FakeUserSignupClient.Get(userSignup.Name)
+			require.NoError(s.T(), err)
+		})
+
+		t.Run("captcha score below required score and it's not a reactivation", func(t *testing.T) {
+
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "123",
+					Namespace: configuration.Namespace(),
+					Annotations: map[string]string{
+						toolchainv1alpha1.UserSignupUserEmailAnnotationKey:         "sbryzak@redhat.com",
+						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "1", // first time user
+						toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:    "0",
+						toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:      "0.5", // and captcha score is low
+						toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:  "123456",
+						toolchainv1alpha1.UserVerificationExpiryAnnotationKey:      now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					},
+					Labels: map[string]string{
+						toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					},
+				},
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username: "sbryzak@redhat.com",
+				},
+			}
+			states.SetVerificationRequired(userSignup, true)
+
+			err := s.FakeUserSignupClient.Delete(userSignup.Name, nil)
+			require.NoError(s.T(), err)
+
+			err = s.FakeUserSignupClient.Tracker.Add(userSignup)
+			require.NoError(s.T(), err)
+
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			err = s.Application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
+			require.EqualError(s.T(), err, "verification failed: verification is not available at this time")
+
+			_, err = s.FakeUserSignupClient.Get(userSignup.Name)
+			require.NoError(s.T(), err)
+		})
+
+		t.Run("captcha score is ok", func(t *testing.T) {
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "123",
+					Namespace: configuration.Namespace(),
+					Annotations: map[string]string{
+						toolchainv1alpha1.UserSignupUserEmailAnnotationKey:         "sbryzak@redhat.com",
+						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "1", // first time user
+						toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:    "0",
+						toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:      "0.6", // and captcha score is ok
+						toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:  "123456",
+						toolchainv1alpha1.UserVerificationExpiryAnnotationKey:      now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
+					},
+					Labels: map[string]string{
+						toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
+					},
+				},
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username: "sbryzak@redhat.com",
+				},
+			}
+			states.SetVerificationRequired(userSignup, true)
+
+			err := s.FakeUserSignupClient.Delete(userSignup.Name, nil)
+			require.NoError(s.T(), err)
+
+			err = s.FakeUserSignupClient.Tracker.Add(userSignup)
+			require.NoError(s.T(), err)
+
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			err = s.Application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.Username, "123456")
+			require.NoError(s.T(), err)
+
+			userSignup, err = s.FakeUserSignupClient.Get(userSignup.Name)
+			require.NoError(s.T(), err)
+
+			require.False(s.T(), states.VerificationRequired(userSignup))
+		})
 	})
 }
 

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -983,7 +983,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 					Namespace: configuration.Namespace(),
 					Annotations: map[string]string{
 						toolchainv1alpha1.UserSignupUserEmailAnnotationKey:         "sbryzak@redhat.com",
-						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "x", // something wrong happend
+						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "x", // something wrong happened
 						toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:    "0",
 						toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:      "0.5", // and captcha score is low
 						toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:  "123456",
@@ -1021,7 +1021,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 					Namespace: configuration.Namespace(),
 					Annotations: map[string]string{
 						toolchainv1alpha1.UserSignupUserEmailAnnotationKey:         "sbryzak@redhat.com",
-						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "x", // something wrong happend
+						toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "x", // something wrong happened
 						toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:    "0",
 						toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:      "0.6", // and captcha score is ok
 						toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:  "123456",

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -959,6 +959,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 			t.Run(k, func(t *testing.T) {
 				// when
 				s.OverrideApplicationDefault(
+					testconfig.RegistrationService().Verification().CaptchaRequiredScore("0.6"),
 					testconfig.RegistrationService().Verification().CaptchaAllowLowScoreReactivation(tc.allowLowScoreConfiguration),
 				)
 				userSignup := &toolchainv1alpha1.UserSignup{

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -954,11 +954,16 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 				allowLowScoreReactivationConfiguration: true,
 				// no error is expected in this case and the verification should proceed
 			},
-			"no activation counter annotation": {
+			"no activation counter annotation and low captcha score": {
 				activationCounterAnnotationValue:       "",    // activation counter is missing thus required score will be compared with captcha score
 				captchaScoreAnnotationValue:            "0.5", // score is low thus verification will fail
 				allowLowScoreReactivationConfiguration: true,
 				expectedErr:                            "verification failed: verification is not available at this time",
+			},
+			"no activation counter annotation and captcha score ok": {
+				activationCounterAnnotationValue:       "",    // activation counter is missing thus required score will be compared with captcha score
+				captchaScoreAnnotationValue:            "0.6", // score is ok thus verification will succeed
+				allowLowScoreReactivationConfiguration: true,
 			},
 		}
 		for k, tc := range tests {


### PR DESCRIPTION
Use new configuration options:
- `toolchainconfig.Spec.Host.RegistrationService.Verification.Captcha.RequiredScore` which blocks usersginup below this value (if it's not a reactivation)
- `toolchainconfig.Spec.Host.RegistrationService.Verification.Captcha. AllowLowScoreReactivation` is enabled by default and allows reactivations to proceed even when captcha score is below the configured `RequiredScore`.

Related PR:
- toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/344
- sandbox-sre: https://github.com/codeready-toolchain/sandbox-sre/pull/1348

Jira: https://issues.redhat.com/browse/SANDBOX-495 