### PR TITLE
Split ci-build.yml

### DIFF
--- a/.github/workflows/ci-golang-sbom.yml
+++ b/.github/workflows/ci-golang-sbom.yml
@@ -1,0 +1,44 @@
+name: ci-build
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '*.*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  golangci:
+    name: GolangCI Lint
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.20.x
+        
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Lint
+      uses: golangci/golangci-lint-action@v4
+      with:
+        version: v1.56.2
+        skip-pkg-cache: true
+        skip-build-cache: true
+        args: --config=./.golangci.yml --verbose
+
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Generate SBOM
+      uses: CycloneDX/gh-gomod-generate-sbom@v2
+      with:
+        version: v1
+        args: mod -licenses -json -output -

--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -39,36 +39,3 @@ jobs:
         flags: unittests # optional
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)
-    
-  golangci:
-    name: GolangCI Lint
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.20.x
-        
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Lint
-      uses: golangci/golangci-lint-action@v4
-      with:
-        version: v1.56.2
-        skip-pkg-cache: true
-        skip-build-cache: true
-        args: --config=./.golangci.yml --verbose
-
-  sbom:
-    name: Generate SBOM
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Generate SBOM
-      uses: CycloneDX/gh-gomod-generate-sbom@v2
-      with:
-        version: v1
-        args: mod -licenses -json -output -


### PR DESCRIPTION
split the ci-build.yml file into following two files

test-with-coverage.yml
ci-golang-sbom.yml
By updating pull_request_target to have tokens the workflow automatically checks out the code from master and not from PR.
This fix is needed only for the tests to upload codecov report, not for linters and hence spliting the workflow