### PR TITLE
move EncodeUserIdentifier & drop userID from tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/aws/aws-sdk-go v1.44.100
 	github.com/codeready-toolchain/api v0.0.0-20250121053759-af12adf8e938
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20250121053752-f7e2c17c3c6b
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20250127073039-8ef21eb833fa
 	github.com/go-logr/logr v1.4.1
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -17,8 +17,6 @@ require (
 	k8s.io/client-go v0.27.3
 	sigs.k8s.io/controller-runtime v0.15.0
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20250124122648-3070b9b8e676
 
 require (
 	cloud.google.com/go/recaptchaenterprise/v2 v2.13.0

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.15.0
 )
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20250124122648-3070b9b8e676
+
 require (
 	cloud.google.com/go/recaptchaenterprise/v2 v2.13.0
 	github.com/gin-contrib/cors v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBS
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/codeready-toolchain/api v0.0.0-20250121053759-af12adf8e938 h1:cj2H8bhNTjHVMUJnPEpLW8nLV9YMnG2nQ3oTgMJWsbI=
 github.com/codeready-toolchain/api v0.0.0-20250121053759-af12adf8e938/go.mod h1:2KYfJlFwZtiKfa5QDhQfXTFh6RyALilURWBXyfKmKso=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250121053752-f7e2c17c3c6b h1:AjguQB0pvRBaArWMs6pzdKu0IimYcfK4MIpM+vwf8us=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250121053752-f7e2c17c3c6b/go.mod h1:YAvlMiumFFmUR8A3eF5TDjyn1KyhKbpdwCMdLKtupGA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -255,6 +253,8 @@ github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmt
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/matousjobanek/toolchain-common v0.0.0-20250124122648-3070b9b8e676 h1:nhi1a6EJTbDvbB+BDM5r5SB9RN6pwQY4lKBoSDIgAoI=
+github.com/matousjobanek/toolchain-common v0.0.0-20250124122648-3070b9b8e676/go.mod h1:wLXGFyEan+RJHZEEMmvTxNa2BrlizIA+4+Lsi1cyuAk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215 h1:hDa3vAq/Zo5gjfJ46XMsGFbH+hTizpR4fUzQCk2nxgk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215/go.mod h1:LH+NgPY9AJpDfqAFtzyer01N9MYNsAKUf3DC9DV1xIY=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBS
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/codeready-toolchain/api v0.0.0-20250121053759-af12adf8e938 h1:cj2H8bhNTjHVMUJnPEpLW8nLV9YMnG2nQ3oTgMJWsbI=
 github.com/codeready-toolchain/api v0.0.0-20250121053759-af12adf8e938/go.mod h1:2KYfJlFwZtiKfa5QDhQfXTFh6RyALilURWBXyfKmKso=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20250127073039-8ef21eb833fa h1:75flfyrKUpq8Ppi/BRSaAUdBGD9wtWMDvL3kYqSRt1s=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20250127073039-8ef21eb833fa/go.mod h1:YAvlMiumFFmUR8A3eF5TDjyn1KyhKbpdwCMdLKtupGA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -253,8 +255,6 @@ github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmt
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/matousjobanek/toolchain-common v0.0.0-20250124122648-3070b9b8e676 h1:nhi1a6EJTbDvbB+BDM5r5SB9RN6pwQY4lKBoSDIgAoI=
-github.com/matousjobanek/toolchain-common v0.0.0-20250124122648-3070b9b8e676/go.mod h1:wLXGFyEan+RJHZEEMmvTxNa2BrlizIA+4+Lsi1cyuAk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215 h1:hDa3vAq/Zo5gjfJ46XMsGFbH+hTizpR4fUzQCk2nxgk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215/go.mod h1:LH+NgPY9AJpDfqAFtzyer01N9MYNsAKUf3DC9DV1xIY=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -28,7 +28,6 @@ import (
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	testsocialevent "github.com/codeready-toolchain/toolchain-common/pkg/test/socialevent"
 	testusersignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
-	apiv1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gin-gonic/gin"
@@ -95,16 +94,16 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 		require.NoError(s.T(), err)
 		expectedUserID := ob.String()
 		ctx.Set(context.SubKey, expectedUserID)
-		ctx.Set(context.UsernameKey, "bill")
+		ctx.Set(context.UsernameKey, "bill@kubesaw")
 		ctx.Set(context.EmailKey, expectedUserID+"@test.com")
 		signup := testusersignup.NewUserSignup(
-			testusersignup.WithName("bill"),
-			IncompleteUserSignupCondition(),
+			testusersignup.WithEncodedName("bill@kubesaw"),
+			testusersignup.SignupIncomplete("test_reason", "test_message"),
 		)
 
 		svc.MockSignup = func(ctx *gin.Context) (*crtapi.UserSignup, error) {
 			assert.Equal(s.T(), expectedUserID, ctx.GetString(context.SubKey))
-			assert.Equal(s.T(), "bill", ctx.GetString(context.UsernameKey))
+			assert.Equal(s.T(), "bill@kubesaw", ctx.GetString(context.UsernameKey))
 			assert.Equal(s.T(), expectedUserID+"@test.com", ctx.GetString(context.EmailKey))
 			return signup, nil
 		}
@@ -147,19 +146,6 @@ func (s *TestSignupSuite) TestSignupPostHandler() {
 	})
 }
 
-func IncompleteUserSignupCondition() testusersignup.Modifier {
-	return func(userSignup *crtapi.UserSignup) {
-		userSignup.Status.Conditions = []crtapi.Condition{
-			{
-				Type:    crtapi.UserSignupComplete,
-				Status:  apiv1.ConditionFalse,
-				Reason:  "test_reason",
-				Message: "test_message",
-			},
-		}
-	}
-}
-
 func (s *TestSignupSuite) TestSignupGetHandler() {
 	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
 	// pass 'nil' as the third parameter.
@@ -175,7 +161,7 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 	// Create UserSignup
 	ob, err := uuid.NewV4()
 	require.NoError(s.T(), err)
-	userID := ob.String()
+	username := ob.String()
 
 	// Create Signup controller instance.
 	ctrl := controller.NewSignup(application)
@@ -186,7 +172,7 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 		rr := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(rr)
 		ctx.Request = req
-		ctx.Set(context.SubKey, userID)
+		ctx.Set(context.UsernameKey, username)
 
 		targetCluster, err := uuid.NewV4()
 		require.NoError(s.T(), err)
@@ -200,8 +186,8 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 				Reason: "Provisioning",
 			},
 		}
