### PR TITLE
Optimize binary

### DIFF
--- a/make/build.mk
+++ b/make/build.mk
@@ -3,7 +3,7 @@ GO_PACKAGE_ORG_NAME ?= codeready-toolchain
 GO_PACKAGE_REPO_NAME ?= $(shell basename $$PWD)
 GO_PACKAGE_PATH ?= github.com/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}
 
-export LDFLAGS=-ldflags "-X ${GO_PACKAGE_PATH}/pkg/configuration.Commit=${GIT_COMMIT_ID} -X ${GO_PACKAGE_PATH}/pkg/configuration.BuildTime=${BUILD_TIME}"
+export LDFLAGS=-ldflags "-X ${GO_PACKAGE_PATH}/pkg/configuration.Commit=${GIT_COMMIT_ID} -X ${GO_PACKAGE_PATH}/pkg/configuration.BuildTime=${BUILD_TIME} -s -w"
 goarch ?= $(shell go env GOARCH)
 
 .PHONY: build build-prod build-dev
@@ -25,7 +25,7 @@ build-dev:
 ## builds production binary
 build-prod: check-template-changes
 	$(Q)CGO_ENABLED=0 GOARCH=${goarch} GOOS=linux \
-		go build ${V_FLAG} ${LDFLAGS} \
+		go build ${V_FLAG} ${LDFLAGS} -trimpath \
 		-o $(OUT_DIR)/bin/registration-service \
 		cmd/main.go
 

--- a/make/build.mk
+++ b/make/build.mk
@@ -3,7 +3,7 @@ GO_PACKAGE_ORG_NAME ?= codeready-toolchain
 GO_PACKAGE_REPO_NAME ?= $(shell basename $$PWD)
 GO_PACKAGE_PATH ?= github.com/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}
 
-export LDFLAGS=-ldflags "-X ${GO_PACKAGE_PATH}/pkg/configuration.Commit=${GIT_COMMIT_ID} -X ${GO_PACKAGE_PATH}/pkg/configuration.BuildTime=${BUILD_TIME} -s -w"
+export LDFLAGS=-X ${GO_PACKAGE_PATH}/pkg/configuration.Commit=${GIT_COMMIT_ID} -X ${GO_PACKAGE_PATH}/pkg/configuration.BuildTime=${BUILD_TIME}
 goarch ?= $(shell go env GOARCH)
 
 .PHONY: build build-prod build-dev
@@ -16,7 +16,7 @@ build: build-prod
 ## builds development binary
 build-dev:
 	$(Q)CGO_ENABLED=0 GOARCH=${goarch} GOOS=linux \
-		go build ${V_FLAG} ${LDFLAGS} \
+		go build ${V_FLAG} -ldflags="${LDFLAGS}" \
 		-tags dev \
 		-o $(OUT_DIR)/bin/registration-service \
 		cmd/main.go
@@ -25,7 +25,7 @@ build-dev:
 ## builds production binary
 build-prod: check-template-changes
 	$(Q)CGO_ENABLED=0 GOARCH=${goarch} GOOS=linux \
-		go build ${V_FLAG} ${LDFLAGS} -trimpath \
+		go build ${V_FLAG} -ldflags="${LDFLAGS} -s -w" -trimpath \
 		-o $(OUT_DIR)/bin/registration-service \
 		cmd/main.go
 


### PR DESCRIPTION
Removes DWARF and symbol tables from the binary. From [https://pkg.go.dev/cmd/link](https://pkg.go.dev/cmd/link):
- `-s`: Omit the symbol table and debug information
- `-w`: Omit the DWARF symbol table.

Also trims the path in panics so they will start from project's local folder. From [https://pkg.go.dev/cmd/go](https://pkg.go.dev/cmd/go):
- `trimpath`: remove all file system paths from the resulting executable. Instead of absolute file system paths, the recorded file names will begin either a module path@version (when using modules), or a plain import path (when using the standard library, or GOPATH).

As a result binary size is reduced from 63MB to 45MB, and binary inspection and debug are prevented.