### PR TITLE
drop MemberClusterService interface & rename the implementation

### DIFF
--- a/pkg/application/service/factory/service_factory.go
+++ b/pkg/application/service/factory/service_factory.go
@@ -8,7 +8,6 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/log"
 	"github.com/codeready-toolchain/registration-service/pkg/namespaced"
-	clusterservice "github.com/codeready-toolchain/registration-service/pkg/proxy/service"
 	signupservice "github.com/codeready-toolchain/registration-service/pkg/signup/service"
 	verificationservice "github.com/codeready-toolchain/registration-service/pkg/verification/service"
 )
@@ -49,10 +48,6 @@ func (s *ServiceFactory) defaultServiceContextProducer() servicecontext.ServiceC
 			services: s,
 		}
 	}
-}
-
-func (s *ServiceFactory) MemberClusterService() service.MemberClusterService {
-	return clusterservice.NewMemberClusterService(s.getContext().Client(), s.getContext().Services().SignupService())
 }
 
 func (s *ServiceFactory) SignupService() service.SignupService {

--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/gin-gonic/gin"
 )
@@ -20,12 +19,7 @@ type VerificationService interface {
 	VerifyActivationCode(ctx *gin.Context, userID, username, code string) error
 }
 
-type MemberClusterService interface {
-	GetClusterAccess(userID, username, workspace, proxyPluginName string, publicViewerEnabled bool) (*access.ClusterAccess, error)
-}
-
 type Services interface {
 	SignupService() SignupService
 	VerificationService() VerificationService
-	MemberClusterService() MemberClusterService
 }

--- a/pkg/server/in_cluster_application.go
+++ b/pkg/server/in_cluster_application.go
@@ -30,7 +30,3 @@ func (r InClusterApplication) SignupService() service.SignupService {
 func (r InClusterApplication) VerificationService() service.VerificationService {
 	return r.serviceFactory.VerificationService()
 }
-
-func (r InClusterApplication) MemberClusterService() service.MemberClusterService {
-	return r.serviceFactory.MemberClusterService()
-}

--- a/test/fake/proxy.go
+++ b/test/fake/proxy.go
@@ -2,46 +2,11 @@ package fake
 
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/registration-service/pkg/application/service"
-	"github.com/codeready-toolchain/registration-service/pkg/proxy/access"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/gin-gonic/gin"
 )
 
 // This whole service abstraction is such a huge pain. We have to get rid of it!!!
-
-type ProxyFakeApp struct {
-	Accesses                 map[string]*access.ClusterAccess
-	Err                      error
-	SignupServiceMock        service.SignupService
-	MemberClusterServiceMock service.MemberClusterService
-}
-
-func (a *ProxyFakeApp) SignupService() service.SignupService {
-	if a.SignupServiceMock != nil {
-		return a.SignupServiceMock
-	}
-	return NewSignupService()
-}
-
-func (a *ProxyFakeApp) VerificationService() service.VerificationService {
-	panic("VerificationService shouldn't be called")
-}
-
-func (a *ProxyFakeApp) MemberClusterService() service.MemberClusterService {
-	if a.MemberClusterServiceMock != nil {
-		return a.MemberClusterServiceMock
-	}
-	return &fakeClusterService{a}
-}
-
-type fakeClusterService struct {
-	fakeApp *ProxyFakeApp
-}
-
-func (f *fakeClusterService) GetClusterAccess(userID, _, _, _ string, _ bool) (*access.ClusterAccess, error) {
-	return f.fakeApp.Accesses[userID], f.fakeApp.Err
-}
 
 type SignupDef func() (string, *signup.Signup)
 


### PR DESCRIPTION
* drop MemberClusterService interface 
* rename the implementation to `MemberClusters`
* move it to the `proxy` package
* provide the `GetMemberClustersFunc` as a parameter, so it uses the same as is used in `proxy.go`
    * this also slightly simplifies the tests
* drop "ServiceImpl options" as they are not needed anymore
* drop `ProxyFakeApp` as it is not needed anymore