-		svc.MockGetSignup = func(_ *gin.Context, id, _ string, _ bool) (*signup.Signup, error) {
-			if id == userID {
+		svc.MockGetSignup = func(_ *gin.Context, _, name string, _ bool) (*signup.Signup, error) {
+			if name == username {
 				return expected, nil
 			}
 			return nil, nil
@@ -225,7 +211,7 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 		rr := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(rr)
 		ctx.Request = req
-		ctx.Set(context.SubKey, userID)
+		ctx.Set(context.UsernameKey, username)
 
 		svc.MockGetSignup = func(_ *gin.Context, _, _ string, _ bool) (*signup.Signup, error) {
 			return nil, nil
@@ -242,7 +228,7 @@ func (s *TestSignupSuite) TestSignupGetHandler() {
 		rr := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(rr)
 		ctx.Request = req
-		ctx.Set(context.SubKey, userID)
+		ctx.Set(context.UsernameKey, username)
 
 		svc.MockGetSignup = func(_ *gin.Context, _, _ string, _ bool) (*signup.Signup, error) {
 			return nil, errors.New("oopsie woopsie")
@@ -261,12 +247,10 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 
 	// Create UserSignup
 	userSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("johnny"),
+		testusersignup.WithEncodedName("johnny@kubesaw"),
 		testusersignup.WithAnnotation(crtapi.UserSignupVerificationCounterAnnotationKey, "0"),
 		testusersignup.WithAnnotation(crtapi.UserSignupVerificationCodeAnnotationKey, ""),
 		testusersignup.VerificationRequiredAgo(time.Second))
-	userID := userSignup.Spec.IdentityClaims.UserID
-
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 	defer gock.Off()
 
@@ -280,7 +264,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 			BodyString("")
 
 		data := []byte(fmt.Sprintf(`{"phone_number": "%s", "country_code": "1"}`, phoneNumber))
-		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, userID, "johnny", http.MethodPut, "/api/v1/signup/verification")
+		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, "johnny@kubesaw", http.MethodPut, "/api/v1/signup/verification")
 		require.Equal(s.T(), http.StatusNoContent, rr.Code)
 
 		updatedUserSignup := &crtapi.UserSignup{}
@@ -314,7 +298,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 			BodyString("")
 
 		data := []byte(`{"phone_number": "2268213044", "country_code": "(1)"}`)
-		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, userID, "johnny", http.MethodPut, "/api/v1/signup/verification")
+		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, "johnny@kubesaw", http.MethodPut, "/api/v1/signup/verification")
 		require.Equal(s.T(), http.StatusBadRequest, rr.Code)
 
 		bodyParams := make(map[string]interface{})
@@ -328,7 +312,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 	})
 	s.Run("init verification request body could not be read", func() {
 		data := []byte(`{"test_number": "2268213044", "test_code": "1"}`)
-		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, userID, "johnny", http.MethodPut, "/api/v1/signup/verification")
+		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, "johnny@kubesaw", http.MethodPut, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
@@ -352,7 +336,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 		defer s.SetConfig(testconfig.RegistrationService().Verification().DailyLimit(originalValue))
 
 		data := []byte(`{"phone_number": "2268213044", "country_code": "1"}`)
-		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, userID, "johnny", http.MethodPut, "/api/v1/signup/verification")
+		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, "johnny@kubesaw", http.MethodPut, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		assert.Equal(s.T(), http.StatusForbidden, rr.Code, "handler returned wrong status code")
@@ -360,8 +344,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 
 	s.Run("init verification handler fails when verification not required", func() {
 		// Create UserSignup
-		userSignup := testusersignup.NewUserSignup(testusersignup.WithName("johnny"))
-		userID := userSignup.Spec.IdentityClaims.UserID
+		userSignup := testusersignup.NewUserSignup(testusersignup.WithEncodedName("johnny@kubesaw"))
 
 		_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
@@ -370,7 +353,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 		handler := gin.HandlerFunc(ctrl.InitVerificationHandler)
 
 		data := []byte(`{"phone_number": "2268213044", "country_code": "1"}`)
-		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, userID, "johnny", http.MethodPut, "/api/v1/signup/verification")
+		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, "johnny@kubesaw", http.MethodPut, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
@@ -386,26 +369,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 	})
 
 	s.Run("init verification handler fails when invalid phone number provided", func() {
-		// Create UserSignup
-		ob, err := uuid.NewV4()
-		require.NoError(s.T(), err)
-		userID := ob.String()
-
-		// Create a mock SignupService
-		svc := &FakeSignupService{
-			MockGetUserSignupFromIdentifier: func(_, _ string) (userSignup *crtapi.UserSignup, e error) {
-				return testusersignup.NewUserSignup(
-					testusersignup.WithName("johnny"),
-					testusersignup.VerificationRequiredAgo(time.Second)), nil
-			},
-			MockPhoneNumberAlreadyInUse: func(_, _, _ string) error {
-				return nil
-			},
-		}
-
-		_, application := testutil.PrepareInClusterAppWithOption(s.T(), func(serviceFactory *factory.ServiceFactory) {
-			serviceFactory.WithSignupService(svc)
-		}, userSignup)
+		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		// Create Signup controller instance.
 		ctrl := controller.NewSignup(application)
@@ -413,7 +377,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 
 		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
 		data := []byte(`{"phone_number": "!226%213044", "country_code": "1"}`)
-		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, userID, "johnny", http.MethodPut, "/api/v1/signup/verification")
+		rr := initPhoneVerification(s.T(), handler, gin.Param{}, data, "johnny@kubesaw", http.MethodPut, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
@@ -423,11 +387,10 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 	// Create UserSignup
 	userSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("johnny"),
+		testusersignup.WithEncodedName("johnny@kubesaw"),
 		testusersignup.WithAnnotation(crtapi.UserVerificationAttemptsAnnotationKey, "0"),
 		testusersignup.WithAnnotation(crtapi.UserSignupVerificationCodeAnnotationKey, "999888"),
 		testusersignup.WithAnnotation(crtapi.UserVerificationExpiryAnnotationKey, time.Now().Add(10*time.Second).Format(service.TimestampLayout)))
-	userID := userSignup.Spec.IdentityClaims.UserID
 
 	s.Run("verification successful", func() {
 		// Create Signup controller instance.
@@ -439,7 +402,7 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 			Key:   "code",
 			Value: "999888",
 		}
-		rr := initPhoneVerification(s.T(), handler, param, nil, userID, "johnny", http.MethodGet, "/api/v1/signup/verification")
+		rr := initPhoneVerification(s.T(), handler, param, nil, "johnny@kubesaw", http.MethodGet, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusOK, rr.Code)
@@ -470,7 +433,7 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 			Key:   "code",
 			Value: "111233",
 		}
-		rr := initPhoneVerification(s.T(), handler, param, nil, userID, "johnny", http.MethodGet, "/api/v1/signup/verification")
+		rr := initPhoneVerification(s.T(), handler, param, nil, "johnny@kubesaw", http.MethodGet, "/api/v1/signup/verification")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusInternalServerError, rr.Code)
@@ -481,7 +444,7 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 
 		require.Equal(s.T(), "Internal Server Error", bodyParams["status"])
 		require.InDelta(s.T(), float64(500), bodyParams["code"], 0.01)
