### PR TITLE
eliminate usages of userIDs in proxy unit tests

### DIFF
--- a/pkg/proxy/handlers/spacelister_get_test.go
+++ b/pkg/proxy/handlers/spacelister_get_test.go
@@ -82,7 +82,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 			overrideMemberClient   *test.FakeClient
 		}{
 			"dancelover gets dancelover space": {
-				username: "dance.lover",
+				username: "dancelover",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "dancelover", "admin", true,
 						commonproxy.WithAvailableRoles([]string{
@@ -120,7 +120,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "dancelover",
 			},
 			"dancelover gets movielover space": {
-				username: "dance.lover",
+				username: "dancelover",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "movielover", "other", false,
 						commonproxy.WithAvailableRoles([]string{
@@ -153,7 +153,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "movielover",
 			},
 			"dancelover gets foodlover space": {
-				username: "dance.lover",
+				username: "dancelover",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "foodlover", "admin", false,
 						commonproxy.WithAvailableRoles([]string{
@@ -177,7 +177,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "foodlover",
 			},
 			"movielover gets movielover space": {
-				username: "movie.lover",
+				username: "movielover",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "movielover", "admin", true,
 						commonproxy.WithAvailableRoles([]string{
@@ -211,14 +211,14 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "movielover",
 			},
 			"movielover cannot get dancelover space": {
-				username:          "movie.lover",
+				username:          "movielover",
 				expectedWs:        nil,
 				expectedErr:       "\"workspaces.toolchain.dev.openshift.com \\\"dancelover\\\" not found\"",
 				expectedWorkspace: "dancelover",
 				expectedErrCode:   404,
 			},
 			"signup not ready yet": {
-				username: "movie.lover",
+				username: "movielover",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "movielover", "admin", true,
 						commonproxy.WithAvailableRoles([]string{
@@ -251,7 +251,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "movielover",
 			},
 			"get nstemplatetier error": {
-				username:        "dance.lover",
+				username:        "dancelover",
 				expectedWs:      nil,
 				expectedErr:     "nstemplatetier error",
 				expectedErrCode: 500,
@@ -266,7 +266,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "dancelover",
 			},
 			"get signup error": {
-				username:        "dance.lover",
+				username:        "dancelover",
 				expectedWs:      nil,
 				expectedErr:     "signup error",
 				expectedErrCode: 500,
@@ -276,14 +276,14 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "dancelover",
 			},
 			"signup has no compliant username set": {
-				username:          "racing.lover",
+				username:          "racinglover",
 				expectedWs:        nil,
 				expectedErr:       "\"workspaces.toolchain.dev.openshift.com \\\"racinglover\\\" not found\"",
 				expectedErrCode:   404,
 				expectedWorkspace: "racinglover",
 			},
 			"list spacebindings error": {
-				username:        "dance.lover",
+				username:        "dancelover",
 				expectedWs:      nil,
 				expectedErr:     "list spacebindings error",
 				expectedErrCode: 500,
@@ -298,7 +298,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "dancelover",
 			},
 			"unable to get space": {
-				username:        "dance.lover",
+				username:        "dancelover",
 				expectedWs:      nil,
 				expectedErr:     "\"workspaces.toolchain.dev.openshift.com \\\"dancelover\\\" not found\"",
 				expectedErrCode: 404,
@@ -313,7 +313,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "dancelover",
 			},
 			"unable to get parent-space": {
-				username:        "food.lover",
+				username:        "foodlover",
 				expectedWs:      nil,
 				expectedErr:     "Internal error occurred: unable to get parent-space: parent-space error",
 				expectedErrCode: 500,
@@ -328,7 +328,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "foodlover",
 			},
 			"error spaceBinding request has no name": {
-				username: "anime.lover",
+				username: "animelover",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "animelover", "admin", true,
 						commonproxy.WithAvailableRoles([]string{
@@ -341,7 +341,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "animelover",
 			},
 			"error spaceBinding request has no namespace set": {
-				username: "car.lover",
+				username: "carlover",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "carlover", "admin", true,
 						commonproxy.WithAvailableRoles([]string{
@@ -354,7 +354,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "carlover",
 			},
 			"parent can list parentspace": {
-				username: "parent.space",
+				username: "parentspace",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "parentspace", "admin", true,
 						commonproxy.WithAvailableRoles([]string{
@@ -372,7 +372,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "parentspace",
 			},
 			"parent can list childspace": {
-				username: "parent.space",
+				username: "parentspace",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "childspace", "admin", false,
 						commonproxy.WithAvailableRoles([]string{
@@ -395,7 +395,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "childspace",
 			},
 			"parent can list grandchildspace": {
-				username: "parent.space",
+				username: "parentspace",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "grandchildspace", "admin", false,
 						commonproxy.WithAvailableRoles([]string{
@@ -423,14 +423,14 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "grandchildspace",
 			},
 			"child cannot list parentspace": {
-				username:          "child.space",
+				username:          "childspace",
 				expectedWs:        nil,
 				expectedErr:       "\"workspaces.toolchain.dev.openshift.com \\\"parentspace\\\" not found\"",
 				expectedErrCode:   404,
 				expectedWorkspace: "parentspace",
 			},
 			"child can list childspace": {
-				username:          "child.space",
+				username:          "childspace",
 				expectedWorkspace: "childspace",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "childspace", "admin", true,
@@ -453,7 +453,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				},
 			},
 			"child can list grandchildspace": {
-				username:          "child.space",
+				username:          "childspace",
 				expectedWorkspace: "grandchildspace",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "grandchildspace", "admin", false,
@@ -481,7 +481,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				},
 			},
 			"grandchild can list grandchildspace": {
-				username: "grandchild.space",
+				username: "grandchildspace",
 				expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 					return []toolchainv1alpha1.Workspace{workspaceFor(t, fakeClient, "grandchildspace", "admin", true,
 						commonproxy.WithAvailableRoles([]string{
@@ -509,21 +509,21 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWorkspace: "grandchildspace",
 			},
 			"grandchild cannot list parentspace": {
-				username:          "grandchild.space",
+				username:          "grandchildspace",
 				expectedWorkspace: "parentspace",
 				expectedErr:       "\"workspaces.toolchain.dev.openshift.com \\\"parentspace\\\" not found\"",
 				expectedErrCode:   404,
 				expectedWs:        nil,
 			},
 			"grandchild cannot list childspace": {
-				username:          "grandchild.space",
+				username:          "grandchildspace",
 				expectedWorkspace: "childspace",
 				expectedErr:       "\"workspaces.toolchain.dev.openshift.com \\\"childspace\\\" not found\"",
 				expectedErrCode:   404,
 				expectedWs:        nil,
 			},
 			"no member clusters found": {
-				username:          "movie.lover",
+				username:          "movielover",
 				expectedWorkspace: "movielover",
 				expectedErr:       "no member clusters found",
 				expectedErrCode:   500,
@@ -532,7 +532,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				},
 			},
 			"error listing spacebinding requests": {
-				username:             "movie.lover",
+				username:             "movielover",
 				expectedWorkspace:    "movielover",
 				expectedErr:          "mock list error",
 				expectedErrCode:      500,
@@ -610,8 +610,8 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 func TestGetUserWorkspace(t *testing.T) {
 
 	fakeSignupService := fake.NewSignupService(
-		newSignup("batman", "batman.space", true),
-		newSignup("robin", "robin.space", true),
+		newSignup("batman", true),
+		newSignup("robin", true),
 	)
 
 	tests := map[string]struct {
@@ -623,19 +623,19 @@ func TestGetUserWorkspace(t *testing.T) {
 		overrideSignupFunc func(ctx *gin.Context, userID, username string, checkUserSignupComplete bool) (*signup.Signup, error)
 	}{
 		"get robin workspace": {
-			username:         "robin.space",
+			username:         "robin",
 			workspaceRequest: "robin",
 			expectedWorkspace: func(t *testing.T, fakeClient *test.FakeClient) toolchainv1alpha1.Workspace {
 				return workspaceFor(t, fakeClient, "robin", "admin", true)
 			},
 		},
 		"invalid number of spacebindings": {
-			username:         "batman.space",
+			username:         "batman",
 			expectedErr:      "invalid number of SpaceBindings found for MUR:batman and Space:batman. Expected 1 got 2",
 			workspaceRequest: "batman",
 		},
 		"user is unauthorized": {
-			username:         "robin.space",
+			username:         "robin",
 			workspaceRequest: "batman",
 		},
 		"usersignup not found": {
@@ -670,7 +670,7 @@ func TestGetUserWorkspace(t *testing.T) {
 			expectedWorkspace: nil, // user is not authorized
 		},
 		"get signup error": {
-			username:         "batman.space",
+			username:         "batman",
 			workspaceRequest: "batman",
 			expectedErr:      "signup error",
 			overrideSignupFunc: func(_ *gin.Context, _, _ string, _ bool) (*signup.Signup, error) {
@@ -679,7 +679,7 @@ func TestGetUserWorkspace(t *testing.T) {
 			expectedWorkspace: nil,
 		},
 		"list spacebindings error": {
-			username:         "robin.space",
+			username:         "robin",
 			workspaceRequest: "robin",
 			expectedErr:      "list spacebindings error",
 			mockFakeClient: func(fakeClient *test.FakeClient) {
@@ -699,7 +699,7 @@ func TestGetUserWorkspace(t *testing.T) {
 			expectedWorkspace: nil,
 		},
 		"batman can not get robin workspace": { // Because public viewer feature is NOT enabled
-			username:          "batman.space",
+			username:          "batman",
 			workspaceRequest:  "robin",
 			expectedErr:       "",
 			expectedWorkspace: nil,
@@ -768,9 +768,9 @@ func TestGetUserWorkspace(t *testing.T) {
 func TestSpaceListerGetPublicViewerEnabled(t *testing.T) {
 
 	fakeSignupService := fake.NewSignupService(
-		newSignup("batman", "batman.space", true),
-		newSignup("robin", "robin.space", true),
-		newSignup("gordon", "gordon.no-space", false),
+		newSignup("batman", true),
+		newSignup("robin", true),
+		newSignup("gordon", false),
 	)
 
 	fakeClient := test.NewFakeClient(t,
@@ -799,32 +799,32 @@ func TestSpaceListerGetPublicViewerEnabled(t *testing.T) {
 		expectedWorkspace *toolchainv1alpha1.Workspace
 	}{
 		"robin can get robin workspace": {
-			username:          "robin.space",
+			username:          "robin",
 			workspaceRequest:  "robin",
 			expectedWorkspace: &robinWS,
 		},
 		"batman can get batman workspace": {
-			username:          "batman.space",
+			username:          "batman",
 			workspaceRequest:  "batman",
 			expectedWorkspace: &batmanWS,
 		},
 		"batman can get robin workspace as public-viewer": {
-			username:          "batman.space",
+			username:          "batman",
 			workspaceRequest:  "robin",
 			expectedWorkspace: publicRobinWS,
 		},
 		"robin can not get batman workspace": {
-			username:          "robin.space",
+			username:          "robin",
 			workspaceRequest:  "batman",
 			expectedWorkspace: nil,
 		},
 		"gordon can get robin workspace as public-viewer": {
-			username:          "gordon.no-space",
+			username:          "gordon",
 			workspaceRequest:  "robin",
 			expectedWorkspace: publicRobinWS,
 		},
 		"gordon can not get batman workspace": {
-			username:          "gordon.no-space",
+			username:          "gordon",
 			workspaceRequest:  "batman",
 			expectedWorkspace: nil,
 		},
@@ -871,9 +871,9 @@ func TestSpaceListerGetPublicViewerEnabled(t *testing.T) {
 func TestGetUserWorkspaceWithBindingsWithPublicViewerEnabled(t *testing.T) {
 
 	fakeSignupService := fake.NewSignupService(
-		newSignup("batman", "batman.space", true),
-		newSignup("robin", "robin.space", true),
-		newSignup("gordon", "gordon.no-space", false),
+		newSignup("batman", true),
+		newSignup("robin", true),
+		newSignup("gordon", false),
 	)
 
 	fakeClient := test.NewFakeClient(t,
@@ -924,17 +924,17 @@ func TestGetUserWorkspaceWithBindingsWithPublicViewerEnabled(t *testing.T) {
 		expectedWorkspace *toolchainv1alpha1.Workspace
 	}{
 		"robin can get robin workspace": {
-			username:          "robin.space",
+			username:          "robin",
 			workspaceRequest:  "robin",
 			expectedWorkspace: &robinWS,
 		},
 		"batman can get batman workspace": {
-			username:          "batman.space",
+			username:          "batman",
 			workspaceRequest:  "batman",
 			expectedWorkspace: &batmanWS,
 		},
 		"batman can get robin workspace": {
-			username:         "batman.space",
+			username:         "batman",
 			workspaceRequest: "robin",
 			expectedWorkspace: func() *toolchainv1alpha1.Workspace {
 				batmansRobinWS := robinWS.DeepCopy()
@@ -944,17 +944,17 @@ func TestGetUserWorkspaceWithBindingsWithPublicViewerEnabled(t *testing.T) {
 			}(),
 		},
 		"robin can not get batman workspace": {
-			username:          "robin.space",
+			username:          "robin",
 			workspaceRequest:  "batman",
 			expectedWorkspace: nil,
 		},
 		"gordon can not get batman workspace": {
-			username:          "gordon.no-space",
+			username:          "gordon",
 			workspaceRequest:  "batman",
 			expectedWorkspace: nil,
 		},
 		"gordon can get robin workspace": {
-			username:         "gordon.no-space",
+			username:         "gordon",
 			workspaceRequest: "robin",
 			expectedWorkspace: func() *toolchainv1alpha1.Workspace {
 				batmansRobinWS := robinWS.DeepCopy()

--- a/pkg/proxy/handlers/spacelister_list_test.go
+++ b/pkg/proxy/handlers/spacelister_list_test.go
@@ -30,15 +30,15 @@ import (
 func TestListUserWorkspaces(t *testing.T) {
 	tests := map[string]struct {
 		username            string
-		additionalSignups   []fake.SignupDef
+		additionalSignups   []*signup.Signup
 		additionalObjects   []runtimeclient.Object
 		expectedWorkspaces  func(*test.FakeClient) []toolchainv1alpha1.Workspace
 		publicViewerEnabled bool
 	}{
 		"dancelover lists spaces with public-viewer enabled": {
-			username: "dance.lover",
-			additionalSignups: []fake.SignupDef{
-				newSignup("communitylover", "community.lover", true),
+			username: "dancelover",
+			additionalSignups: []*signup.Signup{
+				newSignup("communitylover", true),
 			},
 			additionalObjects: []runtimeclient.Object{
 				fake.NewSpace("communitylover", "member-1", "communitylover", space.WithTierName("appstudio")),
@@ -54,7 +54,7 @@ func TestListUserWorkspaces(t *testing.T) {
 			publicViewerEnabled: true,
 		},
 		"dancelover lists spaces with public-viewer disabled": {
-			username: "dance.lover",
+			username: "dancelover",
 			expectedWorkspaces: func(fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 				return []toolchainv1alpha1.Workspace{
 					workspaceFor(t, fakeClient, "dancelover", "admin", true),
@@ -126,7 +126,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 				mockFakeClient     func(fakeClient *test.FakeClient)
 			}{
 				"dancelover lists spaces": {
-					username: "dance.lover",
+					username: "dancelover",
 					expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 						return []toolchainv1alpha1.Workspace{
 							workspaceFor(t, fakeClient, "dancelover", "admin", true),
@@ -136,7 +136,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 					expectedErr: "",
 				},
 				"movielover lists spaces": {
-					username: "movie.lover",
+					username: "movielover",
 					expectedWs: func(t *testing.T, fakeClient *test.FakeClient) []toolchainv1alpha1.Workspace {
 						return []toolchainv1alpha1.Workspace{
 							workspaceFor(t, fakeClient, "movielover", "admin", true),
@@ -145,25 +145,25 @@ func TestHandleSpaceListRequest(t *testing.T) {
 					expectedErr: "",
 				},
 				"signup has no compliant username set": {
-					username:        "racing.lover",
+					username:        "racinglover",
 					expectedWs:      nil,
 					expectedErr:     "",
 					expectedErrCode: 200,
 				},
 				"space not initialized yet": {
-					username:        "panda.lover",
+					username:        "pandalover",
 					expectedWs:      nil,
 					expectedErr:     "",
 					expectedErrCode: 200,
 				},
 				"no spaces found": {
-					username:        "user.nospace",
+					username:        "usernospace",
 					expectedWs:      nil,
 					expectedErr:     "",
 					expectedErrCode: 200,
 				},
 				"informer error": {
-					username:        "dance.lover",
+					username:        "dancelover",
 					expectedWs:      nil,
 					expectedErr:     "list spacebindings error",
 					expectedErrCode: 500,
@@ -177,7 +177,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 					},
 				},
 				"get signup error": {
-					username:        "dance.lover",
+					username:        "dancelover",
 					expectedWs:      nil,
 					expectedErr:     "signup error",
 					expectedErrCode: 500,

--- a/pkg/proxy/handlers/spacelister_test.go
+++ b/pkg/proxy/handlers/spacelister_test.go
@@ -23,19 +23,19 @@ func buildSpaceListerFakes(t *testing.T) (*fake.SignupService, *test.FakeClient)
 	return buildSpaceListerFakesWithResources(t, nil, nil)
 }
 
-func buildSpaceListerFakesWithResources(t *testing.T, signups []fake.SignupDef, objs []client.Object) (*fake.SignupService, *test.FakeClient) {
+func buildSpaceListerFakesWithResources(t *testing.T, signups []*signup.Signup, objs []client.Object) (*fake.SignupService, *test.FakeClient) {
 	ss := append(signups,
-		newSignup("dancelover", "dance.lover", true),
-		newSignup("movielover", "movie.lover", true),
-		newSignup("pandalover", "panda.lover", true),
-		newSignup("usernospace", "user.nospace", true),
-		newSignup("foodlover", "food.lover", true),
-		newSignup("animelover", "anime.lover", true),
-		newSignup("carlover", "car.lover", true),
-		newSignup("racinglover", "racing.lover", false),
-		newSignup("parentspace", "parent.space", true),
-		newSignup("childspace", "child.space", true),
-		newSignup("grandchildspace", "grandchild.space", true),
+		newSignup("dancelover", true),
+		newSignup("movielover", true),
+		newSignup("pandalover", true),
+		newSignup("usernospace", true),
+		newSignup("foodlover", true),
+		newSignup("animelover", true),
+		newSignup("carlover", true),
+		newSignup("racinglover", false),
+		newSignup("parentspace", true),
+		newSignup("childspace", true),
+		newSignup("grandchildspace", true),
 	)
 	fakeSignupService := fake.NewSignupService(ss...)
 
@@ -103,22 +103,20 @@ func buildSpaceListerFakesWithResources(t *testing.T, signups []fake.SignupDef, 
 	return fakeSignupService, test.NewFakeClient(t, oo...)
 }
 
-func newSignup(signupName, username string, ready bool) fake.SignupDef {
+func newSignup(signupName string, ready bool) *signup.Signup {
 	compliantUsername := signupName
 	if !ready {
 		// signup is not ready, let's set compliant username to blank
 		compliantUsername = ""
 	}
-	us := fake.Signup(signupName, &signup.Signup{
+	return &signup.Signup{
 		Name:              signupName,
-		Username:          username,
+		Username:          signupName,
 		CompliantUsername: compliantUsername,
 		Status: signup.Status{
 			Ready: ready,
 		},
-	})
-
-	return us
+	}
 }
 
 func decodeResponseToWorkspace(data []byte) (*toolchainv1alpha1.Workspace, error) {

--- a/pkg/proxy/proxy_community_test.go
+++ b/pkg/proxy/proxy_community_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/codeready-toolchain/registration-service/test/fake"
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
-	"github.com/google/uuid"
 	"go.uber.org/atomic"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -72,15 +71,15 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 
 	s.Run("successfully proxy", func() {
 		// user with public workspace
-		smith := uuid.New()
+		smith := "smith"
 		// user with private workspace
-		alice := uuid.New()
+		alice := "alice"
 		// unsigned user
-		bob := uuid.New()
+		bob := "bob"
 		// not ready
-		john := uuid.New()
+		john := "john"
 		// banned user
-		eve, eveEmail := uuid.New(), "eve@somecorp.com"
+		eve, eveEmail := "eve", "eve@somecorp.com"
 
 		// Start the member-2 API Server
 		httpTestServerResponse := "my response"
@@ -89,43 +88,43 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 
 		// initialize SignupService
 		signupService := fake.NewSignupService(
-			fake.Signup(smith.String(), &signup.Signup{
-				Name:              "smith",
+			&signup.Signup{
+				Name:              smith,
 				APIEndpoint:       testServer.URL,
 				ClusterName:       "member-2",
-				CompliantUsername: "smith",
+				CompliantUsername: smith,
 				Username:          "smith@",
 				Status: signup.Status{
 					Ready: true,
 				},
-			}),
-			fake.Signup(alice.String(), &signup.Signup{
-				Name:              "alice",
+			},
+			&signup.Signup{
+				Name:              alice,
 				APIEndpoint:       testServer.URL,
 				ClusterName:       "member-2",
-				CompliantUsername: "alice",
+				CompliantUsername: alice,
 				Username:          "alice@",
 				Status: signup.Status{
 					Ready: true,
 				},
-			}),
-			fake.Signup(john.String(), &signup.Signup{
-				Name:              "john",
-				CompliantUsername: "john",
+			},
+			&signup.Signup{
+				Name:              john,
+				CompliantUsername: john,
 				Username:          "john@",
 				Status: signup.Status{
 					Ready: false,
 				},
-			}),
-			fake.Signup(eve.String(), &signup.Signup{
-				Name:              "eve",
-				CompliantUsername: "eve",
+			},
+			&signup.Signup{
+				Name:              eve,
+				CompliantUsername: eve,
 				Username:          "eve@",
 				Status: signup.Status{
 					Ready:  false,
 					Reason: toolchainv1alpha1.UserSignupUserBannedReason,
 				},
-			}),
+			},
 		)
 
 		// init fakeClient
@@ -173,7 +172,7 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 				ExpectedAPIServerRequestHeaders: map[string][]string{
 					"Authorization":    {"Bearer clusterSAToken"},
 					"Impersonate-User": {"smith"},
-					"X-SSO-User":       {"username-" + smith.String()},
+					"X-SSO-User":       {smith},
 				},
 				ExpectedProxyResponseStatus: http.StatusOK,
 				RequestPath:                 podsRequestURL("smith-community"),
@@ -191,7 +190,7 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 				ExpectedAPIServerRequestHeaders: map[string][]string{
 					"Authorization":    {"Bearer clusterSAToken"},
 					"Impersonate-User": {toolchainv1alpha1.KubesawAuthenticatedUsername},
-					"X-SSO-User":       {"username-" + john.String()},
+					"X-SSO-User":       {john},
 				},
 				ExpectedProxyResponseStatus: http.StatusOK,
 				RequestPath:                 podsRequestURL("smith-community"),
@@ -209,7 +208,7 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 				ExpectedAPIServerRequestHeaders: map[string][]string{
 					"Authorization":    {"Bearer clusterSAToken"},
 					"Impersonate-User": {toolchainv1alpha1.KubesawAuthenticatedUsername},
-					"X-SSO-User":       {"username-" + bob.String()},
+					"X-SSO-User":       {bob},
 				},
 				ExpectedProxyResponseStatus: http.StatusOK,
 				RequestPath:                 podsRequestURL("smith-community"),
@@ -230,7 +229,7 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 				ExpectedAPIServerRequestHeaders: map[string][]string{
 					"Authorization":    {"Bearer clusterSAToken"},
 					"Impersonate-User": {toolchainv1alpha1.KubesawAuthenticatedUsername},
-					"X-SSO-User":       {"username-" + alice.String()},
+					"X-SSO-User":       {alice},
 				},
 				ExpectedProxyResponseStatus: http.StatusOK,
 				RequestPath:                 podsRequestURL("smith-community"),
@@ -288,7 +287,7 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 				ExpectedAPIServerRequestHeaders: map[string][]string{
 					"Authorization":    {"Bearer clusterSAToken"},
 					"Impersonate-User": {"alice"},
-					"X-SSO-User":       {"username-" + alice.String()},
+					"X-SSO-User":       {alice},
 				},
 				ExpectedProxyResponseStatus: http.StatusOK,
 				RequestPath:                 podsInNamespaceRequestURL("alice-private", "outside-of-workspace-namespace"),
@@ -307,7 +306,7 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 				ExpectedAPIServerRequestHeaders: map[string][]string{
 					"Authorization":    {"Bearer clusterSAToken"},
 					"Impersonate-User": {"smith"},
-					"X-SSO-User":       {"username-" + smith.String()},
+					"X-SSO-User":       {smith},
 				},
 				ExpectedProxyResponseStatus: http.StatusOK,
 				RequestPath:                 podsInNamespaceRequestURL("smith-community", "outside-of-workspace-namespace"),
@@ -326,7 +325,7 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 				ExpectedAPIServerRequestHeaders: map[string][]string{
 					"Authorization":    {"Bearer clusterSAToken"},
 					"Impersonate-User": {toolchainv1alpha1.KubesawAuthenticatedUsername},
-					"X-SSO-User":       {"username-" + alice.String()},
+					"X-SSO-User":       {alice},
 				},
 				ExpectedProxyResponseStatus: http.StatusOK,
 				RequestPath:                 podsInNamespaceRequestURL("smith-community", "outside-of-workspace-namespace"),
@@ -344,7 +343,7 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 				ExpectedAPIServerRequestHeaders: map[string][]string{
 					"Authorization":    {"Bearer clusterSAToken"},
 					"Impersonate-User": {toolchainv1alpha1.KubesawAuthenticatedUsername},
-					"X-SSO-User":       {"username-" + bob.String()},
+					"X-SSO-User":       {bob},
 				},
 				ExpectedProxyResponseStatus: http.StatusOK,
 				RequestPath:                 podsInNamespaceRequestURL("smith-community", "outside-of-workspace-namespace"),
@@ -363,7 +362,7 @@ func (s *TestProxySuite) checkProxyCommunityOK(proxy *Proxy, port string) {
 				ExpectedAPIServerRequestHeaders: map[string][]string{
 					"Authorization":    {"Bearer clusterSAToken"},
 					"Impersonate-User": {toolchainv1alpha1.KubesawAuthenticatedUsername},
-					"X-SSO-User":       {"username-" + john.String()},
+					"X-SSO-User":       {john},
 				},
 				ExpectedProxyResponseStatus: http.StatusOK,
 				RequestPath:                 podsInNamespaceRequestURL("smith-community", "outside-of-workspace-namespace"),

--- a/test/fake/proxy.go
+++ b/test/fake/proxy.go
@@ -8,19 +8,10 @@ import (
 
 // This whole service abstraction is such a huge pain. We have to get rid of it!!!
 
-type SignupDef func() (string, *signup.Signup)
-
-func Signup(identifier string, userSignup *signup.Signup) SignupDef {
-	return func() (string, *signup.Signup) {
-		return identifier, userSignup
-	}
-}
-
-func NewSignupService(signupDefs ...SignupDef) *SignupService {
+func NewSignupService(signups ...*signup.Signup) *SignupService {
 	sc := newFakeSignupService()
-	for _, signupDef := range signupDefs {
-		identifier, signup := signupDef()
-		sc.addSignup(identifier, signup)
+	for _, signup := range signups {
+		sc.addSignup(signup.Name, signup)
 	}
 	return sc
 }
@@ -45,17 +36,8 @@ type SignupService struct {
 }
 
 func (m *SignupService) DefaultMockGetSignup() func(userID, username string) (*signup.Signup, error) {
-	return func(userID, username string) (userSignup *signup.Signup, e error) {
-		us := m.userSignups[userID]
-		if us != nil {
-			return us, nil
-		}
-		for _, v := range m.userSignups {
-			if v.Username == username {
-				return v, nil
-			}
-		}
-		return nil, nil
+	return func(_, username string) (userSignup *signup.Signup, e error) {
+		return m.userSignups[username], nil
 	}
 }
 


### PR DESCRIPTION
this PR eliminates the usage of userID in the proxy unit tests, it relies on username instead

**Why?** 
My ultimate goal is to clean up the leftovers that stayed there after the migration of the naming format of UserSignups that happened a few years ago.
https://github.com/codeready-toolchain/registration-service/blob/690bb9c2518438097c522edd9745932aac4badb9/pkg/signup/service/signup_service.go#L557-L575
We don't use the `sub` claim (userID) for UserSignups for a few years, but most of the unit tests still do that. This change is to minimize the final PR(s) that will drop the usage & support of the UserSignups with names equal to the `sub` claim (userID).

[KUBESAW-254](https://issues.redhat.com/browse/KUBESAW-254)