### PR TITLE
use FakeClient as backend for InformersService in unit tests

### DIFF
--- a/pkg/proxy/handlers/spacelister_get_test.go
+++ b/pkg/proxy/handlers/spacelister_get_test.go
@@ -258,7 +258,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedErrCode: 500,
 				mockFakeClient: func(fakeClient *test.FakeClient) {
 					fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
-						if key.Name == "base1ns" {
+						if _, ok := obj.(*toolchainv1alpha1.NSTemplateTier); ok && key.Name == "base1ns" {
 							return fmt.Errorf("nstemplatetier error")
 						}
 						return fakeClient.Client.Get(ctx, key, obj, opts...)
@@ -289,8 +289,11 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedErr:     "list spacebindings error",
 				expectedErrCode: 500,
 				mockFakeClient: func(fakeClient *test.FakeClient) {
-					fakeClient.MockList = func(_ context.Context, _ runtimeclient.ObjectList, _ ...runtimeclient.ListOption) error {
-						return fmt.Errorf("list spacebindings error")
+					fakeClient.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
+						if _, ok := list.(*toolchainv1alpha1.SpaceBindingList); ok {
+							return fmt.Errorf("list spacebindings error")
+						}
+						return fakeClient.Client.List(ctx, list, opts...)
 					}
 				},
 				expectedWorkspace: "dancelover",
@@ -302,7 +305,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedErrCode: 404,
 				mockFakeClient: func(fakeClient *test.FakeClient) {
 					fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
-						if key.Name == "dancelover" {
+						if _, ok := obj.(*toolchainv1alpha1.Space); ok && key.Name == "dancelover" {
 							return fmt.Errorf("no space")
 						}
 						return fakeClient.Client.Get(ctx, key, obj, opts...)
@@ -317,7 +320,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedErrCode: 500,
 				mockFakeClient: func(fakeClient *test.FakeClient) {
 					fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
-						if key.Name == "dancelover" {
+						if _, ok := obj.(*toolchainv1alpha1.Space); ok && key.Name == "dancelover" {
 							return fmt.Errorf("parent-space error")
 						}
 						return fakeClient.Client.Get(ctx, key, obj, opts...)
@@ -648,7 +651,7 @@ func TestGetUserWorkspace(t *testing.T) {
 			workspaceRequest: "batman",
 			mockFakeClient: func(fakeClient *test.FakeClient) {
 				fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
-					if obj.GetObjectKind().GroupVersionKind().Kind == "Space" {
+					if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 						return fmt.Errorf("no space")
 					}
 					return fakeClient.Client.Get(ctx, key, obj, opts...)
@@ -661,7 +664,7 @@ func TestGetUserWorkspace(t *testing.T) {
 			workspaceRequest: "batman",
 			mockFakeClient: func(fakeClient *test.FakeClient) {
 				fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
-					if obj.GetObjectKind().GroupVersionKind().Kind == "Space" {
+					if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 						return fmt.Errorf("no space")
 					}
 					return fakeClient.Client.Get(ctx, key, obj, opts...)
@@ -683,8 +686,11 @@ func TestGetUserWorkspace(t *testing.T) {
 			workspaceRequest: "robin",
 			expectedErr:      "list spacebindings error",
 			mockFakeClient: func(fakeClient *test.FakeClient) {
-				fakeClient.MockList = func(_ context.Context, _ runtimeclient.ObjectList, _ ...runtimeclient.ListOption) error {
-					return fmt.Errorf("list spacebindings error")
+				fakeClient.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
+					if _, ok := list.(*toolchainv1alpha1.SpaceBindingList); ok {
+						return fmt.Errorf("list spacebindings error")
+					}
+					return fakeClient.Client.List(ctx, list, opts...)
 				}
 			},
 			expectedWorkspace: nil,

--- a/pkg/proxy/handlers/spacelister_list_test.go
+++ b/pkg/proxy/handlers/spacelister_list_test.go
@@ -172,8 +172,11 @@ func TestHandleSpaceListRequest(t *testing.T) {
 					expectedErr:     "list spacebindings error",
 					expectedErrCode: 500,
 					mockFakeClient: func(fakeClient *test.FakeClient) {
-						fakeClient.MockList = func(_ context.Context, _ runtimeclient.ObjectList, _ ...runtimeclient.ListOption) error {
-							return fmt.Errorf("list spacebindings error")
+						fakeClient.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
+							if _, ok := list.(*toolchainv1alpha1.SpaceBindingList); ok {
+								return fmt.Errorf("list spacebindings error")
+							}
+							return fakeClient.Client.List(ctx, list, opts...)
 						}
 					},
 				},

--- a/pkg/proxy/handlers/spacelister_test.go
+++ b/pkg/proxy/handlers/spacelister_test.go
@@ -13,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/test/fake"
 	commonproxy "github.com/codeready-toolchain/toolchain-common/pkg/proxy"
@@ -100,9 +99,8 @@ func buildSpaceListerFakesWithResources(t *testing.T, signups []fake.SignupDef, 
 		//nstemplatetier
 		fake.NewBase1NSTemplateTier(),
 	)
-	fakeClient := fake.InitClient(t, oo...)
 
-	return fakeSignupService, fakeClient
+	return fakeSignupService, test.NewFakeClient(t, oo...)
 }
 
 func newSignup(signupName, username string, ready bool) fake.SignupDef {
@@ -146,7 +144,7 @@ func decodeResponseToWorkspaceList(data []byte) (*toolchainv1alpha1.WorkspaceLis
 func workspaceFor(t *testing.T, fakeClient client.Client, name, role string, isHomeWorkspace bool, additionalWSOptions ...commonproxy.WorkspaceOption) toolchainv1alpha1.Workspace {
 	// get the space for the user
 	space := &toolchainv1alpha1.Space{}
-	err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: configuration.Namespace()}, space)
+	err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: test.HostOperatorNs}, space)
 	require.NoError(t, err)
 
 	// create the workspace based on the space

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -19,7 +19,7 @@ import (
 
 	appservice "github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
-	"github.com/codeready-toolchain/registration-service/pkg/configuration"
+	infservice "github.com/codeready-toolchain/registration-service/pkg/informers/service"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/handlers"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/metrics"
@@ -29,6 +29,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/test"
 	"github.com/codeready-toolchain/registration-service/test/fake"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
@@ -43,7 +44,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +61,7 @@ var (
 	bannedUser = toolchainv1alpha1.BannedUser{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "alice",
-			Namespace: configuration.Namespace(),
+			Namespace: commontest.HostOperatorNs,
 			Labels: map[string]string{
 				toolchainv1alpha1.BannedUserEmailHashLabelKey: hash.EncodeString("alice@redhat.com"),
 			},
@@ -91,24 +91,24 @@ func (s *TestProxySuite) TestProxy() {
 			s.SetConfig(testconfig.RegistrationService().
 				Environment(string(environment)))
 
-			inf := fake.GetInformerService(
-				fake.InitClient(s.T()),
-				fake.WithGetBannedUsersByEmailFunc(func(email string) ([]toolchainv1alpha1.BannedUser, error) {
-					switch email {
-					case bannedUser.Spec.Email:
-						return []toolchainv1alpha1.BannedUser{bannedUser}, nil
-					case bannedUserListErrorEmailValue:
-						return nil, fmt.Errorf("list banned user error")
-					default:
-						return nil, nil
-					}
-				}))()
+			fakeClient := commontest.NewFakeClient(s.T(), &bannedUser)
+			fakeClient.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				listOptions := &client.ListOptions{}
+				for _, opt := range opts {
+					opt.ApplyToList(listOptions)
+				}
+				if strings.Contains(listOptions.LabelSelector.String(), hash.EncodeString(bannedUserListErrorEmailValue)) {
+					return fmt.Errorf("list banned user error")
+				}
+				return fakeClient.Client.List(ctx, list, opts...)
+			}
+			inf := infservice.NewInformerService(fakeClient, commontest.HostOperatorNs)
 
 			fakeApp := &fake.ProxyFakeApp{
 				InformerServiceMock: inf,
 			}
 			proxyMetrics := metrics.NewProxyMetrics(prometheus.NewRegistry())
-			p, err := newProxyWithClusterClient(fakeApp, nil, proxyMetrics, proxytest.NewGetMembersFunc(fake.InitClient(s.T())))
+			p, err := newProxyWithClusterClient(fakeApp, nil, proxyMetrics, proxytest.NewGetMembersFunc(commontest.NewFakeClient(s.T())))
 			require.NoError(s.T(), err)
 
 			server := p.StartProxy(DefaultPort)
@@ -724,49 +724,28 @@ func (s *TestProxySuite) checkProxyOK(fakeApp *fake.ProxyFakeApp, p *Proxy) {
 										}),
 									)
 									s.Application.MockSignupService(fakeApp.SignupServiceMock)
-									inf := fake.NewFakeInformer()
-									inf.GetSpaceFunc = func(name string) (*toolchainv1alpha1.Space, error) {
-										switch name {
-										case "mycoolworkspace":
-											return fake.NewSpace("mycoolworkspace", "member-2", "smith2"), nil
-										}
-										return nil, fmt.Errorf("space not found error")
+
+									proxyPlugin := &toolchainv1alpha1.ProxyPlugin{
+										ObjectMeta: metav1.ObjectMeta{
+											Namespace: commontest.HostOperatorNs,
+											Name:      "myplugin",
+										},
+										Spec: toolchainv1alpha1.ProxyPluginSpec{
+											OpenShiftRouteTargetEndpoint: &toolchainv1alpha1.OpenShiftRouteTarget{
+												Namespace: commontest.HostOperatorNs,
+												Name:      "proxy-plugin",
+											},
+										},
+										Status: toolchainv1alpha1.ProxyPluginStatus{},
 									}
-									inf.ListSpaceBindingFunc = func(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
-										// always return a spacebinding for the purposes of the proxy tests, actual testing of the space lister is covered in the space lister tests
-										spaceBindings := []toolchainv1alpha1.SpaceBinding{}
-										for _, req := range reqs {
-											if req.Values().List()[0] == "smith2" || req.Values().List()[0] == "mycoolworkspace" {
-												spaceBindings = []toolchainv1alpha1.SpaceBinding{*fake.NewSpaceBinding("mycoolworkspace-smith2", "smith2", "mycoolworkspace", "admin")}
-											}
-										}
-										return spaceBindings, nil
-									}
-									inf.GetProxyPluginConfigFunc = func(name string) (*toolchainv1alpha1.ProxyPlugin, error) {
-										switch name {
-										case "myplugin":
-											return &toolchainv1alpha1.ProxyPlugin{
-												ObjectMeta: metav1.ObjectMeta{
-													Namespace: metav1.NamespaceDefault,
-													Name:      "myplugin",
-												},
-												Spec: toolchainv1alpha1.ProxyPluginSpec{
-													OpenShiftRouteTargetEndpoint: &toolchainv1alpha1.OpenShiftRouteTarget{
-														Namespace: metav1.NamespaceDefault,
-														Name:      metav1.NamespaceDefault,
-													},
-												},
-												Status: toolchainv1alpha1.ProxyPluginStatus{},
-											}, nil
-										}
-										return nil, fmt.Errorf("proxy plugin not found")
-									}
-									inf.GetNSTemplateTierFunc = func(_ string) (*toolchainv1alpha1.NSTemplateTier, error) {
-										return fake.NewBase1NSTemplateTier(), nil
-									}
-									inf.ListBannedUsersByEmailFunc = func(_ string) ([]toolchainv1alpha1.BannedUser, error) {
-										return nil, nil
-									}
+									require.NoError(s.T(), routev1.Install(scheme.Scheme))
+									fakeClient := commontest.NewFakeClient(s.T(),
+										fake.NewSpace("mycoolworkspace", "member-2", "smith2"),
+										fake.NewSpaceBinding("mycoolworkspace-smith2", "smith2", "mycoolworkspace", "admin"),
+										proxyPlugin,
+										fake.NewBase1NSTemplateTier())
+									inf := infservice.NewInformerService(fakeClient, commontest.HostOperatorNs)
+
 									s.Application.MockInformerService(inf)
 									fakeApp.MemberClusterServiceMock = s.newMemberClusterServiceWithMembers(testServer.URL)
 
@@ -811,7 +790,6 @@ type headerToAdd struct {
 }
 
 func (s *TestProxySuite) newMemberClusterServiceWithMembers(serverURL string) appservice.MemberClusterService {
-	fakeClient := commontest.NewFakeClient(s.T())
 	serverHost := serverURL
 	switch {
 	case strings.HasPrefix(serverURL, "http://"):
@@ -819,21 +797,24 @@ func (s *TestProxySuite) newMemberClusterServiceWithMembers(serverURL string) ap
 	case strings.HasPrefix(serverURL, "https://"):
 		serverHost = strings.TrimPrefix(serverURL, "https://")
 	}
-	fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-		route, ok := obj.(*routev1.Route)
-		if ok && key.Namespace == metav1.NamespaceDefault && key.Name == metav1.NamespaceDefault {
-			route.Namespace = key.Namespace
-			route.Name = key.Name
-			route.Spec.Port = &routev1.RoutePort{TargetPort: intstr.FromString("http")}
-			route.Status.Ingress = []routev1.RouteIngress{
+
+	route := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: commontest.HostOperatorNs,
+			Name:      "proxy-plugin",
+		},
+		Spec: routev1.RouteSpec{
+			Port: &routev1.RoutePort{TargetPort: intstr.FromString("http")},
+		},
+		Status: routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{
 				{
 					Host: serverHost,
 				},
-			}
-			return nil
-		}
-		return fakeClient.Client.Get(ctx, key, obj, opts...)
+			},
+		},
 	}
+	fakeClient := commontest.NewFakeClient(s.T(), route)
 	return service.NewMemberClusterService(
 		fake.MemberClusterServiceContext{
 			CrtClient: s,

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -164,7 +164,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 			s.Run("unable to get space", func() {
 				s.Run("informer service returns error", func() {
 					fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-						if key.Name == "smith2" {
+						if _, ok := obj.(*toolchainv1alpha1.Space); ok && key.Name == "smith2" {
 							return fmt.Errorf("oopsi woopsi")
 						}
 						return fakeClient.Client.Get(ctx, key, obj, opts...)

--- a/test/fake/informer.go
+++ b/test/fake/informer.go
@@ -1,93 +1,12 @@
 package fake
 
 import (
-	"context"
-	"testing"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	spacetest "github.com/codeready-toolchain/toolchain-common/pkg/test/space"
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
-
-func NewFakeInformer() Informer {
-	return Informer{}
-}
-
-type Informer struct {
-	GetMurFunc                 func(name string) (*toolchainv1alpha1.MasterUserRecord, error)
-	GetSpaceFunc               func(name string) (*toolchainv1alpha1.Space, error)
-	GetToolchainStatusFunc     func() (*toolchainv1alpha1.ToolchainStatus, error)
-	GetUserSignupFunc          func(name string) (*toolchainv1alpha1.UserSignup, error)
-	ListSpaceBindingFunc       func(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error)
-	GetProxyPluginConfigFunc   func(name string) (*toolchainv1alpha1.ProxyPlugin, error)
-	GetNSTemplateTierFunc      func(name string) (*toolchainv1alpha1.NSTemplateTier, error)
-	ListBannedUsersByEmailFunc func(email string) ([]toolchainv1alpha1.BannedUser, error)
-}
-
-func (f Informer) GetProxyPluginConfig(name string) (*toolchainv1alpha1.ProxyPlugin, error) {
-	if f.GetProxyPluginConfigFunc != nil {
-		return f.GetProxyPluginConfigFunc(name)
-	}
-	panic("not supposed to call GetProxyPluginConfig")
-}
-
-func (f Informer) GetMasterUserRecord(name string) (*toolchainv1alpha1.MasterUserRecord, error) {
-	if f.GetMurFunc != nil {
-		return f.GetMurFunc(name)
-	}
-	panic("not supposed to call GetMasterUserRecord")
-}
-
-func (f Informer) GetSpace(name string) (*toolchainv1alpha1.Space, error) {
-	if f.GetSpaceFunc != nil {
-		return f.GetSpaceFunc(name)
-	}
-	panic("not supposed to call GetSpace")
-}
-
-func (f Informer) GetToolchainStatus() (*toolchainv1alpha1.ToolchainStatus, error) {
-	if f.GetToolchainStatusFunc != nil {
-		return f.GetToolchainStatusFunc()
-	}
-	panic("not supposed to call GetToolchainStatus")
-}
-
-func (f Informer) GetUserSignup(name string) (*toolchainv1alpha1.UserSignup, error) {
-	if f.GetUserSignupFunc != nil {
-		return f.GetUserSignupFunc(name)
-	}
-	panic("not supposed to call GetUserSignup")
-}
-
-func (f Informer) ListSpaceBindings(req ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
-	if f.ListSpaceBindingFunc != nil {
-		return f.ListSpaceBindingFunc(req...)
-	}
-	panic("not supposed to call ListSpaceBindings")
-}
-
-func (f Informer) GetNSTemplateTier(tier string) (*toolchainv1alpha1.NSTemplateTier, error) {
-	if f.GetNSTemplateTierFunc != nil {
-		return f.GetNSTemplateTierFunc(tier)
-	}
-	panic("not supposed to call GetNSTemplateTierFunc")
-}
-
-func (f Informer) ListBannedUsersByEmail(email string) ([]toolchainv1alpha1.BannedUser, error) {
-	if f.ListBannedUsersByEmailFunc != nil {
-		return f.ListBannedUsersByEmailFunc(email)
-	}
-	panic("not supposed to call BannedUsersByEmail")
-}
 
 func NewSpace(name, targetCluster, compliantUserName string, spaceTestOptions ...spacetest.Option) *toolchainv1alpha1.Space {
 
@@ -108,7 +27,7 @@ func NewSpace(name, targetCluster, compliantUserName string, spaceTestOptions ..
 			},
 		),
 	)
-	return spacetest.NewSpace(configuration.Namespace(), name,
+	return spacetest.NewSpace(test.HostOperatorNs, name,
 		spaceTestOptions...,
 	)
 }
@@ -116,7 +35,8 @@ func NewSpace(name, targetCluster, compliantUserName string, spaceTestOptions ..
 func NewSpaceBinding(name, murLabelValue, spaceLabelValue, role string) *toolchainv1alpha1.SpaceBinding {
 	return &toolchainv1alpha1.SpaceBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
+			Namespace: test.HostOperatorNs,
 			Labels: map[string]string{
 				toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: murLabelValue,
 				toolchainv1alpha1.SpaceBindingSpaceLabelKey:            spaceLabelValue,
@@ -133,7 +53,7 @@ func NewSpaceBinding(name, murLabelValue, spaceLabelValue, role string) *toolcha
 func NewBase1NSTemplateTier() *toolchainv1alpha1.NSTemplateTier {
 	return &toolchainv1alpha1.NSTemplateTier{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: configuration.Namespace(),
+			Namespace: test.HostOperatorNs,
 			Name:      "base1ns",
 		},
 		Spec: toolchainv1alpha1.NSTemplateTierSpec{
@@ -179,80 +99,4 @@ func NewMasterUserRecord(name string) *toolchainv1alpha1.MasterUserRecord {
 			},
 		},
 	}
-}
-
-type InformerServiceOptions func(informer *Informer)
-
-func WithGetNSTemplateTierFunc(getNsTemplateTierFunc func(tier string) (*toolchainv1alpha1.NSTemplateTier, error)) InformerServiceOptions {
-	return func(informer *Informer) {
-		informer.GetNSTemplateTierFunc = getNsTemplateTierFunc
-	}
-}
-
-func WithListSpaceBindingFunc(listSpaceBindingFunc func(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error)) InformerServiceOptions {
-	return func(informer *Informer) {
-		informer.ListSpaceBindingFunc = listSpaceBindingFunc
-	}
-}
-
-func WithGetSpaceFunc(getSpaceFunc func(name string) (*toolchainv1alpha1.Space, error)) InformerServiceOptions {
-	return func(informer *Informer) {
-		informer.GetSpaceFunc = getSpaceFunc
-	}
-}
-
-func WithGetMurFunc(getMurFunc func(name string) (*toolchainv1alpha1.MasterUserRecord, error)) InformerServiceOptions {
-	return func(informer *Informer) {
-		informer.GetMurFunc = getMurFunc
-	}
-}
-
-func WithGetBannedUsersByEmailFunc(bannedUsersByEmail func(ermail string) ([]toolchainv1alpha1.BannedUser, error)) InformerServiceOptions {
-	return func(informer *Informer) {
-		informer.ListBannedUsersByEmailFunc = bannedUsersByEmail
-	}
-}
-
-func GetInformerService(fakeClient client.Client, options ...InformerServiceOptions) func() service.InformerService {
-	return func() service.InformerService {
-
-		inf := NewFakeInformer()
-		inf.GetSpaceFunc = func(name string) (*toolchainv1alpha1.Space, error) {
-			space := &toolchainv1alpha1.Space{}
-			err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: configuration.Namespace()}, space)
-			return space, err
-		}
-		inf.ListSpaceBindingFunc = func(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error) {
-			sbList := &toolchainv1alpha1.SpaceBindingList{}
-			err := fakeClient.List(context.TODO(), sbList, &client.ListOptions{LabelSelector: labels.NewSelector().Add(reqs...)})
-			return sbList.Items, err
-		}
-		inf.GetNSTemplateTierFunc = func(tier string) (*toolchainv1alpha1.NSTemplateTier, error) {
-			nsTemplateTier := &toolchainv1alpha1.NSTemplateTier{}
-			err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: tier, Namespace: configuration.Namespace()}, nsTemplateTier)
-			return nsTemplateTier, err
-		}
-		inf.GetMurFunc = func(name string) (*toolchainv1alpha1.MasterUserRecord, error) {
-			mur := &toolchainv1alpha1.MasterUserRecord{}
-			err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: configuration.Namespace()}, mur)
-			return mur, err
-		}
-
-		for _, modify := range options {
-			modify(&inf)
-		}
-
-		return inf
-	}
-}
-
-func InitClient(t *testing.T, initObjs ...runtime.Object) *test.FakeClient {
-	scheme := runtime.NewScheme()
-	var AddToSchemes runtime.SchemeBuilder
-	addToSchemes := append(AddToSchemes,
-		toolchainv1alpha1.AddToScheme)
-	err := addToSchemes.AddToScheme(scheme)
-	require.NoError(t, err)
-	cl := test.NewFakeClient(t, initObjs...)
-	return cl
 }


### PR DESCRIPTION
First PR to migrate unit tests to use FakeClient instead of the mocks. I was able to isolate the changes for the InformerService only. 
* Unit tests now rely on the FakeClient as the back-end of the InformerService in all unit tests where it was used. 
* I removed the "fake informer" as well as other extra mocks.
* I tried to minimize the changes, so I adjusted some formatting here and there accordingly

The main goal of this PR is to start using the FakeClient in unit tests, its purpose is not to improve the unit tests, or increase the coverage. This can (and should) be done later.

[KUBESAW-193](https://issues.redhat.com/browse/KUBESAW-193)