-		require.Equal(s.T(), fmt.Sprintf("no user: error retrieving usersignup: %s", userID), bodyParams["message"])
+		require.Equal(s.T(), "no user: error retrieving usersignup: ", bodyParams["message"])
 		require.Equal(s.T(), "error while verifying phone code", bodyParams["details"])
 	})
 
@@ -496,7 +459,7 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 			Key:   "code",
 			Value: "111233",
 		}
-		rr := initPhoneVerification(s.T(), handler, param, nil, userID, "jsmith", http.MethodGet, "/api/v1/signup/verification/111233")
+		rr := initPhoneVerification(s.T(), handler, param, nil, "jsmith@kubesaw", http.MethodGet, "/api/v1/signup/verification/111233")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusNotFound, rr.Code)
@@ -507,7 +470,7 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 
 		require.Equal(s.T(), "Not Found", bodyParams["status"])
 		require.InDelta(s.T(), float64(404), bodyParams["code"], 0.01)
-		require.Equal(s.T(), "usersignups.toolchain.dev.openshift.com \"jsmith\" not found: user not found", bodyParams["message"])
+		require.Equal(s.T(), "usersignups.toolchain.dev.openshift.com \"fdebf2d6-jsmithkubesaw\" not found: user not found", bodyParams["message"])
 		require.Equal(s.T(), "error while verifying phone code", bodyParams["details"])
 	})
 
