### PR TITLE
fix LabelSelector forwarding in fake/informer

### DIFF
--- a/test/fake/informer.go
+++ b/test/fake/informer.go
@@ -209,12 +209,8 @@ func GetInformerService(fakeClient client.Client, options ...InformerServiceOpti
 			return space, err
 		}
 		inf.ListSpaceBindingFunc = func(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
-			labelMatch := client.MatchingLabels{}
-			for _, r := range reqs {
-				labelMatch[r.Key()] = r.Values().List()[0]
-			}
 			sbList := &toolchainv1alpha1.SpaceBindingList{}
-			err := fakeClient.List(context.TODO(), sbList, labelMatch)
+			err := fakeClient.List(context.TODO(), sbList, &client.ListOptions{LabelSelector: labels.NewSelector().Add(reqs...)})
 			return sbList.Items, err
 		}
 		inf.GetNSTemplateTierFunc = func(tier string) (*toolchainv1alpha1.NSTemplateTier, error) {


### PR DESCRIPTION
I was not able to obtain the correct result when using a LabelSelector with multiple values, like the one in the following snippet:

```golang
func listSpaceBindingsForUsers(spaceLister *SpaceLister, murNames []string) ([]toolchainv1alpha1.SpaceBinding, error) {
       mursSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey, selection.In, murNames)
        if err != nil {
                return nil, err
        }
	return spaceLister.GetInformerServiceFunc().ListSpaceBindings(*mursSelector)
}
```

This change solved the problem. 