### PR TITLE
KSPACE-43: Adding common GetClusters func

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -101,7 +101,7 @@ func main() {
 	// this will speed up the first request
 	cacheLog := controllerlog.Log.WithName("registration-service")
 	cluster.NewToolchainClusterService(cl, cacheLog, configuration.Namespace(), 5*time.Second)
-	cluster.GetMemberClusters()
+	cluster.GetClusters()
 
 	_, err = auth.InitializeDefaultTokenParser()
 	if err != nil {
@@ -114,7 +114,7 @@ func main() {
 	metricsSrv := proxyMetrics.StartMetricsServer()
 
 	// Start the proxy server
-	p, err := proxy.NewProxy(app, proxyMetrics, cluster.GetMemberClusters)
+	p, err := proxy.NewProxy(app, proxyMetrics, cluster.GetClusters)
 	if err != nil {
 		panic(errs.Wrap(err, "failed to create proxy"))
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/codeready-toolchain/registration-service
 
 go 1.20
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240314072551-61beb0c3429f
+
 require (
 	github.com/aws/aws-sdk-go v1.44.100
 	github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87
@@ -146,3 +148,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,6 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87 h1:eQLsrMqfjAzGfuO9t6pVxO4K6cUDKOMxEvl0ujQq/2I=
 github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240313081501-5cafefaa6598 h1:06nit/nCQFVKp51ZtIOyY49ncmxEK5shJGTaM+Ogicw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240313081501-5cafefaa6598/go.mod h1:c2JxboVI7keMD5fx5bB7LwzowFYYTwbepJhzPWSYXVs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -143,6 +141,8 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
+github.com/fbm3307/toolchain-common v0.0.0-20240314072551-61beb0c3429f h1:TcxrjEm61AiEQsZAzMJkVJJTQ15I/9zsKnjwOgZIFHA=
+github.com/fbm3307/toolchain-common v0.0.0-20240314072551-61beb0c3429f/go.mod h1:gTXxfr21LX9fQeldm16BhVbLJPSU1D4mbhHQd4S3ZiQ=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=

--- a/pkg/proxy/handlers/spacelister_get.go
+++ b/pkg/proxy/handlers/spacelister_get.go
@@ -23,7 +23,7 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func HandleSpaceGetRequest(spaceLister *SpaceLister, GetMembersFunc cluster.GetMemberClustersFunc) echo.HandlerFunc {
+func HandleSpaceGetRequest(spaceLister *SpaceLister, GetMembersFunc cluster.GetClustersFunc) echo.HandlerFunc {
 	// get specific workspace
 	return func(ctx echo.Context) error {
 		requestReceivedTime := ctx.Get(regsercontext.RequestReceivedTime).(time.Time)
@@ -88,7 +88,7 @@ func GetUserWorkspace(ctx echo.Context, spaceLister *SpaceLister, workspaceName 
 }
 
 // GetUserWorkspaceWithBindings returns a workspace object with the required fields+bindings (the list with all the users access details)
-func GetUserWorkspaceWithBindings(ctx echo.Context, spaceLister *SpaceLister, workspaceName string, GetMembersFunc cluster.GetMemberClustersFunc) (*toolchainv1alpha1.Workspace, error) {
+func GetUserWorkspaceWithBindings(ctx echo.Context, spaceLister *SpaceLister, workspaceName string, GetMembersFunc cluster.GetClustersFunc) (*toolchainv1alpha1.Workspace, error) {
 	userSignup, space, err := getUserSignupAndSpace(ctx, spaceLister, workspaceName)
 	if err != nil {
 		return nil, err
@@ -165,7 +165,7 @@ func getUserSignupAndSpace(ctx echo.Context, spaceLister *SpaceLister, workspace
 }
 
 // listSpaceBindingRequestsForSpace searches for the SpaceBindingRequests in all the provisioned namespaces for the given Space
-func listSpaceBindingRequestsForSpace(ctx echo.Context, GetMembersFunc cluster.GetMemberClustersFunc, space *toolchainv1alpha1.Space) ([]toolchainv1alpha1.SpaceBindingRequest, error) {
+func listSpaceBindingRequestsForSpace(ctx echo.Context, GetMembersFunc cluster.GetClustersFunc, space *toolchainv1alpha1.Space) ([]toolchainv1alpha1.SpaceBindingRequest, error) {
 	members := GetMembersFunc()
 	if len(members) == 0 {
 		return nil, errs.New("no member clusters found")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -68,10 +68,10 @@ type Proxy struct {
 	tokenParser    *auth.TokenParser
 	spaceLister    *handlers.SpaceLister
 	metrics        *metrics.ProxyMetrics
-	getMembersFunc commoncluster.GetMemberClustersFunc
+	getMembersFunc commoncluster.GetClustersFunc
 }
 
-func NewProxy(app application.Application, proxyMetrics *metrics.ProxyMetrics, getMembersFunc commoncluster.GetMemberClustersFunc) (*Proxy, error) {
+func NewProxy(app application.Application, proxyMetrics *metrics.ProxyMetrics, getMembersFunc commoncluster.GetClustersFunc) (*Proxy, error) {
 	cl, err := newClusterClient()
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func NewProxy(app application.Application, proxyMetrics *metrics.ProxyMetrics, g
 	return newProxyWithClusterClient(app, cl, proxyMetrics, getMembersFunc)
 }
 
-func newProxyWithClusterClient(app application.Application, cln client.Client, proxyMetrics *metrics.ProxyMetrics, getMembersFunc commoncluster.GetMemberClustersFunc) (*Proxy, error) {
+func newProxyWithClusterClient(app application.Application, cln client.Client, proxyMetrics *metrics.ProxyMetrics, getMembersFunc commoncluster.GetClustersFunc) (*Proxy, error) {
 	tokenParser, err := auth.DefaultTokenParser()
 	if err != nil {
 		return nil, err

--- a/pkg/proxy/service/cluster_service.go
+++ b/pkg/proxy/service/cluster_service.go
@@ -25,14 +25,14 @@ type Option func(f *ServiceImpl)
 // ServiceImpl represents the implementation of the member cluster service.
 type ServiceImpl struct { // nolint:revive
 	base.BaseService
-	GetMembersFunc cluster.GetMemberClustersFunc
+	GetMembersFunc cluster.GetClustersFunc
 }
 
 // NewMemberClusterService creates a service object for performing toolchain cluster related activities.
 func NewMemberClusterService(context servicecontext.ServiceContext, options ...Option) service.MemberClusterService {
 	si := &ServiceImpl{
 		BaseService:    base.NewBaseService(context),
-		GetMembersFunc: cluster.GetMemberClusters,
+		GetMembersFunc: cluster.GetClusters,
 	}
 	for _, o := range options {
 		o(si)

--- a/pkg/proxy/test/clusteraccess.go
+++ b/pkg/proxy/test/clusteraccess.go
@@ -6,7 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewGetMembersFunc(fakeClient client.Client) commoncluster.GetMemberClustersFunc {
+func NewGetMembersFunc(fakeClient client.Client) commoncluster.GetClustersFunc {
 	return func(_ ...commoncluster.Condition) []*commoncluster.CachedToolchainCluster {
 		return []*commoncluster.CachedToolchainCluster{
 			{


### PR DESCRIPTION
Adding a new common function GetClusters() to fetch the clusters from cache as we have dropped the cluster type as per changes in toolchain-common

Related PRs
Toolchain-common - https://github.com/codeready-toolchain/toolchain-common/pull/372