@@ -524,7 +487,7 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 			Key:   "code",
 			Value: "555555",
 		}
-		rr := initPhoneVerification(s.T(), handler, param, nil, userID, "johnny", http.MethodGet,
+		rr := initPhoneVerification(s.T(), handler, param, nil, "johnny@kubesaw", http.MethodGet,
 			"/api/v1/signup/verification/555555")
 
 		// Check the status code is what we expect.
@@ -558,7 +521,7 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 			Key:   "code",
 			Value: "333333",
 		}
-		rr := initPhoneVerification(s.T(), handler, param, nil, userID, "johnny", http.MethodGet, "/api/v1/signup/verification/333333")
+		rr := initPhoneVerification(s.T(), handler, param, nil, "johnny@kubesaw", http.MethodGet, "/api/v1/signup/verification/333333")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusTooManyRequests, rr.Code)
@@ -583,55 +546,20 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 			Key:   "code",
 			Value: "",
 		}
-		rr := initPhoneVerification(s.T(), handler, param, nil, userID, "", http.MethodGet, "/api/v1/signup/verification/")
+		rr := initPhoneVerification(s.T(), handler, param, nil, "", http.MethodGet, "/api/v1/signup/verification/")
 
 		// Check the status code is what we expect.
 		require.Equal(s.T(), http.StatusBadRequest, rr.Code)
 	})
