### PR TITLE
drop newProxyWithClusterClient function and related unnecessary client creation

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -65,7 +65,6 @@ func authorizationEndpointTarget() string {
 
 type Proxy struct {
 	app            application.Application
-	cl             client.Client
 	tokenParser    *auth.TokenParser
 	spaceLister    *handlers.SpaceLister
 	metrics        *metrics.ProxyMetrics
@@ -73,14 +72,6 @@ type Proxy struct {
 }
 
 func NewProxy(app application.Application, proxyMetrics *metrics.ProxyMetrics, getMembersFunc commoncluster.GetMemberClustersFunc) (*Proxy, error) {
-	cl, err := newClusterClient()
-	if err != nil {
-		return nil, err
-	}
-	return newProxyWithClusterClient(app, cl, proxyMetrics, getMembersFunc)
-}
-
-func newProxyWithClusterClient(app application.Application, cln client.Client, proxyMetrics *metrics.ProxyMetrics, getMembersFunc commoncluster.GetMemberClustersFunc) (*Proxy, error) {
 	tokenParser, err := auth.DefaultTokenParser()
 	if err != nil {
 		return nil, err
@@ -90,7 +81,6 @@ func newProxyWithClusterClient(app application.Application, cln client.Client, p
 	spaceLister := handlers.NewSpaceLister(app, proxyMetrics)
 	return &Proxy{
 		app:            app,
-		cl:             cln,
 		tokenParser:    tokenParser,
 		spaceLister:    spaceLister,
 		metrics:        proxyMetrics,

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -109,7 +109,7 @@ func (s *TestProxySuite) TestProxy() {
 				InformerServiceMock: inf,
 			}
 			proxyMetrics := metrics.NewProxyMetrics(prometheus.NewRegistry())
-			p, err := newProxyWithClusterClient(fakeApp, nil, proxyMetrics, proxytest.NewGetMembersFunc(commontest.NewFakeClient(s.T())))
+			p, err := NewProxy(fakeApp, proxyMetrics, proxytest.NewGetMembersFunc(commontest.NewFakeClient(s.T())))
 			require.NoError(s.T(), err)
 
 			server := p.StartProxy(DefaultPort)
@@ -135,8 +135,8 @@ func (s *TestProxySuite) TestProxy() {
 
 func (s *TestProxySuite) spinUpProxy(fakeApp *fake.ProxyFakeApp, port string) (*Proxy, *http.Server) {
 	proxyMetrics := metrics.NewProxyMetrics(prometheus.NewRegistry())
-	p, err := newProxyWithClusterClient(
-		fakeApp, nil, proxyMetrics, proxytest.NewGetMembersFunc(commontest.NewFakeClient(s.T())))
+	p, err := NewProxy(
+		fakeApp, proxyMetrics, proxytest.NewGetMembersFunc(commontest.NewFakeClient(s.T())))
 	require.NoError(s.T(), err)
 
 	server := p.StartProxy(port)


### PR DESCRIPTION
drop newProxyWithClusterClient function and related unnecessary client creation as it's not used for anything