### PR TITLE
SANDBOX-759: increase cache update frequency

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -154,13 +154,13 @@ func main() {
 		}
 	}()
 
-	// update cache every 10 seconds
+	// update cache every 2 seconds
 	go func() {
 		for {
 			if _, err := configuration.ForceLoadRegistrationServiceConfig(cl); err != nil {
 				log.Error(nil, err, "failed to update the configuration cache")
 			}
-			time.Sleep(10 * time.Second)
+			time.Sleep(2 * time.Second)
 		}
 	}()
 


### PR DESCRIPTION
## Description
As a quick fix for flakiness in TestAutomaticApproval (ToolchainConfig isn't updated in regestration-service in the time frame expected which makes TestAutomaticApproval fail because it requires verification of the UserSignup when should not)

Thanks @MatousJobanek!

## Issue ticket number and link
[SANDBOX-759](https://issues.redhat.com/browse/SANDBOX-759)