-
-	s.Run("usersignup stored by its username", func() {
-		// Create another UserSignup
-		otherUserSignup := testusersignup.NewUserSignup(
-			testusersignup.WithName("jsmith"),
-			testusersignup.WithAnnotation(crtapi.UserVerificationAttemptsAnnotationKey, "0"),
-			testusersignup.WithAnnotation(crtapi.UserSignupVerificationCodeAnnotationKey, "999127"),
-			testusersignup.WithAnnotation(crtapi.UserVerificationExpiryAnnotationKey, time.Now().Add(10*time.Second).Format(service.TimestampLayout)))
-
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), otherUserSignup, userSignup)
-
-		// Create Signup controller instance.
-		ctrl := controller.NewSignup(application)
-		handler := gin.HandlerFunc(ctrl.VerifyPhoneCodeHandler)
-
-		param := gin.Param{
-			Key:   "code",
-			Value: "999127",
-		}
-		rr := initPhoneVerification(s.T(), handler, param, nil, "", otherUserSignup.Spec.IdentityClaims.PreferredUsername, http.MethodGet, "/api/v1/signup/verification")
-
-		// Check the status code is what we expect.
-		require.Equal(s.T(), http.StatusOK, rr.Code)
-
-		updatedUserSignup := &crtapi.UserSignup{}
-		err := fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(otherUserSignup), updatedUserSignup)
-		require.NoError(s.T(), err)
-
-		// Check that the correct UserSignup is passed into the FakeSignupService for update
-		require.False(s.T(), states.VerificationRequired(updatedUserSignup))
-		require.Empty(s.T(), updatedUserSignup.Annotations[crtapi.UserVerificationAttemptsAnnotationKey])
-		require.Empty(s.T(), updatedUserSignup.Annotations[crtapi.UserSignupVerificationCodeAnnotationKey])
-		require.Empty(s.T(), updatedUserSignup.Annotations[crtapi.UserVerificationExpiryAnnotationKey])
-	})
 }
 
