### PR TITLE
use helper function for UserSignup creation in verification tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20241114213029-44333bf24bcf
+	github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20241114215157-a6a85252b2f5
 	github.com/go-logr/logr v1.4.1
 	github.com/gofrs/uuid v4.2.0+incompatible
@@ -17,6 +17,8 @@ require (
 	k8s.io/client-go v0.27.3
 	sigs.k8s.io/controller-runtime v0.15.0
 )
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20250113085950-89e60ca3a9f0
 
 require (
 	cloud.google.com/go/recaptchaenterprise/v2 v2.13.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/aws/aws-sdk-go v1.44.100
 	github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20241114215157-a6a85252b2f5
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20250113092648-1078d683961b
 	github.com/go-logr/logr v1.4.1
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -17,8 +17,6 @@ require (
 	k8s.io/client-go v0.27.3
 	sigs.k8s.io/controller-runtime v0.15.0
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20250113085950-89e60ca3a9f0
 
 require (
 	cloud.google.com/go/recaptchaenterprise/v2 v2.13.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBS
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80 h1:OpZkP3OGAdrDHOb1TtHVnLSVuevEiQhOH//plnpVL/c=
 github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80/go.mod h1:DUq1ffy9Mbersdgji48i/cm9Y+6NMwAdAQJNlfOrPRo=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20250113092648-1078d683961b h1:zlLUDN9ddogCX8hzuPrIdS/YpAF8siucA5b56zGUz00=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20250113092648-1078d683961b/go.mod h1:wLXGFyEan+RJHZEEMmvTxNa2BrlizIA+4+Lsi1cyuAk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -240,8 +242,6 @@ github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmt
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/matousjobanek/toolchain-common v0.0.0-20250113085950-89e60ca3a9f0 h1:IM5gAH1kfF1dfSzBV+LAU7UL/bx3HRSYKLn4ROHUJuI=
-github.com/matousjobanek/toolchain-common v0.0.0-20250113085950-89e60ca3a9f0/go.mod h1:wLXGFyEan+RJHZEEMmvTxNa2BrlizIA+4+Lsi1cyuAk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215 h1:hDa3vAq/Zo5gjfJ46XMsGFbH+hTizpR4fUzQCk2nxgk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215/go.mod h1:LH+NgPY9AJpDfqAFtzyer01N9MYNsAKUf3DC9DV1xIY=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=

--- a/go.sum
+++ b/go.sum
@@ -44,10 +44,8 @@ github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtM
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/codeready-toolchain/api v0.0.0-20241114213029-44333bf24bcf h1:tOHKd4PT6gnV8lLh3kmqqK9YONvL6oFKHpi0kGzfsvw=
-github.com/codeready-toolchain/api v0.0.0-20241114213029-44333bf24bcf/go.mod h1:DUq1ffy9Mbersdgji48i/cm9Y+6NMwAdAQJNlfOrPRo=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20241114215157-a6a85252b2f5 h1:vW0C32c6sI9ZUGcUw3e9ftE9hqJ/bMo+TtRHp84Hung=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20241114215157-a6a85252b2f5/go.mod h1:wx/d4HVbDPOadwpbxn28ZGClC5OmzelIK8p4wupDJVI=
+github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80 h1:OpZkP3OGAdrDHOb1TtHVnLSVuevEiQhOH//plnpVL/c=
+github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80/go.mod h1:DUq1ffy9Mbersdgji48i/cm9Y+6NMwAdAQJNlfOrPRo=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -242,6 +240,8 @@ github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmt
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/matousjobanek/toolchain-common v0.0.0-20250113085950-89e60ca3a9f0 h1:IM5gAH1kfF1dfSzBV+LAU7UL/bx3HRSYKLn4ROHUJuI=
+github.com/matousjobanek/toolchain-common v0.0.0-20250113085950-89e60ca3a9f0/go.mod h1:wLXGFyEan+RJHZEEMmvTxNa2BrlizIA+4+Lsi1cyuAk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215 h1:hDa3vAq/Zo5gjfJ46XMsGFbH+hTizpR4fUzQCk2nxgk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215/go.mod h1:LH+NgPY9AJpDfqAFtzyer01N9MYNsAKUf3DC9DV1xIY=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -715,7 +715,7 @@ func (s *TestSignupSuite) TestVerifyActivationCodeHandler() {
 
 	s.Run("verification successful", func() {
 		// given
-		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second)) // just signed up
+		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second)) // just signed up
 		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event")
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 		ctrl := controller.NewSignup(application)
@@ -739,7 +739,7 @@ func (s *TestSignupSuite) TestVerifyActivationCodeHandler() {
 		s.Run("too many attempts", func() {
 			// given
 			userSignup := testusersignup.NewUserSignup(
-				testusersignup.VerificationRequired(time.Second),                                                                       // just signed up
+				testusersignup.VerificationRequiredAgo(time.Second),                                                                    // just signed up
 				testusersignup.WithVerificationAttempts(configuration.GetRegistrationServiceConfig().Verification().AttemptsAllowed()), // already reached max attempts
 			)
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
@@ -760,7 +760,7 @@ func (s *TestSignupSuite) TestVerifyActivationCodeHandler() {
 
 		s.Run("invalid code", func() {
 			// given
-			userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second)) // just signed up
+			userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second)) // just signed up
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 			ctrl := controller.NewSignup(application)
 			handler := gin.HandlerFunc(ctrl.VerifyActivationCodeHandler)
@@ -779,7 +779,7 @@ func (s *TestSignupSuite) TestVerifyActivationCodeHandler() {
 
 		s.Run("inactive code", func() {
 			// given
-			userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second)) // just signed up
+			userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second)) // just signed up
 			event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithStartTime(time.Now().Add(60*time.Minute)))
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 			ctrl := controller.NewSignup(application)
@@ -801,7 +801,7 @@ func (s *TestSignupSuite) TestVerifyActivationCodeHandler() {
 
 		s.Run("expired code", func() {
 			// given
-			userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second)) // just signed up
+			userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second)) // just signed up
 			event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithEndTime(time.Now().Add(-1*time.Minute)))
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 			ctrl := controller.NewSignup(application)
@@ -823,7 +823,7 @@ func (s *TestSignupSuite) TestVerifyActivationCodeHandler() {
 
 		s.Run("overbooked code", func() {
 			// given
-			userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second))                         // just signed up
+			userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second))                      // just signed up
 			event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithActivationCount(10)) // same as `spec.MaxAttendees`
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 			ctrl := controller.NewSignup(application)

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -339,8 +339,8 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 	userSignup := testusersignup.NewUserSignup(
 		testusersignup.WithName("johny"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
-		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
-		testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "3"),
+		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Add(-25*time.Hour).Format(verificationservice.TimestampLayout)),
+		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey, "3"),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
 		testusersignup.VerificationRequiredAgo(time.Second))
 

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -137,14 +137,14 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 	userSignup := testusersignup.NewUserSignup(
 		testusersignup.WithName("johny"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
-		testusersignup.VerificationRequired(0))
+		testusersignup.VerificationRequiredAgo(time.Second))
 
 	// Create a second UserSignup which we will test by username lookup instead of UserID lookup.  This will also function
 	// as some additional noise for the test
 	userSignup2 := testusersignup.NewUserSignup(
 		testusersignup.WithName("jsmith"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+61NUMBER"),
-		testusersignup.VerificationRequired(0))
+		testusersignup.VerificationRequiredAgo(time.Second))
 
 	// Add both UserSignups to the fake client
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup, userSignup2)
@@ -247,7 +247,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 	userSignup := testusersignup.NewUserSignup(
 		testusersignup.WithName("johny"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
-		testusersignup.VerificationRequired(0))
+		testusersignup.VerificationRequiredAgo(time.Second))
 
 	s.Run("when client GET call fails should return error", func() {
 		fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
@@ -342,7 +342,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "3"),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
-		testusersignup.VerificationRequired(0))
+		testusersignup.VerificationRequiredAgo(time.Second))
 
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
@@ -383,7 +383,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenCountContain
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey, "abc"),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
-		testusersignup.VerificationRequired(0))
+		testusersignup.VerificationRequiredAgo(time.Second))
 
 	_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
