### PR TITLE
add ToolchainCluster to client cache

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -201,6 +201,7 @@ func newCachedClient(ctx context.Context, cfg *rest.Config) (client.Client, erro
 		"NSTemplateTier":   &toolchainv1alpha1.NSTemplateTierList{},
 		"ToolchainConfig":  &toolchainv1alpha1.ToolchainConfigList{},
 		"BannedUser":       &toolchainv1alpha1.BannedUserList{},
+		"ToolchainCluster": &toolchainv1alpha1.ToolchainClusterList{},
 		"Secret":           &corev1.SecretList{}}
 
 	for resourceName := range objectsToList {


### PR DESCRIPTION
add ToolchainCluster to client cache to match the Role in the registration-service template in host-operator repo. see https://github.com/codeready-toolchain/host-operator/pull/1089