### PR TITLE
fix: log errors inside VerifyPhoneCode

### DIFF
--- a/pkg/controller/signup.go
+++ b/pkg/controller/signup.go
@@ -139,7 +139,6 @@ func (s *Signup) VerifyPhoneCodeHandler(ctx *gin.Context) {
 
 	err := s.app.VerificationService().VerifyPhoneCode(ctx, userID, username, code)
 	if err != nil {
-		log.Error(ctx, err, "error validating user verification phone code")
 		e := &crterrors.Error{}
 		switch {
 		case errors.As(err, &e):

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -321,6 +321,7 @@ func (s *ServiceImpl) VerifyPhoneCode(ctx *gin.Context, userID, username, code s
 	doUpdate := func() error {
 		signup, err := s.Services().SignupService().GetUserSignupFromIdentifier(userID, username)
 		if err != nil {
+			log.Error(ctx, err, fmt.Sprintf("error getting signup from identifier. user_id: %s | username: %s", userID, username))
 			return err
 		}
 
@@ -342,6 +343,7 @@ func (s *ServiceImpl) VerifyPhoneCode(ctx *gin.Context, userID, username, code s
 
 		_, err = s.Services().SignupService().UpdateUserSignup(signup)
 		if err != nil {
+			log.Error(ctx, err, fmt.Sprintf("error updating usesrsignup: %s", signup.Name))
 			return err
 		}
 

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -343,7 +343,7 @@ func (s *ServiceImpl) VerifyPhoneCode(ctx *gin.Context, userID, username, code s
 
 		_, err = s.Services().SignupService().UpdateUserSignup(signup)
 		if err != nil {
-			log.Error(ctx, err, fmt.Sprintf("error updating usesrsignup: %s", signup.Name))
+			log.Error(ctx, err, fmt.Sprintf("error updating usersignup: %s", signup.Name))
 			return err
 		}
 


### PR DESCRIPTION
This PR moves all the logging inside the `VerifyPhoneCode` function and removes the log error from the caller since the function might return an error that doesn't need to be logged which was already logged as `Info`.