@@ -409,7 +409,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey, strconv.Itoa(cfg.Verification().DailyLimit())),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
-		testusersignup.VerificationRequired(0))
+		testusersignup.VerificationRequiredAgo(time.Second))
 
 	_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
@@ -441,7 +441,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 
 	bravoUserSignup := testusersignup.NewUserSignup(
 		testusersignup.WithName("bravo"),
-		testusersignup.VerificationRequired(0))
+		testusersignup.VerificationRequiredAgo(time.Second))
 
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), alphaUserSignup, bravoUserSignup)
 
@@ -481,7 +481,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUs
 
 	bravoUserSignup := testusersignup.NewUserSignup(
 		testusersignup.WithName("bravo"),
-		testusersignup.VerificationRequired(0))
+		testusersignup.VerificationRequiredAgo(time.Second))
 
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), alphaUserSignup, bravoUserSignup)
 
@@ -511,8 +511,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey, "0.8"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, now.Add(10*time.Second).Format(verificationservice.TimestampLayout)),
-
-			testusersignup.VerificationRequired(0))
+			testusersignup.VerificationRequiredAgo(time.Second))
 
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
@@ -536,7 +535,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey, "0.7"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "654321"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, now.Add(10*time.Second).Format(verificationservice.TimestampLayout)),
-			testusersignup.VerificationRequired(0))
+			testusersignup.VerificationRequiredAgo(time.Second))
 
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
@@ -733,7 +732,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 					testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
 					testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
 					testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, now.Add(10*time.Second).Format(verificationservice.TimestampLayout)),
