### PR TITLE
add PublicViewer's middleware

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -118,6 +118,7 @@ func (p *Proxy) StartProxy(port string) *http.Server {
 				return next(ctx)
 			}
 		},
+		p.addPublicViewerContext(),
 	)
 
 	// middleware after routing
@@ -398,6 +399,17 @@ func (p *Proxy) addUserContext() echo.MiddlewareFunc {
 			ctx.Set(context.SubKey, userID)
 			ctx.Set(context.UsernameKey, username)
 
+			return next(ctx)
+		}
+	}
+}
+
+// addPublicViewerContext updates echo.Context with the configuration's PublicViewerEnabled value.
+func (p *Proxy) addPublicViewerContext() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+			publicViewerEnabled := configuration.GetRegistrationServiceConfig().PublicViewerEnabled()
+			ctx.Set(context.PublicViewerEnabled, publicViewerEnabled)
 			return next(ctx)
 		}
 	}


### PR DESCRIPTION
This PR is part of the effort of splitting #443.

This PR introduces the logic to effectively turn on the PublicViewer support and for this reason it should be the latest PR to merge.

Requirements:
- [ ] https://github.com/codeready-toolchain/registration-service/pull/443

Signed-off-by: Francesco Ilario <filario@redhat.com>
