### PR TITLE
Add signup URL to authconfig payload

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -136,7 +136,7 @@ func (r RegistrationServiceConfig) LogLevel() string {
 }
 
 func (r RegistrationServiceConfig) RegistrationServiceURL() string {
-	return commonconfig.GetString(r.cfg.Host.RegistrationService.RegistrationServiceURL, "https://registration.crt-placeholder.com")
+	return commonconfig.GetString(r.cfg.Host.RegistrationService.RegistrationServiceURL, "")
 }
 
 func (r RegistrationServiceConfig) Verification() VerificationConfig {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -43,7 +43,7 @@ func TestRegistrationService(t *testing.T) {
 		// then
 		assert.Equal(t, "prod", regServiceCfg.Environment())
 		assert.Equal(t, "info", regServiceCfg.LogLevel())
-		assert.Equal(t, "https://registration.crt-placeholder.com", regServiceCfg.RegistrationServiceURL())
+		assert.Equal(t, "", regServiceCfg.RegistrationServiceURL())
 		assert.Empty(t, regServiceCfg.Analytics().SegmentWriteKey())
 		assert.Empty(t, regServiceCfg.Analytics().DevSpacesSegmentWriteKey())
 		assert.Equal(t, "https://sso.devsandbox.dev/auth/js/keycloak.js", regServiceCfg.Auth().AuthClientLibraryURL())

--- a/pkg/controller/authconfig.go
+++ b/pkg/controller/authconfig.go
@@ -12,6 +12,9 @@ type configResponse struct {
 	// this holds the raw config. Note: this is intentionally a string
 	// not json as this field may also hold non-json configs!
 	AuthClientConfigRaw string `json:"auth-client-config"`
+	// The signup page URL. After user logs into SSO but has not signed up yet then this URL can be used to redirect the user to
+	// sign up. If not set then the base URL of the registration service is supposed to be used by the clients.
+	SignupURL string `json:"signup-url"`
 }
 
 // AuthConfig implements the auth config endpoint, which is invoked to
@@ -30,6 +33,7 @@ func (ac *AuthConfig) GetHandler(ctx *gin.Context) {
 	configRespData := configResponse{
 		AuthClientLibraryURL: cfg.Auth().AuthClientLibraryURL(),
 		AuthClientConfigRaw:  cfg.Auth().AuthClientConfigRaw(),
+		SignupURL:            cfg.RegistrationServiceURL(),
 	}
 	ctx.JSON(http.StatusOK, configRespData)
 }

--- a/pkg/controller/authconfig_test.go
+++ b/pkg/controller/authconfig_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/test"
 
@@ -31,6 +33,9 @@ func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
 
 	// Check if the config is set to testing mode, so the handler may use this.
 	assert.True(s.T(), configuration.IsTestingMode(), "testing mode not set correctly to true")
+	s.OverrideApplicationDefault(testconfig.RegistrationService().
+		RegistrationServiceURL("https://signup.domain.com"))
+	defer s.DefaultConfig()
 	cfg := configuration.GetRegistrationServiceConfig()
 
 	// Create handler instance.
@@ -114,6 +119,10 @@ func (s *TestAuthConfigSuite) TestAuthClientConfigHandler() {
 				assert.True(s.T(), ok, "returned 'public-client' value is not of type 'bool'")
 				assert.Equal(s.T(), config["public-client"], valBool, "wrong 'public-client' in authconfig response")
 			})
+		})
+
+		s.Run("envelope signup url", func() {
+			assert.Equal(s.T(), "https://signup.domain.com", dataEnvelope.SignupURL)
 		})
 	})
 }


### PR DESCRIPTION
Required for https://github.com/codeready-toolchain/registration-service/pull/438
There is a new redirect page in that PR ^^^  which is supposed to do the following:
- it loads the authconfig from `/api/v1/authconfig`
- then if the user is not logged in already then it redirects the user to SSO for login
- then it checks if the user has already signed up. If not then the page redirects the user to the signup page.

This PR adds the signup URL (we store it as `registrationServiceURL` in the configuration) to the authconfig payload, so it's available to the clients in the last step above.