-func initPhoneVerification(t *testing.T, handler gin.HandlerFunc, params gin.Param, data []byte, userID, username, httpMethod, url string) *httptest.ResponseRecorder {
+func initPhoneVerification(t *testing.T, handler gin.HandlerFunc, params gin.Param, data []byte, username, httpMethod, url string) *httptest.ResponseRecorder {
 	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
 	rr := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(rr)
 	req, err := http.NewRequest(httpMethod, url, bytes.NewBuffer(data))
 	require.NoError(t, err)
 	ctx.Request = req
-	ctx.Set(context.SubKey, userID)
 	ctx.Set(context.UsernameKey, username)
 
 	ctx.Params = append(ctx.Params, params)
@@ -782,7 +710,6 @@ func initActivationCodeVerification(t *testing.T, handler gin.HandlerFunc, usern
 	req, err := http.NewRequest(http.MethodPost, "/api/v1/signup/verification/activation-code", bytes.NewBuffer([]byte(payload)))
 	require.NoError(t, err)
 	ctx.Request = req
-	ctx.Set(context.SubKey, username)
 	ctx.Set(context.UsernameKey, username)
 	handler(ctx)
 	return rr

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -477,6 +477,7 @@ func (s *TestSignupSuite) TestVerifyPhoneCodeHandler() {
 
 		require.Equal(s.T(), "Not Found", bodyParams["status"])
 		require.InDelta(s.T(), float64(404), bodyParams["code"], 0.01)
+		// the fdebf2d6-jsmithkubesaw is an encoded version of the jsmith@kubesaw username (removed @ and prefixed with crc32 hash of the original value)
 		require.Equal(s.T(), "usersignups.toolchain.dev.openshift.com \"fdebf2d6-jsmithkubesaw\" not found: user not found", bodyParams["message"])
 		require.Equal(s.T(), "error while verifying phone code", bodyParams["details"])
 	})

--- a/pkg/proxy/handlers/spacelister.go
+++ b/pkg/proxy/handlers/spacelister.go
@@ -41,10 +41,9 @@ func NewSpaceLister(client namespaced.Client, app application.Application, proxy
 }
 
 func (s *SpaceLister) GetProvisionedUserSignup(ctx echo.Context) (*signup.Signup, error) {
-	userID, _ := ctx.Get(context.SubKey).(string)
 	username, _ := ctx.Get(context.UsernameKey).(string)
 
-	userSignup, err := s.GetSignupFunc(nil, userID, username, false)
+	userSignup, err := s.GetSignupFunc(nil, "", username, false)
 	if err != nil {
 		ctx.Logger().Error(errs.Wrap(err, "error retrieving signup"))
 		return nil, err

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -135,14 +135,13 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 	gock.Observe(obs)
 
 	userSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("johny"),
+		testusersignup.WithEncodedName("johnny@kubesaw"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 		testusersignup.VerificationRequiredAgo(time.Second))
 
-	// Create a second UserSignup which we will test by username lookup instead of UserID lookup.  This will also function
-	// as some additional noise for the test
+	// Create a second UserSignup as some additional noise for the test
 	userSignup2 := testusersignup.NewUserSignup(
-		testusersignup.WithName("jsmith"),
+		testusersignup.WithEncodedName("jsmith@kubesaw"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+61NUMBER"),
 		testusersignup.VerificationRequiredAgo(time.Second))
 
@@ -151,7 +150,7 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 
 	// Test the init verification for the first UserSignup
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+	err := application.VerificationService().InitVerification(ctx, "", "johnny@kubesaw", "+1NUMBER", "1")
 	require.NoError(s.T(), err)
 
 	signup := &toolchainv1alpha1.UserSignup{}
@@ -186,8 +185,8 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 	gock.Observe(obs)
 
 	ctx, _ = gin.CreateTestContext(httptest.NewRecorder())
-	// This time we won't pass in the UserID, just the username yet still expect the UserSignup to be found
-	err = application.VerificationService().InitVerification(ctx, "", userSignup2.Spec.IdentityClaims.PreferredUsername, "+61NUMBER", "1")
+	// for the second usersignup
+	err = application.VerificationService().InitVerification(ctx, "", "jsmith@kubesaw", "+61NUMBER", "1")
 	require.NoError(s.T(), err)
 
 	signup2 := &toolchainv1alpha1.UserSignup{}
@@ -245,7 +244,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 	gock.Observe(obs)
 
 	userSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("johny"),
+		testusersignup.WithEncodedName("johnny@kubesaw"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 		testusersignup.VerificationRequiredAgo(time.Second))
 
@@ -261,8 +260,8 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 		}
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
-		require.EqualError(s.T(), err, "get failed: error retrieving usersignup: johny", err.Error())
+		err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+		require.EqualError(s.T(), err, "get failed: error retrieving usersignup: ", err.Error())
 	})
 
 	s.Run("when client UPDATE call fails indefinitely should return error", func() {
@@ -275,7 +274,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 		}
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+		err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 		require.EqualError(s.T(), err, "there was an error while updating your account - please wait a moment before "+
 			"trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com "+
 			"for assistance: error while verifying phone code")
@@ -295,7 +294,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 		}
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+		err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 		require.NoError(s.T(), err)
 
 		signup := &toolchainv1alpha1.UserSignup{}
@@ -337,7 +336,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 	gock.Observe(obs)
 
 	userSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("johny"),
+		testusersignup.WithEncodedName("johny@kubesaw"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Add(-25*time.Hour).Format(verificationservice.TimestampLayout)),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey, "3"),
@@ -347,7 +346,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+	err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 	require.NoError(s.T(), err)
 
 	signup := &toolchainv1alpha1.UserSignup{}
@@ -379,7 +378,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenCountContain
 	now := time.Now()
 
 	userSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("johny"),
+		testusersignup.WithEncodedName("johny@kubesaw"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey, "abc"),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
@@ -388,7 +387,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenCountContain
 	_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+	err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 	require.EqualError(s.T(), err, "daily limit exceeded: cannot generate new verification code")
 }
 
