### PR TITLE
proposal: simplify labels.Requirement creation

### DIFF
--- a/pkg/proxy/handlers/spacelister_get.go
+++ b/pkg/proxy/handlers/spacelister_get.go
@@ -19,7 +19,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/selection"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -56,15 +55,9 @@ func GetUserWorkspace(ctx echo.Context, spaceLister *SpaceLister, workspaceName 
 
 	// recursively get all the spacebindings for the current workspace
 	listSpaceBindingsFunc := func(spaceName string) ([]toolchainv1alpha1.SpaceBinding, error) {
-		spaceSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingSpaceLabelKey, selection.Equals, []string{spaceName})
-		if err != nil {
-			return nil, err
-		}
-		murSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey, selection.Equals, []string{userSignup.CompliantUsername})
-		if err != nil {
-			return nil, err
-		}
-		return spaceLister.GetInformerServiceFunc().ListSpaceBindings(*spaceSelector, *murSelector)
+		spaceSelector, _ := labels.SelectorFromSet(labels.Set{toolchainv1alpha1.SpaceBindingSpaceLabelKey: spaceName}).Requirements()
+		murSelector, _ := labels.SelectorFromSet(labels.Set{toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: userSignup.CompliantUsername}).Requirements()
+		return spaceLister.GetInformerServiceFunc().ListSpaceBindings(spaceSelector[0], murSelector[0])
 	}
 	spaceBindingLister := spacebinding.NewLister(listSpaceBindingsFunc, spaceLister.GetInformerServiceFunc().GetSpace)
 	userSpaceBindings, err := spaceBindingLister.ListForSpace(space, []toolchainv1alpha1.SpaceBinding{})
@@ -100,11 +93,8 @@ func GetUserWorkspaceWithBindings(ctx echo.Context, spaceLister *SpaceLister, wo
 
 	// recursively get all the spacebindings for the current workspace
 	listSpaceBindingsFunc := func(spaceName string) ([]toolchainv1alpha1.SpaceBinding, error) {
-		spaceSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingSpaceLabelKey, selection.Equals, []string{spaceName})
-		if err != nil {
-			return nil, err
-		}
-		return spaceLister.GetInformerServiceFunc().ListSpaceBindings(*spaceSelector)
+		ss, _ := labels.SelectorFromSet(labels.Set{toolchainv1alpha1.SpaceBindingSpaceLabelKey: spaceName}).Requirements()
+		return spaceLister.GetInformerServiceFunc().ListSpaceBindings(ss[0])
 	}
 	spaceBindingLister := spacebinding.NewLister(listSpaceBindingsFunc, spaceLister.GetInformerServiceFunc().GetSpace)
 	allSpaceBindings, err := spaceBindingLister.ListForSpace(space, []toolchainv1alpha1.SpaceBinding{})

--- a/pkg/proxy/handlers/spacelister_list.go
+++ b/pkg/proxy/handlers/spacelister_list.go
@@ -14,7 +14,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 )
 
 func HandleSpaceListRequest(spaceLister *SpaceLister) echo.HandlerFunc {
@@ -68,12 +67,8 @@ func listWorkspaceResponse(ctx echo.Context, workspaces []toolchainv1alpha1.Work
 }
 
 func listSpaceBindingsForUser(spaceLister *SpaceLister, murName string) ([]toolchainv1alpha1.SpaceBinding, error) {
-	murSelector, err := labels.NewRequirement(toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey, selection.Equals, []string{murName})
-	if err != nil {
-		return nil, err
-	}
-	requirements := []labels.Requirement{*murSelector}
-	return spaceLister.GetInformerServiceFunc().ListSpaceBindings(requirements...)
+	mrr, _ := labels.SelectorFromSet(labels.Set{toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: murName}).Requirements()
+	return spaceLister.GetInformerServiceFunc().ListSpaceBindings(mrr[0])
 }
 
 func workspacesFromSpaceBindings(ctx echo.Context, spaceLister *SpaceLister, signupName string, spaceBindings []toolchainv1alpha1.SpaceBinding) []toolchainv1alpha1.Workspace {


### PR DESCRIPTION
We can skip validations performed by [labels.NewRequirement](https://pkg.go.dev/k8s.io/apimachinery/pkg/labels#NewRequirement) as operator is fixed, key is constant, and value is extracted from Custom Resources.

> NewRequirement is the constructor for a Requirement. If any of these rules is violated, an error is returned:
>
> 1. The operator can only be In, NotIn, Equals, DoubleEquals, Gt, Lt, NotEquals, Exists, or DoesNotExist.
> 1. If the operator is In or NotIn, the values set must be non-empty.
> 1. If the operator is Equals, DoubleEquals, or NotEquals, the values set must contain one value.
> 1. If the operator is Exists or DoesNotExist, the value set must be empty.
> 1. If the operator is Gt or Lt, the values set must contain only one value, which will be interpreted as an integer.
> 1. The key is invalid due to its length, or sequence of characters. See validateLabelKey for more details.
>
> The empty string is a valid value in the input values set. Returned error, if not nil, is guaranteed to be an aggregated field.ErrorList 

[SelectorFromSet](https://pkg.go.dev/k8s.io/apimachinery/pkg/labels#SelectorFromSet) does not perform any validation, which means the server will reject the request if the Set contains invalid values. 