-					testusersignup.VerificationRequired(0))
+					testusersignup.VerificationRequiredAgo(time.Second))
 				if tc.activationCounterAnnotationValue != "" {
 					userSignup.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey] = tc.activationCounterAnnotationValue
 				}
@@ -773,7 +772,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 
 	s.Run("verification ok", func() {
 		// given
-		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second)) // just signed up
+		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second)) // just signed up
 		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithTargetCluster(targetCluster))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
@@ -791,7 +790,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 
 	s.Run("last user to signup", func() {
 		// given
-		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second))                                                                          // just signed up
+		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second))                                                                       // just signed up
 		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithActivationCount(9), testsocialevent.WithTargetCluster(targetCluster)) // one seat left
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
@@ -810,7 +809,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 	s.Run("when too many attempts made", func() {
 		// given
 		userSignup := testusersignup.NewUserSignup(
-			testusersignup.VerificationRequired(time.Second), // just signed up
+			testusersignup.VerificationRequiredAgo(time.Second), // just signed up
 			testusersignup.WithVerificationAttempts(cfg.Verification().AttemptsAllowed()))
 		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithTargetCluster(targetCluster))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
@@ -831,7 +830,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 
 		s.Run("first attempt", func() {
 			// given
-			userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second)) // just signed up
+			userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second)) // just signed up
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 			// when
@@ -849,8 +848,8 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		s.Run("second attempt", func() {
 			// given
 			userSignup := testusersignup.NewUserSignup(
-				testusersignup.VerificationRequired(time.Second), // just signed up
-				testusersignup.WithVerificationAttempts(2))       // already tried twice before
+				testusersignup.VerificationRequiredAgo(time.Second), // just signed up
+				testusersignup.WithVerificationAttempts(2))          // already tried twice before
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 			// when
@@ -868,7 +867,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 
 	s.Run("when max attendees reached", func() {
 		// given
-		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second))                                                                           // just signed up
+		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second))                                                                        // just signed up
 		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithActivationCount(10), testsocialevent.WithTargetCluster(targetCluster)) // same as default `spec.MaxAttendees`
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
@@ -887,7 +886,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 
 	s.Run("when event not open yet", func() {
 		// given
-		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second))                                                                                            // just signed up
+		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second))                                                                                         // just signed up
 		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithStartTime(time.Now().Add(time.Hour)), testsocialevent.WithTargetCluster(targetCluster)) // starting in 1hr
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
@@ -906,7 +905,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 
 	s.Run("when event already closed", func() {
 		// given
-		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequired(time.Second))                                                                                           // just signed up
+		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second))                                                                                        // just signed up
 		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithEndTime(time.Now().Add(-time.Hour)), testsocialevent.WithTargetCluster(targetCluster)) // ended 1hr ago
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -134,43 +134,17 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 
 	gock.Observe(obs)
 
