### PR TITLE
KUBESAW-43: Replace the special ToolchainClusterCondition with the standard toolchain Condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,13 @@ module github.com/codeready-toolchain/registration-service
 
 go 1.20
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20240507023248-73662d6db2c5
+	github.com/codeready-toolchain/api v0.0.0-20240514085958-3b5237399fe5
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240507174147-ed50ce546b3c
 	github.com/go-logr/logr v1.2.3
 	github.com/gofrs/uuid v4.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/codeready-toolchain/registration-service
 
 go 1.20
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,10 @@ module github.com/codeready-toolchain/registration-service
 
 go 1.20
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac
-
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20240514085958-3b5237399fe5
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20240507174147-ed50ce546b3c
+	github.com/codeready-toolchain/api v0.0.0-20240530120602-c11598ccffb7
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20240530121312-98aad712838f
 	github.com/go-logr/logr v1.2.3
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/codeready-toolchain/registration-service
 
 go 1.20
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/codeready-toolchain/registration-service
 
 go 1.20
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/codeready-toolchain/registration-service
 
 go 1.20
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,13 @@ module github.com/codeready-toolchain/registration-service
 
 go 1.20
 
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8
+
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20240322110702-5ab3840476e9
+	github.com/codeready-toolchain/api v0.0.0-20240424103940-03edc96d88fb
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240422084400-e6d41ea74313
 	github.com/go-logr/logr v1.2.3
 	github.com/gofrs/uuid v4.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,10 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
-github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e h1:Qkw0QZ3//P6pLL+9JpFSXJe62Inz4kH2PF+ssXzhIlg=
-github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e/go.mod h1:edqvWcRWzUJzCR7C5jDgK9/E4uitru0DhrFSxSunAjI=
-github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7 h1:iH+MPU2iq6KN6v161Y0VrlEfp1gyz6zEBDjFkGDwHRU=
-github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70 h1:bXkUar0zqhEjnWkrmcWAuRVh4Kzl5Og//XJ2APnFjOI=
+github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70/go.mod h1:CEYP+kvf4ckNVUocGJHTQNKAOwg21Dy2JtEUlYqSGic=
+github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b h1:fF3V9dFDmZCzbV2rWkII7b/LJ9hj5yL2zR0vdaXzeK4=
+github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,10 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
-github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e h1:0ebS34Y5ft2u7ixBqjWWxSewjnKUnaPUE5aNW88njho=
-github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e/go.mod h1:ykixqKPvSfpASeqwV2U5UASl1J566MfsQz3eCUmgwZc=
-github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f h1:SU/YIxkyXbvXfZMLsxdHb71X0Bs3WHe6vfev9N25VUI=
-github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e h1:Qkw0QZ3//P6pLL+9JpFSXJe62Inz4kH2PF+ssXzhIlg=
+github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e/go.mod h1:edqvWcRWzUJzCR7C5jDgK9/E4uitru0DhrFSxSunAjI=
+github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7 h1:iH+MPU2iq6KN6v161Y0VrlEfp1gyz6zEBDjFkGDwHRU=
+github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,10 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
-github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70 h1:bXkUar0zqhEjnWkrmcWAuRVh4Kzl5Og//XJ2APnFjOI=
-github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70/go.mod h1:CEYP+kvf4ckNVUocGJHTQNKAOwg21Dy2JtEUlYqSGic=
-github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b h1:fF3V9dFDmZCzbV2rWkII7b/LJ9hj5yL2zR0vdaXzeK4=
-github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac h1:WbOV613ZMtm/wzx1OOoDz7SiNgzlgN4KGusVL8vnMig=
+github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac/go.mod h1:D/yFnVW7yM+OhIMDY5H/7jGZGlKIgaeTkiA4F5DIc4g=
+github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69 h1:WiMpRk3NnsEeCVzQzD2gzc2EFx15eWCrkdfmGeG2ltU=
+github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,10 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/codeready-toolchain/api v0.0.0-20240530120602-c11598ccffb7 h1:o5JLcHCVS1BlZevw2mh1mH+iKwn9fLUrT1Ek8NFjvPY=
+github.com/codeready-toolchain/api v0.0.0-20240530120602-c11598ccffb7/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20240530121312-98aad712838f h1:2qfRfyh7wfEnnfxrUtQeQrvhzWlkBCN0B/UXv1YUMiA=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20240530121312-98aad712838f/go.mod h1:cyHrUfvBYEtsf+FbqQYmR9y0AQi9QAVtM3SUWLA5bd4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -139,10 +143,6 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
-github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac h1:WbOV613ZMtm/wzx1OOoDz7SiNgzlgN4KGusVL8vnMig=
-github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac/go.mod h1:D/yFnVW7yM+OhIMDY5H/7jGZGlKIgaeTkiA4F5DIc4g=
-github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69 h1:WiMpRk3NnsEeCVzQzD2gzc2EFx15eWCrkdfmGeG2ltU=
-github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,10 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
-github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881 h1:nIXhnL4y4YUIvUlYUcVWBUeItv+xoNZHOh/81czSlww=
-github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881/go.mod h1:iPQiIf6G5qBnt6gMIR1GhThqPmvMST/QmotIrm15E2A=
-github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf h1:s2k7giZJOHA3EYRya8EqqbkUl4vHJYG2s5g2XL4Eezo=
-github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e h1:0ebS34Y5ft2u7ixBqjWWxSewjnKUnaPUE5aNW88njho=
+github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e/go.mod h1:ykixqKPvSfpASeqwV2U5UASl1J566MfsQz3eCUmgwZc=
+github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f h1:SU/YIxkyXbvXfZMLsxdHb71X0Bs3WHe6vfev9N25VUI=
+github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=

