### PR TITLE
drop BaseService from MemberClusterService & use Client directly

### DIFF
--- a/pkg/application/service/factory/service_factory.go
+++ b/pkg/application/service/factory/service_factory.go
@@ -57,7 +57,7 @@ func (s *ServiceFactory) InformerService() service.InformerService {
 }
 
 func (s *ServiceFactory) MemberClusterService() service.MemberClusterService {
-	return clusterservice.NewMemberClusterService(s.getContext())
+	return clusterservice.NewMemberClusterService(s.getContext().Client(), s.getContext().Services().SignupService())
 }
 
 func (s *ServiceFactory) SignupService() service.SignupService {

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -12,7 +12,6 @@ type InformerService interface {
 	GetMasterUserRecord(name string) (*toolchainv1alpha1.MasterUserRecord, error)
 	GetSpace(name string) (*toolchainv1alpha1.Space, error)
 	ListSpaceBindings(reqs ...labels.Requirement) ([]toolchainv1alpha1.SpaceBinding, error)
-	GetProxyPluginConfig(name string) (*toolchainv1alpha1.ProxyPlugin, error)
 	GetNSTemplateTier(name string) (*toolchainv1alpha1.NSTemplateTier, error)
 	ListBannedUsersByEmail(email string) ([]toolchainv1alpha1.BannedUser, error)
 }

--- a/pkg/informers/service/informer_service.go
+++ b/pkg/informers/service/informer_service.go
@@ -29,13 +29,6 @@ func NewInformerService(client client.Client, namespace string) service.Informer
 	return si
 }
 
-func (s *ServiceImpl) GetProxyPluginConfig(name string) (*toolchainv1alpha1.ProxyPlugin, error) {
-	pluginConfig := &toolchainv1alpha1.ProxyPlugin{}
-	namespacedName := types.NamespacedName{Name: name, Namespace: s.namespace}
-	err := s.client.Get(context.TODO(), namespacedName, pluginConfig)
-	return pluginConfig, err
-}
-
 func (s *ServiceImpl) GetMasterUserRecord(name string) (*toolchainv1alpha1.MasterUserRecord, error) {
 	mur := &toolchainv1alpha1.MasterUserRecord{}
 	namespacedName := types.NamespacedName{Name: name, Namespace: s.namespace}

--- a/pkg/informers/service/informer_service_test.go
+++ b/pkg/informers/service/informer_service_test.go
@@ -136,27 +136,6 @@ func TestInformerService(t *testing.T) {
 		})
 	})
 