@@ -405,7 +404,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 	now := time.Now()
 
 	userSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("johny"),
+		testusersignup.WithEncodedName("johny@kubesaw"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey, strconv.Itoa(cfg.Verification().DailyLimit())),
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
@@ -414,7 +413,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 	_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+	err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 	require.EqualError(s.T(), err, "daily limit exceeded: cannot generate new verification code", err.Error())
 	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 }
@@ -434,19 +433,19 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 	phoneHash := hash.EncodeString(e164PhoneNumber)
 
 	alphaUserSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("alpha"),
+		testusersignup.WithEncodedName("alpha@kubesaw"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, phoneHash),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupStateLabelKey, toolchainv1alpha1.UserSignupStateLabelValueApproved),
 		testusersignup.ApprovedManually())
 
 	bravoUserSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("bravo"),
+		testusersignup.WithEncodedName("bravo@kubesaw"),
 		testusersignup.VerificationRequiredAgo(time.Second))
 
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), alphaUserSignup, bravoUserSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, bravoUserSignup.Name, bravoUserSignup.Spec.IdentityClaims.PreferredUsername, e164PhoneNumber, "1")
+	err := application.VerificationService().InitVerification(ctx, "", bravoUserSignup.Spec.IdentityClaims.PreferredUsername, e164PhoneNumber, "1")
 	require.Error(s.T(), err)
 	require.Equal(s.T(), "phone number already in use: cannot register using phone number: +19875551122", err.Error())
 
@@ -473,20 +472,20 @@ func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUs
 	phoneHash := hash.EncodeString(e164PhoneNumber)
 
 	alphaUserSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("alpha"),
+		testusersignup.WithEncodedName("alpha@kubesaw"),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, phoneHash),
 		testusersignup.WithLabel(toolchainv1alpha1.UserSignupStateLabelKey, toolchainv1alpha1.UserSignupStateLabelValueDeactivated),
 		testusersignup.ApprovedManually(),
 		testusersignup.Deactivated())
 
 	bravoUserSignup := testusersignup.NewUserSignup(
-		testusersignup.WithName("bravo"),
+		testusersignup.WithEncodedName("bravo@kubesaw"),
 		testusersignup.VerificationRequiredAgo(time.Second))
 
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), alphaUserSignup, bravoUserSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, bravoUserSignup.Name, bravoUserSignup.Spec.IdentityClaims.PreferredUsername, e164PhoneNumber, "1")
+	err := application.VerificationService().InitVerification(ctx, "", bravoUserSignup.Spec.IdentityClaims.PreferredUsername, e164PhoneNumber, "1")
 	require.NoError(s.T(), err)
 
 	// Reload bravoUserSignup