-	userSignup := &toolchainv1alpha1.UserSignup{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "123",
-			Namespace: configuration.Namespace(),
-			Labels: map[string]string{
-				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-			},
-		},
-		Spec: toolchainv1alpha1.UserSignupSpec{
-			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-				PreferredUsername: "sbryzak@redhat.com",
-			},
-		},
-	}
+	userSignup := testusersignup.NewUserSignup(
+		testusersignup.WithName("johny"),
+		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+		testusersignup.VerificationRequired(0))
 
 	// Create a second UserSignup which we will test by username lookup instead of UserID lookup.  This will also function
 	// as some additional noise for the test
-	userSignup2 := &toolchainv1alpha1.UserSignup{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "jsmith",
-			Namespace: configuration.Namespace(),
-			Labels: map[string]string{
-				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+61NUMBER",
-			},
-		},
-		Spec: toolchainv1alpha1.UserSignupSpec{
-			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-				PreferredUsername: "jsmith",
-			},
-		},
-	}
-
-	// Require verification for both UserSignups
-	states.SetVerificationRequired(userSignup, true)
-	states.SetVerificationRequired(userSignup2, true)
+	userSignup2 := testusersignup.NewUserSignup(
+		testusersignup.WithName("jsmith"),
+		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+61NUMBER"),
+		testusersignup.VerificationRequired(0))
 
 	// Add both UserSignups to the fake client
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup, userSignup2)
@@ -270,23 +244,10 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 
 	gock.Observe(obs)
 
-	userSignup := &toolchainv1alpha1.UserSignup{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "123",
-			Namespace: configuration.Namespace(),
-			Labels: map[string]string{
-				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-			},
-		},
-		Spec: toolchainv1alpha1.UserSignupSpec{
-			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-				PreferredUsername: "shane@redhat.com",
-			},
-		},
-	}
-
-	states.SetVerificationRequired(userSignup, true)
+	userSignup := testusersignup.NewUserSignup(
+		testusersignup.WithName("johny"),
+		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+		testusersignup.VerificationRequired(0))
 
 	s.Run("when client GET call fails should return error", func() {
 		fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
@@ -301,7 +262,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 		err := application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
-		require.EqualError(s.T(), err, "get failed: error retrieving usersignup: 123", err.Error())
+		require.EqualError(s.T(), err, "get failed: error retrieving usersignup: johny", err.Error())
 	})
 
 	s.Run("when client UPDATE call fails indefinitely should return error", func() {
@@ -375,27 +336,13 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 
 	gock.Observe(obs)
 
-	userSignup := &toolchainv1alpha1.UserSignup{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "123",
-			Namespace: configuration.Namespace(),
-			Annotations: map[string]string{
-				toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey: now.Add(-25 * time.Hour).Format(verificationservice.TimestampLayout),
-				toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:            "3",
-				toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey:          "123456",
-			},
-			Labels: map[string]string{
-				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-			},
-		},
-		Spec: toolchainv1alpha1.UserSignupSpec{
-			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-				PreferredUsername: "shane@redhat.com",
-			},
-		},
-	}
-	states.SetVerificationRequired(userSignup, true)
+	userSignup := testusersignup.NewUserSignup(
+		testusersignup.WithName("johny"),
+		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
+		testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "3"),
+		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
+		testusersignup.VerificationRequired(0))
 
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
@@ -431,26 +378,12 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenCountContain
 
 	now := time.Now()
 