-	t.Run("proxy configs", func(t *testing.T) {
-		t.Run("not found", func(t *testing.T) {
-			// when
-			val, err := svc.GetProxyPluginConfig("unknown")
-
-			// then
-			assert.Empty(t, val)
-			assert.EqualError(t, err, "proxyplugins.toolchain.dev.openshift.com \"unknown\" not found")
-		})
-
-		t.Run("found", func(t *testing.T) {
-			// when
-			val, err := svc.GetProxyPluginConfig("tekton-results")
-
-			// then
-			require.NotNil(t, val)
-			require.NoError(t, err)
-			assert.Equal(t, pluginTekton.Spec, val.Spec)
-		})
-	})
-
 	t.Run("bannedusers", func(t *testing.T) {
 		t.Run("not found", func(t *testing.T) {
 			// when

--- a/pkg/proxy/proxy_community_test.go
+++ b/pkg/proxy/proxy_community_test.go
@@ -9,6 +9,7 @@ import (
 	appservice "github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
 	infservice "github.com/codeready-toolchain/registration-service/pkg/informers/service"
+	"github.com/codeready-toolchain/registration-service/pkg/namespaced"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/handlers"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/test/fake"
@@ -144,11 +145,12 @@ func (s *TestProxySuite) checkProxyCommunityOK(fakeApp *fake.ProxyFakeApp, p *Pr
 
 		// configure informer
 		inf := infservice.NewInformerService(cli, commontest.HostOperatorNs)
+		nsClient := namespaced.NewClient(cli, commontest.HostOperatorNs)
 
 		// configure Application
 		fakeApp.Err = nil
 		fakeApp.InformerServiceMock = inf
-		fakeApp.MemberClusterServiceMock = s.newMemberClusterServiceWithMembers(testServer.URL)
+		fakeApp.MemberClusterServiceMock = s.newMemberClusterServiceWithMembers(nsClient, signupService, testServer.URL)
 		fakeApp.SignupServiceMock = signupService
 
 		s.Application.MockSignupService(signupService)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -20,6 +20,7 @@ import (
 	appservice "github.com/codeready-toolchain/registration-service/pkg/application/service"
 	"github.com/codeready-toolchain/registration-service/pkg/auth"
 	infservice "github.com/codeready-toolchain/registration-service/pkg/informers/service"
+	"github.com/codeready-toolchain/registration-service/pkg/namespaced"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/handlers"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/metrics"
@@ -850,9 +851,10 @@ func (s *TestProxySuite) checkProxyOK(fakeApp *fake.ProxyFakeApp, p *Proxy) {
 										proxyPlugin,
 										fake.NewBase1NSTemplateTier())
 									inf := infservice.NewInformerService(fakeClient, commontest.HostOperatorNs)
+									nsClient := namespaced.NewClient(fakeClient, commontest.HostOperatorNs)
 
 									s.Application.MockInformerService(inf)
-									fakeApp.MemberClusterServiceMock = s.newMemberClusterServiceWithMembers(testServer.URL)
+									fakeApp.MemberClusterServiceMock = s.newMemberClusterServiceWithMembers(nsClient, fakeApp.SignupServiceMock, testServer.URL)
 									fakeApp.InformerServiceMock = inf
 
 									p.spaceLister = &handlers.SpaceLister{
@@ -900,7 +902,7 @@ type headerToAdd struct {
 	key, value string
 }
 
-func (s *TestProxySuite) newMemberClusterServiceWithMembers(serverURL string) appservice.MemberClusterService {
+func (s *TestProxySuite) newMemberClusterServiceWithMembers(nsClient namespaced.Client, signupService appservice.SignupService, serverURL string) appservice.MemberClusterService {
 	serverHost := serverURL
 	switch {
 	case strings.HasPrefix(serverURL, "http://"):
@@ -911,7 +913,7 @@ func (s *TestProxySuite) newMemberClusterServiceWithMembers(serverURL string) ap
 
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: commontest.HostOperatorNs,
+			Namespace: nsClient.Namespace,
 			Name:      "proxy-plugin",
 		},
 		Spec: routev1.RouteSpec{
@@ -925,11 +927,9 @@ func (s *TestProxySuite) newMemberClusterServiceWithMembers(serverURL string) ap
 			},
 		},
 	}
-	fakeClient := commontest.NewFakeClient(s.T(), route)
 	return service.NewMemberClusterService(
-		fake.MemberClusterServiceContext{
-			Svcs: s.Application,
-		},
+		nsClient,
+		signupService,
 		func(si *service.ServiceImpl) {
 			si.GetMembersFunc = func(_ ...commoncluster.Condition) []*commoncluster.CachedToolchainCluster {
 				return []*commoncluster.CachedToolchainCluster{
@@ -949,7 +949,7 @@ func (s *TestProxySuite) newMemberClusterServiceWithMembers(serverURL string) ap
 								BearerToken: "clusterSAToken",
 							},
 						},
-						Client: fakeClient,
+						Client: commontest.NewFakeClient(s.T(), route),
 					},
 				}
 			}

--- a/pkg/proxy/service/cluster_service_test.go
+++ b/pkg/proxy/service/cluster_service_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	infservice "github.com/codeready-toolchain/registration-service/pkg/informers/service"
+	"github.com/codeready-toolchain/registration-service/pkg/namespaced"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/service"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
@@ -88,14 +89,8 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 		fake.NewSpace("smith2", "member-2", "smith2"),
 		fake.NewSpace("unknown-cluster", "unknown-cluster", "unknown-cluster"),
 		pp)
-	inf := infservice.NewInformerService(fakeClient, commontest.HostOperatorNs)
-	s.Application.MockInformerService(inf)
-
-	svc := service.NewMemberClusterService(
-		fake.MemberClusterServiceContext{
-			Svcs: s.Application,
-		},
-	)
+	nsClient := namespaced.NewClient(fakeClient, commontest.HostOperatorNs)
+	svc := service.NewMemberClusterService(nsClient, sc)
 
 	tt := map[string]struct {
 		publicViewerEnabled bool
@@ -193,10 +188,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 
 			s.Run("no member cluster found", func() {
 				s.Run("no member clusters", func() {
-					svc := service.NewMemberClusterService(
-						fake.MemberClusterServiceContext{
-							Svcs: s.Application,
-						},
+					svc := service.NewMemberClusterService(nsClient, sc,
 						func(si *service.ServiceImpl) {
 							si.GetMembersFunc = func(_ ...commoncluster.Condition) []*commoncluster.CachedToolchainCluster {
 								return []*commoncluster.CachedToolchainCluster{}
@@ -221,10 +213,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 				})
 
 				s.Run("no member cluster with the given URL", func() {
-					svc := service.NewMemberClusterService(
-						fake.MemberClusterServiceContext{
-							Svcs: s.Application,
-						},
+					svc := service.NewMemberClusterService(nsClient, sc,
 						func(si *service.ServiceImpl) {
 							si.GetMembersFunc = func(_ ...commoncluster.Condition) []*commoncluster.CachedToolchainCluster {
 								return s.memberClusters()
@@ -282,10 +271,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 					},
 				}
 
-				svc := service.NewMemberClusterService(
-					fake.MemberClusterServiceContext{
-						Svcs: s.Application,
-					},
+				svc := service.NewMemberClusterService(nsClient, sc,
 					func(si *service.ServiceImpl) {
 						si.GetMembersFunc = func(_ ...commoncluster.Condition) []*commoncluster.CachedToolchainCluster {
 							return memberArray
@@ -449,10 +435,7 @@ func (s *TestClusterServiceSuite) TestGetClusterAccess() {
 		})
 
 		s.Run("get workspace by name", func() {
-			svc := service.NewMemberClusterService(
-				fake.MemberClusterServiceContext{
-					Svcs: s.Application,
-				},
+			svc := service.NewMemberClusterService(nsClient, sc,
 				func(si *service.ServiceImpl) {
 					si.GetMembersFunc = func(_ ...commoncluster.Condition) []*commoncluster.CachedToolchainCluster {
 						return s.memberClusters()

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	gocontext "context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -448,7 +447,7 @@ func (s *ServiceImpl) VerifyActivationCode(ctx *gin.Context, userID, username, c
 
 	// look-up the SocialEvent
 	event := &toolchainv1alpha1.SocialEvent{}
-	if err := s.Get(gocontext.TODO(), s.NamespacedName(code), event); err != nil {
+	if err := s.Get(ctx, s.NamespacedName(code), event); err != nil {
 		if apierrors.IsNotFound(err) {
 			// a SocialEvent was not found for the provided code
 			return crterrors.NewForbiddenError("invalid code", "the provided code is invalid")

--- a/test/fake/mockable_application.go
+++ b/test/fake/mockable_application.go
@@ -12,11 +12,10 @@ func NewMockableApplication(options ...factory.Option) *MockableApplication {
 }
 
 type MockableApplication struct {
-	serviceFactory           *factory.ServiceFactory
-	mockInformerService      service.InformerService
-	mockSignupService        service.SignupService
-	mockVerificationService  service.VerificationService
-	mockMemberClusterService service.MemberClusterService
+	serviceFactory          *factory.ServiceFactory
+	mockInformerService     service.InformerService
+	mockSignupService       service.SignupService
+	mockVerificationService service.VerificationService
 }
 
 func (m *MockableApplication) SignupService() service.SignupService {
@@ -38,9 +37,6 @@ func (m *MockableApplication) VerificationService() service.VerificationService 
 }
 
 func (m *MockableApplication) MemberClusterService() service.MemberClusterService {
-	if m.mockMemberClusterService != nil {
-		return m.mockMemberClusterService
-	}
 	return m.serviceFactory.MemberClusterService()
 }
 

--- a/test/fake/proxy.go
+++ b/test/fake/proxy.go
@@ -3,7 +3,6 @@ package fake
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/application/service"
-	"github.com/codeready-toolchain/registration-service/pkg/namespaced"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/gin-gonic/gin"
@@ -122,17 +121,4 @@ func (m *SignupService) UpdateUserSignup(_ *toolchainv1alpha1.UserSignup) (*tool
 }
 func (m *SignupService) PhoneNumberAlreadyInUse(_, _, _ string) error {
 	return nil
-}
-
-type MemberClusterServiceContext struct {
-	NamespacedClient namespaced.Client
-	Svcs             service.Services
-}
-
-func (sc MemberClusterServiceContext) Client() namespaced.Client {
-	return sc.NamespacedClient
-}
-
-func (sc MemberClusterServiceContext) Services() service.Services {
-	return sc.Svcs
 }


### PR DESCRIPTION
* drops BaseService from MemberClusterService
* uses the controller-runtime client directly for communication with k8s api
* the implementation of the SignupService is set directly (not via the BaseService) which simplifies the tests

this is a prerequisite for dropping the InformerService  [KUBESAW-198](https://issues.redhat.com/browse/KUBESAW-198)