### PR TITLE
metrics: measure roundtrips in seconds

### DIFF
--- a/pkg/middleware/promhttp_middleware.go
+++ b/pkg/middleware/promhttp_middleware.go
@@ -42,7 +42,7 @@ func InstrumentRoundTripperDuration(histVec *prometheus.HistogramVec) gin.Handle
 				"code":   strconv.Itoa(c.Writer.Status()),
 				"method": c.Request.Method,
 				"path":   c.Request.URL.Path,
-			}).Observe(float64(duration.Milliseconds()))
+			}).Observe(float64(duration.Seconds()))
 		}()
 		c.Next()
 	}


### PR DESCRIPTION
not in milliseconds, which results in histogram buckets under '1' being always empty

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