-	userSignup := &toolchainv1alpha1.UserSignup{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "123",
-			Namespace: configuration.Namespace(),
-			Annotations: map[string]string{
-				toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey:       "abc",
-				toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey: now.Format(verificationservice.TimestampLayout),
-			},
-			Labels: map[string]string{
-				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-			},
-		},
-		Spec: toolchainv1alpha1.UserSignupSpec{
-			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-				PreferredUsername: "shane@redhat.com",
-			},
-		},
-	}
-	states.SetVerificationRequired(userSignup, true)
+	userSignup := testusersignup.NewUserSignup(
+		testusersignup.WithName("johny"),
+		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey, "abc"),
+		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
+		testusersignup.VerificationRequired(0))
 
 	_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
@@ -471,26 +404,12 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 
 	now := time.Now()
 
-	userSignup := &toolchainv1alpha1.UserSignup{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "123",
-			Namespace: configuration.Namespace(),
-			Annotations: map[string]string{
-				toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey:       strconv.Itoa(cfg.Verification().DailyLimit()),
-				toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey: now.Format(verificationservice.TimestampLayout),
-			},
-			Labels: map[string]string{
-				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-			},
-		},
-		Spec: toolchainv1alpha1.UserSignupSpec{
-			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-				PreferredUsername: "shane@redhat.com",
-			},
-		},
-	}
-	states.SetVerificationRequired(userSignup, true)
+	userSignup := testusersignup.NewUserSignup(
+		testusersignup.WithName("johny"),
+		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey, strconv.Itoa(cfg.Verification().DailyLimit())),
+		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
+		testusersignup.VerificationRequired(0))
 
 	_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
@@ -514,38 +433,15 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 	// calculate the phone number hash
 	phoneHash := hash.EncodeString(e164PhoneNumber)
 
-	alphaUserSignup := &toolchainv1alpha1.UserSignup{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "alpha",
-			Namespace: configuration.Namespace(),
-			Labels: map[string]string{
-				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: phoneHash,
-				toolchainv1alpha1.UserSignupStateLabelKey:         toolchainv1alpha1.UserSignupStateLabelValueApproved,
-			},
-		},
-		Spec: toolchainv1alpha1.UserSignupSpec{
-			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-				PreferredUsername: "alpha@foxtrot.com",
-			},
-		},
-	}
-	states.SetApprovedManually(alphaUserSignup, true)
+	alphaUserSignup := testusersignup.NewUserSignup(
+		testusersignup.WithName("alpha"),
+		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, phoneHash),
+		testusersignup.WithLabel(toolchainv1alpha1.UserSignupStateLabelKey, toolchainv1alpha1.UserSignupStateLabelValueApproved),
+		testusersignup.ApprovedManually())
 
-	bravoUserSignup := &toolchainv1alpha1.UserSignup{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bravo",
-			Namespace: configuration.Namespace(),
-			Labels:    map[string]string{},
-		},
-		Spec: toolchainv1alpha1.UserSignupSpec{
-			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-				PreferredUsername: "bravo@foxtrot.com",
-			},
-		},
-	}
-	states.SetVerificationRequired(bravoUserSignup, true)
+	bravoUserSignup := testusersignup.NewUserSignup(
+		testusersignup.WithName("bravo"),
+		testusersignup.VerificationRequired(0))
 
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), alphaUserSignup, bravoUserSignup)
 
@@ -576,39 +472,16 @@ func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUs
 	// calculate the phone number hash
 	phoneHash := hash.EncodeString(e164PhoneNumber)
 
-	alphaUserSignup := &toolchainv1alpha1.UserSignup{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "alpha",
-			Namespace: configuration.Namespace(),
-			Labels: map[string]string{
-				toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: phoneHash,
-				toolchainv1alpha1.UserSignupStateLabelKey:         toolchainv1alpha1.UserSignupStateLabelValueDeactivated,
-			},
-		},
-		Spec: toolchainv1alpha1.UserSignupSpec{
-			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-				PreferredUsername: "alpha@foxtrot.com",
-			},
-		},
-	}
-	states.SetApprovedManually(alphaUserSignup, true)
-	states.SetDeactivated(alphaUserSignup, true)
+	alphaUserSignup := testusersignup.NewUserSignup(
+		testusersignup.WithName("alpha"),
+		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, phoneHash),
+		testusersignup.WithLabel(toolchainv1alpha1.UserSignupStateLabelKey, toolchainv1alpha1.UserSignupStateLabelValueDeactivated),
+		testusersignup.ApprovedManually(),
+		testusersignup.Deactivated())
 
