### PR TITLE
Minor: Fix outdated reference to username on call to GetSignup

### DIFF
--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -408,7 +408,7 @@ func (s *ServiceImpl) DoGetSignup(ctx *gin.Context, provider ResourceProvider, u
 
 	signupResponse := &signup.Signup{
 		Name:     userSignup.GetName(),
-		Username: userSignup.Spec.Username,
+		Username: userSignup.Spec.IdentityClaims.PreferredUsername,
 	}
 	if userSignup.Status.CompliantUsername != "" {
 		signupResponse.CompliantUsername = userSignup.Status.CompliantUsername


### PR DESCRIPTION
This PR fixes an outdated reference to the old UserSignup.Spec.Username property.