--- a/go.sum
+++ b/go.sum
@@ -115,10 +115,6 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/codeready-toolchain/api v0.0.0-20240322110702-5ab3840476e9 h1:Lm7bFLrzfJzrUiRGVqtsSaZMpj+akLiR/fvAFjjE9gM=
-github.com/codeready-toolchain/api v0.0.0-20240322110702-5ab3840476e9/go.mod h1:cfNN6YPX4TORvhhZXMSjSPesqAHlB3nD/WAfGe4WLKQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240422084400-e6d41ea74313 h1:UuLjLbn8Rh1QX8jyLipAtaZ3o25Ard33B2+DCcmJLsQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240422084400-e6d41ea74313/go.mod h1:rfVQhC9ctteNi2vbg300fgD0zgTfk/h3qjW9nsCayFs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -143,6 +139,10 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
+github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8 h1:PVui6JJ8qnZJwO4tZMmNbS6j8iOIRyhNMt6XJfP2Oos=
+github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8/go.mod h1:XM/GvevqWYzwWrIqEkRyoImGnRY+R6uIyVJ5mkVqO7k=
+github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967 h1:6NHrU9WNkeCnAniKFUb6YhUxKkccYidj5fD/yY912y0=
+github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,10 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
-github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8 h1:PVui6JJ8qnZJwO4tZMmNbS6j8iOIRyhNMt6XJfP2Oos=
-github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8/go.mod h1:XM/GvevqWYzwWrIqEkRyoImGnRY+R6uIyVJ5mkVqO7k=
-github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967 h1:6NHrU9WNkeCnAniKFUb6YhUxKkccYidj5fD/yY912y0=
-github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881 h1:nIXhnL4y4YUIvUlYUcVWBUeItv+xoNZHOh/81czSlww=
+github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881/go.mod h1:iPQiIf6G5qBnt6gMIR1GhThqPmvMST/QmotIrm15E2A=
+github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf h1:s2k7giZJOHA3EYRya8EqqbkUl4vHJYG2s5g2XL4Eezo=
+github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=


### PR DESCRIPTION
This is just updating the dependency of API , Toolchain Common
This is to replace the special ToolchainClusterCondition with the standard toolchain Condition

This is Related to Change in

- API - https://github.com/codeready-toolchain/api/pull/416
- Toolchain-Common - https://github.com/codeready-toolchain/toolchain-common/pull/391
- Member-Operator - https://github.com/codeready-toolchain/member-operator/pull/560
- Toolchain-E2E - https://github.com/codeready-toolchain/toolchain-e2e/pull/955
- Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1017
- KSCTL - https://github.com/kubesaw/ksctl/pull/38

Only change is updating the dependency of API and toolchain-common

- Sandbox-SRE - https://github.com/codeready-toolchain/sandbox-sre/pull/1706