-	bravoUserSignup := &toolchainv1alpha1.UserSignup{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bravo",
-			Namespace: configuration.Namespace(),
-			Labels:    map[string]string{},
-		},
-		Spec: toolchainv1alpha1.UserSignupSpec{
-			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-				PreferredUsername: "bravo@foxtrot.com",
-			},
-		},
-	}
-	states.SetVerificationRequired(bravoUserSignup, true)
+	bravoUserSignup := testusersignup.NewUserSignup(
+		testusersignup.WithName("bravo"),
+		testusersignup.VerificationRequired(0))
 
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), alphaUserSignup, bravoUserSignup)
 
@@ -631,27 +504,15 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 
 	s.Run("verification ok", func() {
 
-		userSignup := &toolchainv1alpha1.UserSignup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "123",
-				Namespace: configuration.Namespace(),
-				Annotations: map[string]string{
-					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:     "0.8",
-					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
-				},
-				Labels: map[string]string{
-					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-				},
-			},
-			Spec: toolchainv1alpha1.UserSignupSpec{
-				IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-					PreferredUsername: "shane@redhat.com",
-				},
-			},
-		}
-		states.SetVerificationRequired(userSignup, true)
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithName("johny"),
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey, "0.8"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, now.Add(10*time.Second).Format(verificationservice.TimestampLayout)),
+
+			testusersignup.VerificationRequired(0))
 
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
@@ -668,27 +529,14 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 
 	s.Run("verification ok for usersignup with username identifier", func() {
 
-		userSignup := &toolchainv1alpha1.UserSignup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "employee085",
-				Namespace: configuration.Namespace(),
-				Annotations: map[string]string{
-					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey:     "0.7",
-					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "654321",
-					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
-				},
-				Labels: map[string]string{
-					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-				},
-			},
-			Spec: toolchainv1alpha1.UserSignupSpec{
-				IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-					PreferredUsername: "employee085@redhat.com",
-				},
-			},
-		}
-		states.SetVerificationRequired(userSignup, true)
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithName("employee085"),
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey, "0.7"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "654321"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, now.Add(10*time.Second).Format(verificationservice.TimestampLayout)),
+			testusersignup.VerificationRequired(0))
 
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
@@ -705,25 +553,13 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 
 	s.Run("when verification code is invalid", func() {
 
-		userSignup := &toolchainv1alpha1.UserSignup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "123",
-				Namespace: configuration.Namespace(),
-				Annotations: map[string]string{
-					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "000000",
-					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
-				},
-				Labels: map[string]string{
-					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-				},
-			},
-			Spec: toolchainv1alpha1.UserSignupSpec{
-				IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-					PreferredUsername: "shane@redhat.com",
-				},
-			},
-		}
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithName("johny"),
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "000000"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, now.Add(10*time.Second).Format(verificationservice.TimestampLayout)),
+		)
 
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
@@ -738,25 +574,13 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 
 	s.Run("when verification code has expired", func() {
 
-		userSignup := &toolchainv1alpha1.UserSignup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "123",
-				Namespace: configuration.Namespace(),
-				Annotations: map[string]string{
-					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(-10 * time.Second).Format(verificationservice.TimestampLayout),
-				},
-				Labels: map[string]string{
-					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-				},
-			},
-			Spec: toolchainv1alpha1.UserSignupSpec{
-				IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-					PreferredUsername: "shane@redhat.com",
-				},
-			},
-		}
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithName("johny"),
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, now.Add(-10*time.Second).Format(verificationservice.TimestampLayout)),
+		)
 
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
@@ -770,25 +594,13 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 
 	s.Run("when verifications exceeded maximum attempts", func() {
 
-		userSignup := &toolchainv1alpha1.UserSignup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "123",
-				Namespace: configuration.Namespace(),
-				Annotations: map[string]string{
-					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "3",
-					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
-				},
-				Labels: map[string]string{
-					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-				},
-			},
-			Spec: toolchainv1alpha1.UserSignupSpec{
-				IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-					PreferredUsername: "shane@redhat.com",
-				},
-			},
-		}
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithName("johny"),
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "3"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, now.Add(10*time.Second).Format(verificationservice.TimestampLayout)),
+		)
 
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
@@ -799,25 +611,13 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 
 	s.Run("when verifications attempts has invalid value", func() {
 
-		userSignup := &toolchainv1alpha1.UserSignup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "123",
-				Namespace: configuration.Namespace(),
-				Annotations: map[string]string{
-					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "ABC",
-					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Second).Format(verificationservice.TimestampLayout),
-				},
-				Labels: map[string]string{
-					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-				},
-			},
-			Spec: toolchainv1alpha1.UserSignupSpec{
-				IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-					PreferredUsername: "shane@redhat.com",
-				},
-			},
-		}
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithName("johny"),
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "ABC"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, now.Add(10*time.Second).Format(verificationservice.TimestampLayout)),
+		)
 
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
@@ -834,25 +634,13 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 
 	s.Run("when verifications expiry is corrupt", func() {
 
-		userSignup := &toolchainv1alpha1.UserSignup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "123",
-				Namespace: configuration.Namespace(),
-				Annotations: map[string]string{
-					toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-					toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-					toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     "ABC",
-				},
-				Labels: map[string]string{
-					toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-				},
-			},
-			Spec: toolchainv1alpha1.UserSignupSpec{
-				IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-					PreferredUsername: "shane@redhat.com",
-				},
-			},
-		}
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithName("johny"),
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, "ABC"),
+		)
 
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
@@ -938,32 +726,20 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 					testconfig.RegistrationService().Verification().CaptchaRequiredScore("0.6"),
 					testconfig.RegistrationService().Verification().CaptchaAllowLowScoreReactivation(tc.allowLowScoreReactivationConfiguration),
 				)
