### PR TITLE
check substrings of GH comments to run PR CD workflow

### DIFF
--- a/.github/workflows/publish-operators-for-e2e-tests.yml
+++ b/.github/workflows/publish-operators-for-e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build & push operator bundles for e2e tests
 
     runs-on: ubuntu-20.04
-    if: ${{ github.event.comment == '' || github.event.comment.body == '/retest' || github.event.comment.body == '/test all' || github.event.comment.body == '/test e2e' }}
+    if: ${{ github.event.comment == '' || contains(github.event.comment.body, '/retest') || contains(github.event.comment.body, '/test all') || contains(github.event.comment.body, '/test e2e') }}
     steps:
     # Checkout from PR event - in that case the comment field is empty
     - name: Checkout code from PR event


### PR DESCRIPTION
let's look for substrings instead of matching the whole content of the comment
https://redhat-internal.slack.com/archives/CHK0J6HT6/p1706068576169849