@@ -505,7 +504,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 	s.Run("verification ok", func() {
 
 		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithName("johny"),
+			testusersignup.WithEncodedName("johny@kubesaw"),
 			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey, "0.8"),
@@ -516,7 +515,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		require.NoError(s.T(), err)
 
 		signup := &toolchainv1alpha1.UserSignup{}
@@ -529,7 +528,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 	s.Run("verification ok for usersignup with username identifier", func() {
 
 		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithName("employee085"),
+			testusersignup.WithEncodedName("employee085@kubesaw"),
 			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupCaptchaScoreAnnotationKey, "0.7"),
@@ -540,7 +539,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, "", "employee085", "654321")
+		err := application.VerificationService().VerifyPhoneCode(ctx, "", "employee085@kubesaw", "654321")
 		require.NoError(s.T(), err)
 
 		signup := &toolchainv1alpha1.UserSignup{}
@@ -553,7 +552,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 	s.Run("when verification code is invalid", func() {
 
 		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithName("johny"),
+			testusersignup.WithEncodedName("johny@kubesaw"),
 			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "000000"),
@@ -563,7 +562,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		require.Error(s.T(), err)
 		e := &crterrors.Error{}
 		require.ErrorAs(s.T(), err, &e)
@@ -574,7 +573,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 	s.Run("when verification code has expired", func() {
 
 		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithName("johny"),
+			testusersignup.WithEncodedName("johny@kubesaw"),
 			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
@@ -584,7 +583,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		e := &crterrors.Error{}
 		require.ErrorAs(s.T(), err, &e)
 		require.Equal(s.T(), "expired: verification code expired", e.Error())
@@ -594,7 +593,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 	s.Run("when verifications exceeded maximum attempts", func() {
 
 		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithName("johny"),
+			testusersignup.WithEncodedName("johny@kubesaw"),
 			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "3"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
@@ -604,14 +603,14 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		require.EqualError(s.T(), err, "too many verification attempts", err.Error())
 	})
 
 	s.Run("when verifications attempts has invalid value", func() {
 
 		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithName("johny"),
+			testusersignup.WithEncodedName("johny@kubesaw"),
 			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "ABC"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
@@ -621,7 +620,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		require.EqualError(s.T(), err, "too many verification attempts", err.Error())
 
 		signup := &toolchainv1alpha1.UserSignup{}
@@ -634,7 +633,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 	s.Run("when verifications expiry is corrupt", func() {
 
 		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithName("johny"),
+			testusersignup.WithEncodedName("johny@kubesaw"),
 			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
@@ -644,7 +643,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		require.EqualError(s.T(), err, "parsing time \"ABC\" as \"2006-01-02T15:04:05.000Z07:00\": cannot parse \"ABC\" as \"2006\": error parsing expiry timestamp", err.Error())
 	})
 
@@ -727,7 +726,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 				)
 
 				userSignup := testusersignup.NewUserSignup(
-					testusersignup.WithName("johny"),
+					testusersignup.WithEncodedName("johny@kubesaw"),
 					testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "+1NUMBER"),
 					testusersignup.WithAnnotation(toolchainv1alpha1.UserVerificationAttemptsAnnotationKey, "0"),
 					testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
@@ -743,7 +742,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 				fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 				ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-				err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+				err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 
 				// then
 				signup := &toolchainv1alpha1.UserSignup{}
@@ -777,7 +776,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.NoError(s.T(), err)
@@ -795,7 +794,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.NoError(s.T(), err)
@@ -815,7 +814,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.EqualError(s.T(), err, "too many verification attempts: 3")
@@ -834,7 +833,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 			// when
-			err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "invalid")
+			err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "invalid")
 
 			// then
 			require.EqualError(s.T(), err, "invalid code: the provided code is invalid")
@@ -853,7 +852,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 			// when
-			err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, "invalid")
+			err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "invalid")
 
 			// then
 			require.EqualError(s.T(), err, "invalid code: the provided code is invalid")
@@ -872,7 +871,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.EqualError(s.T(), err, "invalid code: the event is full")
@@ -891,7 +890,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.EqualError(s.T(), err, "invalid code: the provided code is invalid")
@@ -910,7 +909,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Name, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.EqualError(s.T(), err, "invalid code: the provided code is invalid")


### PR DESCRIPTION
depends on: https://github.com/codeready-toolchain/toolchain-common/pull/452

* moves the EncodeUserIdentifier to toolchain-common (so it can be used in the helper function)
* drops usage of userID from unit tests
* Improves the unit-tests so they use an encoded value as the name of the UserSignup CRs
* applies new helper functions introduced in the toolchain-common PR

[KUBESAW-254](https://issues.redhat.com/browse/KUBESAW-254)

This is hopefully the last PR before final dropping of the usage of userIDs as the UserSignup names