-				userSignup := &toolchainv1alpha1.UserSignup{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "123",
-						Namespace: configuration.Namespace(),
-						Annotations: map[string]string{
-							toolchainv1alpha1.UserVerificationAttemptsAnnotationKey:   "0",
-							toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey: "123456",
-							toolchainv1alpha1.UserVerificationExpiryAnnotationKey:     now.Add(10 * time.Minute).Format(verificationservice.TimestampLayout),
-						},
-						Labels: map[string]string{
-							toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: "+1NUMBER",
-						},
-					},
-					Spec: toolchainv1alpha1.UserSignupSpec{
-						IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
-							PreferredUsername: "shane@redhat.com",
-						},
-					},
-				}
+
+				userSignup := testusersignup.NewUserSignup(
+					testusersignup.WithName("johny"),
+					testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
+					testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
+					testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
+					testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationExpiryAnnotationKey, now.Add(10*time.Second).Format(verificationservice.TimestampLayout)),
+					testusersignup.VerificationRequired(0))
 				if tc.activationCounterAnnotationValue != "" {
 					userSignup.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey] = tc.activationCounterAnnotationValue
 				}
 				if tc.captchaScoreAnnotationValue != "" {
 					userSignup.Annotations[toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey] = tc.captchaScoreAnnotationValue
 				}
-				states.SetVerificationRequired(userSignup, true)
 
 				fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 


### PR DESCRIPTION
This PR replaces manual creation of UserSignups with helper functions from toolchain common.

**Why?** 
My ultimate goal is to clean up the leftovers that stayed there after the migration of the naming format of UserSignups that happened a few years ago.
https://github.com/codeready-toolchain/registration-service/blob/690bb9c2518438097c522edd9745932aac4badb9/pkg/signup/service/signup_service.go#L557-L575
We don't use the `sub` claim (userID) for UserSignups for a few years, but most of the unit tests still do that. This change is to minimize the final PR(s) that will drop the usage & support of the UserSignups with names equal to the `sub` claim (userID).