### PR TITLE
drop usage of userID for names of UserSignup

### DIFF
--- a/pkg/application/service/services.go
+++ b/pkg/application/service/services.go
@@ -8,15 +8,14 @@ import (
 
 type SignupService interface {
 	Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error)
-	GetSignup(ctx *gin.Context, userID, username string, checkUserSignupCompleted bool) (*signup.Signup, error)
-	GetUserSignupFromIdentifier(userID, username string) (*toolchainv1alpha1.UserSignup, error)
-	PhoneNumberAlreadyInUse(userID, username, phoneNumberOrHash string) error
+	GetSignup(ctx *gin.Context, username string, checkUserSignupCompleted bool) (*signup.Signup, error)
+	PhoneNumberAlreadyInUse(username, phoneNumberOrHash string) error
 }
 
 type VerificationService interface {
-	InitVerification(ctx *gin.Context, userID, username, e164PhoneNumber, countryCode string) error
-	VerifyPhoneCode(ctx *gin.Context, userID, username, code string) error
-	VerifyActivationCode(ctx *gin.Context, userID, username, code string) error
+	InitVerification(ctx *gin.Context, username, e164PhoneNumber, countryCode string) error
+	VerifyPhoneCode(ctx *gin.Context, username, code string) error
+	VerifyActivationCode(ctx *gin.Context, username, code string) error
 }
 
 type Services interface {

--- a/pkg/proxy/handlers/spacelister.go
+++ b/pkg/proxy/handlers/spacelister.go
@@ -28,7 +28,7 @@ const (
 
 type SpaceLister struct {
 	namespaced.Client
-	GetSignupFunc func(ctx *gin.Context, userID, username string, checkUserSignupCompleted bool) (*signup.Signup, error)
+	GetSignupFunc func(ctx *gin.Context, username string, checkUserSignupCompleted bool) (*signup.Signup, error)
 	ProxyMetrics  *metrics.ProxyMetrics
 }
 
@@ -43,7 +43,7 @@ func NewSpaceLister(client namespaced.Client, app application.Application, proxy
 func (s *SpaceLister) GetProvisionedUserSignup(ctx echo.Context) (*signup.Signup, error) {
 	username, _ := ctx.Get(context.UsernameKey).(string)
 
-	userSignup, err := s.GetSignupFunc(nil, "", username, false)
+	userSignup, err := s.GetSignupFunc(nil, username, false)
 	if err != nil {
 		ctx.Logger().Error(errs.Wrap(err, "error retrieving signup"))
 		return nil, err

--- a/pkg/proxy/handlers/spacelister_get_test.go
+++ b/pkg/proxy/handlers/spacelister_get_test.go
@@ -76,7 +76,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 			expectedErr            string
 			expectedErrCode        int
 			expectedWorkspace      string
-			overrideSignupFunc     func(ctx *gin.Context, userID, username string, checkUserSignupComplete bool) (*signup.Signup, error)
+			overrideSignupFunc     func(ctx *gin.Context, username string, checkUserSignupComplete bool) (*signup.Signup, error)
 			mockFakeClient         func(fakeClient *test.FakeClient)
 			overrideGetMembersFunc func(conditions ...commoncluster.Condition) []*commoncluster.CachedToolchainCluster
 			overrideMemberClient   *test.FakeClient
@@ -270,7 +270,7 @@ func testSpaceListerGet(t *testing.T, publicViewerEnabled bool) {
 				expectedWs:      nil,
 				expectedErr:     "signup error",
 				expectedErrCode: 500,
-				overrideSignupFunc: func(_ *gin.Context, _, _ string, _ bool) (*signup.Signup, error) {
+				overrideSignupFunc: func(_ *gin.Context, _ string, _ bool) (*signup.Signup, error) {
 					return nil, fmt.Errorf("signup error")
 				},
 				expectedWorkspace: "dancelover",
@@ -620,7 +620,7 @@ func TestGetUserWorkspace(t *testing.T) {
 		workspaceRequest   string
 		expectedWorkspace  func(t *testing.T, fakeClient *test.FakeClient) toolchainv1alpha1.Workspace
 		mockFakeClient     func(fakeClient *test.FakeClient)
-		overrideSignupFunc func(ctx *gin.Context, userID, username string, checkUserSignupComplete bool) (*signup.Signup, error)
+		overrideSignupFunc func(ctx *gin.Context, username string, checkUserSignupComplete bool) (*signup.Signup, error)
 	}{
 		"get robin workspace": {
 			username:         "robin",
@@ -673,7 +673,7 @@ func TestGetUserWorkspace(t *testing.T) {
 			username:         "batman",
 			workspaceRequest: "batman",
 			expectedErr:      "signup error",
-			overrideSignupFunc: func(_ *gin.Context, _, _ string, _ bool) (*signup.Signup, error) {
+			overrideSignupFunc: func(_ *gin.Context, _ string, _ bool) (*signup.Signup, error) {
 				return nil, fmt.Errorf("signup error")
 			},
 			expectedWorkspace: nil,

--- a/pkg/proxy/handlers/spacelister_list_test.go
+++ b/pkg/proxy/handlers/spacelister_list_test.go
@@ -122,7 +122,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 				expectedErr        string
 				expectedErrCode    int
 				expectedWorkspace  string
-				overrideSignupFunc func(ctx *gin.Context, userID, username string, checkUserSignupComplete bool) (*signup.Signup, error)
+				overrideSignupFunc func(ctx *gin.Context, username string, checkUserSignupComplete bool) (*signup.Signup, error)
 				mockFakeClient     func(fakeClient *test.FakeClient)
 			}{
 				"dancelover lists spaces": {
@@ -181,7 +181,7 @@ func TestHandleSpaceListRequest(t *testing.T) {
 					expectedWs:      nil,
 					expectedErr:     "signup error",
 					expectedErrCode: 500,
-					overrideSignupFunc: func(_ *gin.Context, _, _ string, _ bool) (*signup.Signup, error) {
+					overrideSignupFunc: func(_ *gin.Context, _ string, _ bool) (*signup.Signup, error) {
 						return nil, fmt.Errorf("signup error")
 					},
 				},

--- a/pkg/proxy/members_test.go
+++ b/pkg/proxy/members_test.go
@@ -116,12 +116,12 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 				for k, tc := range tt {
 					s.Run(k, func() {
 						s.Run("signup service returns error", func() {
-							sc.MockGetSignup = func(_, _ string) (*signup.Signup, error) {
+							sc.MockGetSignup = func(_ string) (*signup.Signup, error) {
 								return nil, errors.New("oopsi woopsi")
 							}
 
 							// when
-							_, err := members.GetClusterAccess("", "789-ready", tc.workspace, "", publicViewerEnabled)
+							_, err := members.GetClusterAccess("789-ready", tc.workspace, "", publicViewerEnabled)
 
 							// then
 							require.EqualError(s.T(), err, "oopsi woopsi")
@@ -131,7 +131,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 
 						s.Run("username is not found", func() {
 							// when
-							_, err := members.GetClusterAccess("", "unknown_username", tc.workspace, "", publicViewerEnabled)
+							_, err := members.GetClusterAccess("unknown_username", tc.workspace, "", publicViewerEnabled)
 
 							// then
 							require.EqualError(s.T(), err, "user is not provisioned (yet)")
@@ -139,7 +139,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 
 						s.Run("user is not provisioned yet", func() {
 							// when
-							_, err := members.GetClusterAccess("", "456-not-ready", tc.workspace, "", publicViewerEnabled)
+							_, err := members.GetClusterAccess("456-not-ready", tc.workspace, "", publicViewerEnabled)
 
 							// then
 							require.EqualError(s.T(), err, "user is not provisioned (yet)")
@@ -165,7 +165,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 					members := proxy.NewMemberClusters(nsClient, sc, commoncluster.GetMemberClusters)
 
 					// when
-					_, err := members.GetClusterAccess("", "789-ready", "smith2", "", publicViewerEnabled)
+					_, err := members.GetClusterAccess("789-ready", "smith2", "", publicViewerEnabled)
 
 					// then
 					// original error is only logged so that it doesn't reveal information about a space that may not belong to the requestor
@@ -174,7 +174,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 
 				s.Run("space not found", func() {
 					// when
-					_, err := members.GetClusterAccess("", "789-ready", "unknown", "", publicViewerEnabled) // unknown workspace requested
+					_, err := members.GetClusterAccess("789-ready", "unknown", "", publicViewerEnabled) // unknown workspace requested
 
 					// then
 					require.EqualError(s.T(), err, "the requested space is not available")
@@ -188,7 +188,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 					})
 					s.Run("default workspace case", func() {
 						// when
-						_, err := members.GetClusterAccess("", "789-ready", "", "", publicViewerEnabled)
+						_, err := members.GetClusterAccess("789-ready", "", "", publicViewerEnabled)
 
 						// then
 						require.EqualError(s.T(), err, "no member clusters found")
@@ -196,7 +196,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 
 					s.Run("workspace context case", func() {
 						// when
-						_, err := members.GetClusterAccess("", "789-ready", "smith2", "", publicViewerEnabled)
+						_, err := members.GetClusterAccess("789-ready", "smith2", "", publicViewerEnabled)
 
 						// then
 						require.EqualError(s.T(), err, "no member clusters found")
@@ -209,7 +209,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 					})
 					s.Run("default workspace case", func() {
 						// when
-						_, err := members.GetClusterAccess("", "012-ready-unknown-cluster", "", "", publicViewerEnabled)
+						_, err := members.GetClusterAccess("012-ready-unknown-cluster", "", "", publicViewerEnabled)
 
 						// then
 						require.EqualError(s.T(), err, "no member cluster found for the user")
@@ -217,7 +217,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 
 					s.Run("workspace context case", func() {
 						// when
-						_, err := members.GetClusterAccess("", "012-ready-unknown-cluster", "unknown-cluster", "", publicViewerEnabled)
+						_, err := members.GetClusterAccess("012-ready-unknown-cluster", "unknown-cluster", "", publicViewerEnabled)
 
 						// then
 						require.EqualError(s.T(), err, "no member cluster found for space 'unknown-cluster'")
@@ -278,7 +278,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 					expectedToken := "abc123" // should match member 2 bearer token
 
 					// when
-					ca, err := members.GetClusterAccess("", "789-ready", "", "tekton-results", publicViewerEnabled)
+					ca, err := members.GetClusterAccess("789-ready", "", "tekton-results", publicViewerEnabled)
 
 					// then
 					require.NoError(s.T(), err)
@@ -291,7 +291,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 
 					s.Run("cluster access correct when using workspace context", func() {
 						// when
-						ca, err := members.GetClusterAccess("", "789-ready", "smith2", "tekton-results", publicViewerEnabled) // workspace-context specified
+						ca, err := members.GetClusterAccess("789-ready", "smith2", "tekton-results", publicViewerEnabled) // workspace-context specified
 
 						// then
 						require.NoError(s.T(), err)
@@ -319,7 +319,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 								return memberClient.Client.Get(ctx, key, obj, opts...)
 							}
 							memberArray[0].Client = mC
-							ca, err := members.GetClusterAccess("", "789-ready", "teamspace", "tekton-results", publicViewerEnabled) // workspace-context specified
+							ca, err := members.GetClusterAccess("789-ready", "teamspace", "tekton-results", publicViewerEnabled) // workspace-context specified
 
 							// then
 							require.NoError(s.T(), err)
@@ -337,7 +337,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 					expectedToken := "abc123" // should match member 2 bearer token
 
 					// when
-					ca, err := members.GetClusterAccess("", "789-ready", "", "", publicViewerEnabled)
+					ca, err := members.GetClusterAccess("789-ready", "", "", publicViewerEnabled)
 
 					// then
 					require.NoError(s.T(), err)
@@ -350,7 +350,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 
 					s.Run("cluster access correct when using workspace context", func() {
 						// when
-						ca, err := members.GetClusterAccess("", "789-ready", "smith2", "", publicViewerEnabled) // workspace-context specified
+						ca, err := members.GetClusterAccess("789-ready", "smith2", "", publicViewerEnabled) // workspace-context specified
 
 						// then
 						require.NoError(s.T(), err)
@@ -362,7 +362,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 
 						s.Run("another workspace on another cluster", func() {
 							// when
-							ca, err := members.GetClusterAccess("", "789-ready", "teamspace", "", publicViewerEnabled) // workspace-context specified
+							ca, err := members.GetClusterAccess("789-ready", "teamspace", "", publicViewerEnabled) // workspace-context specified
 
 							// then
 							require.NoError(s.T(), err)
@@ -382,7 +382,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 	s.Run("user is public-viewer", func() {
 		s.Run("has no default workspace", func() {
 			// when
-			ca, err := members.GetClusterAccess("", toolchainv1alpha1.KubesawAuthenticatedUsername, "", "", true)
+			ca, err := members.GetClusterAccess(toolchainv1alpha1.KubesawAuthenticatedUsername, "", "", true)
 
 			// then
 			require.EqualError(s.T(), err, "user is not provisioned (yet)")
@@ -395,7 +395,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 			})
 			s.Run("public-viewer is disabled", func() {
 				// when
-				ca, err := members.GetClusterAccess("", toolchainv1alpha1.KubesawAuthenticatedUsername, "smith2", "", false)
+				ca, err := members.GetClusterAccess(toolchainv1alpha1.KubesawAuthenticatedUsername, "smith2", "", false)
 
 				// then
 				require.EqualError(s.T(), err, "user is not provisioned (yet)")
@@ -409,7 +409,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 				expectedClusterAccess := access.NewClusterAccess(*expectedURL, "token", toolchainv1alpha1.KubesawAuthenticatedUsername)
 
 				// when
-				clusterAccess, err := members.GetClusterAccess("", toolchainv1alpha1.KubesawAuthenticatedUsername, "smith2", "", true)
+				clusterAccess, err := members.GetClusterAccess(toolchainv1alpha1.KubesawAuthenticatedUsername, "smith2", "", true)
 
 				// then
 				require.NoError(s.T(), err)
@@ -418,7 +418,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 
 			s.Run("not-available space", func() {
 				// when
-				clusterAccess, err := members.GetClusterAccess("", toolchainv1alpha1.KubesawAuthenticatedUsername, "456-not-ready", "", true)
+				clusterAccess, err := members.GetClusterAccess(toolchainv1alpha1.KubesawAuthenticatedUsername, "456-not-ready", "", true)
 
 				// then
 				require.EqualError(s.T(), err, "the requested space is not available")
@@ -427,7 +427,7 @@ func (s *TestMemberClustersSuite) TestGetClusterAccess() {
 
 			s.Run("ready space with unknown cluster", func() {
 				// when
-				clusterAccess, err := members.GetClusterAccess("", toolchainv1alpha1.KubesawAuthenticatedUsername, "012-ready-unknown-cluster", "", true)
+				clusterAccess, err := members.GetClusterAccess(toolchainv1alpha1.KubesawAuthenticatedUsername, "012-ready-unknown-cluster", "", true)
 
 				// then
 				require.EqualError(s.T(), err, "the requested space is not available")

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -215,10 +215,10 @@ func (s *TestProxySuite) checkPlainHTTPErrors(proxy *Proxy) {
 			require.NotNil(s.T(), resp)
 			defer resp.Body.Close()
 			assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
-			s.assertResponseBody(resp, "invalid bearer token: unable to extract userID from token: token is malformed: token contains an invalid number of segments")
+			s.assertResponseBody(resp, "invalid bearer token: unable to extract claims from token: token is malformed: token contains an invalid number of segments")
 		})
 
-		s.Run("unauthorized if can't extract userID from a valid token", func() {
+		s.Run("unauthorized if can't extract claims from a valid token", func() {
 			// when
 			req, err := http.NewRequest("GET", "http://localhost:8081/api/mycoolworkspace/pods", nil)
 			require.NoError(s.T(), err)
@@ -231,7 +231,7 @@ func (s *TestProxySuite) checkPlainHTTPErrors(proxy *Proxy) {
 			require.NotNil(s.T(), resp)
 			defer resp.Body.Close()
 			assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
-			s.assertResponseBody(resp, "invalid bearer token: unable to extract userID from token: token does not comply to expected claims: subject missing")
+			s.assertResponseBody(resp, "invalid bearer token: unable to extract claims from token: token does not comply to expected claims: subject missing")
 		})
 
 		s.Run("unauthorized if can't extract email from a valid token", func() {
@@ -247,7 +247,7 @@ func (s *TestProxySuite) checkPlainHTTPErrors(proxy *Proxy) {
 			require.NotNil(s.T(), resp)
 			defer resp.Body.Close()
 			assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
-			s.assertResponseBody(resp, "invalid bearer token: unable to extract userID from token: token does not comply to expected claims: email missing")
+			s.assertResponseBody(resp, "invalid bearer token: unable to extract claims from token: token does not comply to expected claims: email missing")
 		})
 
 		s.Run("unauthorized if workspace context is invalid", func() {
@@ -353,7 +353,7 @@ func (s *TestProxySuite) checkWebsocketsError() {
 			},
 			"not a jwt token": {
 				ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.dG9rZW4,dummy"},
-				ExpectedError:   "invalid bearer token: unable to extract userID from token: token is malformed: token contains an invalid number of segments",
+				ExpectedError:   "invalid bearer token: unable to extract claims from token: token is malformed: token contains an invalid number of segments",
 			},
 			"invalid token is not base64 encoded": {
 				ProtocolHeaders: []string{"base64url.bearer.authorization.k8s.io.token,dummy"},
@@ -515,7 +515,7 @@ func (s *TestProxySuite) checkProxyOK(proxy *Proxy) {
 			ExpectedProxyResponseStatus     int
 			Standalone                      bool // If true then the request is not expected to be forwarded to the kube api server
 
-			OverrideGetSignupFunc func(ctx *gin.Context, userID, username string, checkUserSignupCompleted bool) (*signup.Signup, error)
+			OverrideGetSignupFunc func(ctx *gin.Context, username string, checkUserSignupCompleted bool) (*signup.Signup, error)
 			ExpectedResponse      *string
 		}{
 			"plain http cors preflight request with no request method": {
@@ -680,7 +680,7 @@ func (s *TestProxySuite) checkProxyOK(proxy *Proxy) {
 					"Authorization": {"Bearer clusterSAToken"},
 				},
 				ExpectedProxyResponseStatus: http.StatusInternalServerError,
-				OverrideGetSignupFunc: func(_ *gin.Context, _, _ string, _ bool) (*signup.Signup, error) {
+				OverrideGetSignupFunc: func(_ *gin.Context, _ string, _ bool) (*signup.Signup, error) {
 					return nil, fmt.Errorf("test error")
 				},
 				ExpectedResponse: ptr("unable to retrieve user workspaces: test error"),

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -31,8 +31,6 @@ import (
 )
 
 const (
-	DNS1123NameMaximumLength = 63
-
 	// NoSpaceKey is the query key for specifying whether the UserSignup should be created without a Space
 	NoSpaceKey = "no-space"
 )
@@ -64,7 +62,7 @@ func NewSignupService(client namespaced.Client, opts ...SignupServiceOption) ser
 	return s
 }
 
-// newUserSignup generates a new UserSignup resource with the specified username and userID.
+// newUserSignup generates a new UserSignup resource with the specified username and available claims.
 // This resource then can be used to create a new UserSignup in the host cluster or to update the existing one.
 func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
 	username := ctx.GetString(context.UsernameKey)
@@ -78,7 +76,7 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 	}
 
 	if isCRTAdmin(username) {
-		log.Info(ctx, fmt.Sprintf("A crtadmin user '%s' just tried to signup - the UserID is: '%s'", ctx.GetString(context.UsernameKey), ctx.GetString(context.SubKey)))
+		log.Info(ctx, fmt.Sprintf("A crtadmin user '%s' just tried to signup", ctx.GetString(context.UsernameKey)))
 		return nil, apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("failed to create usersignup for %s", username))
 	}
 
@@ -233,28 +231,21 @@ func extractEmailHost(email string) string {
 	return email[i+1:]
 }
 
-// Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username and userID
+// Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username
 // if doesn't exist yet.
 func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
-	encodedUserID := signupcommon.EncodeUserIdentifier(ctx.GetString(context.SubKey))
+	username := ctx.GetString(context.UsernameKey)
+	encodedUsername := signupcommon.EncodeUserIdentifier(username)
 
 	// Retrieve UserSignup resource from the host cluster
 	userSignup := &toolchainv1alpha1.UserSignup{}
-	if err := s.Get(ctx, s.NamespacedName(encodedUserID), userSignup); err != nil {
+	if err := s.Get(ctx, s.NamespacedName(encodedUsername), userSignup); err != nil {
 		if apierrors.IsNotFound(err) {
-			// The UserSignup could not be located by its encoded UserID, attempt to load it using its encoded PreferredUsername instead
-			encodedUsername := signupcommon.EncodeUserIdentifier(ctx.GetString(context.UsernameKey))
-			if err := s.Get(ctx, s.NamespacedName(encodedUsername), userSignup); err != nil {
-				if apierrors.IsNotFound(err) {
-					// New Signup
-					log.WithValues(map[string]interface{}{"encoded_user_id": encodedUserID}).Info(ctx, "user not found, creating a new one")
-					return s.createUserSignup(ctx)
-				}
-				return nil, err
-			}
-		} else {
-			return nil, err
+			// New Signup
+			log.WithValues(map[string]interface{}{"encoded_username": encodedUsername}).Info(ctx, "user not found, creating a new one")
+			return s.createUserSignup(ctx)
 		}
+		return nil, err
 	}
 
 	// Check UserSignup status to determine whether user signup is deactivated
@@ -264,12 +255,11 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 		return s.reactivateUserSignup(ctx, userSignup)
 	}
 
-	username := ctx.GetString(context.UsernameKey)
 	return nil, apierrors.NewConflict(schema.GroupResource{}, "", fmt.Errorf(
-		"UserSignup [id: %s; username: %s]. Unable to create UserSignup because there is already an active UserSignup with such ID", encodedUserID, username))
+		"UserSignup [username: %s]. Unable to create UserSignup because there is already an active UserSignup with such a username", username))
 }
 
-// createUserSignup creates a new UserSignup resource with the specified username and userID
+// createUserSignup creates a new UserSignup resource with the specified username
 func (s *ServiceImpl) createUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
 	userSignup, err := s.newUserSignup(ctx)
 	if err != nil {
@@ -279,7 +269,7 @@ func (s *ServiceImpl) createUserSignup(ctx *gin.Context) (*toolchainv1alpha1.Use
 	return userSignup, s.Create(ctx, userSignup)
 }
 
-// reactivateUserSignup reactivates the deactivated UserSignup resource with the specified username and userID
+// reactivateUserSignup reactivates the deactivated UserSignup resource with the specified username
 func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
 	// Update the existing usersignup's spec and annotations/labels by new values from a freshly generated one.
 	// We don't want to deal with merging/patching the usersignup resource
@@ -310,24 +300,23 @@ func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing *toolchain
 // The checkUserSignupCompleted was introduced in order to avoid checking the readiness of the complete condition on the UserSignup in certain situations,
 // such as proxy calls for example.
 // Returns nil, nil if the UserSignup resource is not found or if it's deactivated.
-func (s *ServiceImpl) GetSignup(ctx *gin.Context, userID, username string, checkUserSignupCompleted bool) (*signup.Signup, error) {
-	return s.DoGetSignup(ctx, s.Client, userID, username, checkUserSignupCompleted)
+func (s *ServiceImpl) GetSignup(ctx *gin.Context, username string, checkUserSignupCompleted bool) (*signup.Signup, error) {
+	return s.DoGetSignup(ctx, s.Client, username, checkUserSignupCompleted)
 }
 
-func (s *ServiceImpl) DoGetSignup(ctx *gin.Context, cl namespaced.Client, userID, username string, checkUserSignupCompleted bool) (*signup.Signup, error) {
+func (s *ServiceImpl) DoGetSignup(ctx *gin.Context, cl namespaced.Client, username string, checkUserSignupCompleted bool) (*signup.Signup, error) {
 	var userSignup *toolchainv1alpha1.UserSignup
 
 	err := signup.PollUpdateSignup(ctx, func() error {
-		// Retrieve UserSignup resource from the host cluster, using the specified UserID and username
-		var getError error
-		userSignup, getError = s.DoGetUserSignupFromIdentifier(cl, userID, username)
-		// If an error was returned, then return here
-		if getError != nil {
-			if apierrors.IsNotFound(getError) {
+		// Retrieve UserSignup resource from the host cluster
+		us := &toolchainv1alpha1.UserSignup{}
+		if err := cl.Get(gocontext.TODO(), cl.NamespacedName(signupcommon.EncodeUserIdentifier(username)), us); err != nil {
+			if apierrors.IsNotFound(err) {
 				return nil
 			}
-			return getError
+			return err
 		}
+		userSignup = us
 
 		// Otherwise if the returned userSignup is nil, return here also
 		if userSignup == nil || ctx == nil {
@@ -505,41 +494,15 @@ func (s *ServiceImpl) auditUserSignupAgainstClaims(ctx *gin.Context, userSignup 
 	return updated
 }
 
-// GetUserSignupFromIdentifier is used to return the actual UserSignup resource instance, rather than the Signup DTO
-func (s *ServiceImpl) GetUserSignupFromIdentifier(userID, username string) (*toolchainv1alpha1.UserSignup, error) {
-	return s.DoGetUserSignupFromIdentifier(s.Client, userID, username)
-}
-
-// GetUserSignupFromIdentifier is used to return the actual UserSignup resource instance, rather than the Signup DTO
-func (s *ServiceImpl) DoGetUserSignupFromIdentifier(cl namespaced.Client, userID, username string) (*toolchainv1alpha1.UserSignup, error) {
-	// Retrieve UserSignup resource from the host cluster
-	userSignup := &toolchainv1alpha1.UserSignup{}
-	if err := cl.Get(gocontext.TODO(), cl.NamespacedName(signupcommon.EncodeUserIdentifier(username)), userSignup); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Capture any error here in a separate var, as we need to preserve the original
-			if err2 := cl.Get(gocontext.TODO(), cl.NamespacedName(signupcommon.EncodeUserIdentifier(userID)), userSignup); err2 != nil {
-				if apierrors.IsNotFound(err2) {
-					return nil, err
-				}
-				return nil, err2
-			}
-			return userSignup, nil
-		}
-		return nil, err
-	}
-
-	return userSignup, nil
-}
-
 var (
 	md5Matcher = regexp.MustCompile("(?i)[a-f0-9]{32}$")
 )
 
 // PhoneNumberAlreadyInUse checks if the phone number has been banned. If so, return
-// an internal server error. If not, check if an approved UserSignup with a different userID and username
+// an internal server error. If not, check if an approved UserSignup with a different username
 // and email address exists. If so, return an internal server error. Otherwise, return without error.
 // Either the actual phone number, or the md5 hash of the phone number may be provided here.
-func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, username, phoneNumberOrHash string) error {
+func (s *ServiceImpl) PhoneNumberAlreadyInUse(username, phoneNumberOrHash string) error {
 	labelValue := hash.EncodeString(phoneNumberOrHash)
 	if md5Matcher.Match([]byte(phoneNumberOrHash)) {
 		labelValue = phoneNumberOrHash
@@ -566,7 +529,7 @@ func (s *ServiceImpl) PhoneNumberAlreadyInUse(userID, username, phoneNumberOrHas
 
 	for _, signup := range userSignups.Items {
 		userSignup := signup // drop with go 1.22
-		if userSignup.Spec.IdentityClaims.Sub != userID && userSignup.Spec.IdentityClaims.PreferredUsername != username && !states.Deactivated(&userSignup) {
+		if userSignup.Spec.IdentityClaims.PreferredUsername != username && !states.Deactivated(&userSignup) {
 			return errors.NewForbiddenError("cannot re-register with phone number",
 				"phone number already in use")
 		}

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -150,7 +150,7 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 
 	// Test the init verification for the first UserSignup
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, "", "johnny@kubesaw", "+1NUMBER", "1")
+	err := application.VerificationService().InitVerification(ctx, "johnny@kubesaw", "+1NUMBER", "1")
 	require.NoError(s.T(), err)
 
 	signup := &toolchainv1alpha1.UserSignup{}
@@ -186,7 +186,7 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 
 	ctx, _ = gin.CreateTestContext(httptest.NewRecorder())
 	// for the second usersignup
-	err = application.VerificationService().InitVerification(ctx, "", "jsmith@kubesaw", "+61NUMBER", "1")
+	err = application.VerificationService().InitVerification(ctx, "jsmith@kubesaw", "+61NUMBER", "1")
 	require.NoError(s.T(), err)
 
 	signup2 := &toolchainv1alpha1.UserSignup{}
@@ -260,8 +260,8 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 		}
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
-		require.EqualError(s.T(), err, "get failed: error retrieving usersignup: ", err.Error())
+		err := application.VerificationService().InitVerification(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+		require.EqualError(s.T(), err, "get failed: error retrieving usersignup with username 'johnny@kubesaw'", err.Error())
 	})
 
 	s.Run("when client UPDATE call fails indefinitely should return error", func() {
@@ -274,7 +274,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 		}
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+		err := application.VerificationService().InitVerification(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 		require.EqualError(s.T(), err, "there was an error while updating your account - please wait a moment before "+
 			"trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com "+
 			"for assistance: error while verifying phone code")
@@ -294,7 +294,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 		}
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+		err := application.VerificationService().InitVerification(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 		require.NoError(s.T(), err)
 
 		signup := &toolchainv1alpha1.UserSignup{}
@@ -346,7 +346,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+	err := application.VerificationService().InitVerification(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 	require.NoError(s.T(), err)
 
 	signup := &toolchainv1alpha1.UserSignup{}
@@ -387,7 +387,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenCountContain
 	_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+	err := application.VerificationService().InitVerification(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 	require.EqualError(s.T(), err, "daily limit exceeded: cannot generate new verification code")
 }
 
@@ -413,7 +413,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 	_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
+	err := application.VerificationService().InitVerification(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 	require.EqualError(s.T(), err, "daily limit exceeded: cannot generate new verification code", err.Error())
 	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 }
@@ -445,7 +445,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), alphaUserSignup, bravoUserSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, "", bravoUserSignup.Spec.IdentityClaims.PreferredUsername, e164PhoneNumber, "1")
+	err := application.VerificationService().InitVerification(ctx, bravoUserSignup.Spec.IdentityClaims.PreferredUsername, e164PhoneNumber, "1")
 	require.Error(s.T(), err)
 	require.Equal(s.T(), "phone number already in use: cannot register using phone number: +19875551122", err.Error())
 
@@ -485,7 +485,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUs
 	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), alphaUserSignup, bravoUserSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-	err := application.VerificationService().InitVerification(ctx, "", bravoUserSignup.Spec.IdentityClaims.PreferredUsername, e164PhoneNumber, "1")
+	err := application.VerificationService().InitVerification(ctx, bravoUserSignup.Spec.IdentityClaims.PreferredUsername, e164PhoneNumber, "1")
 	require.NoError(s.T(), err)
 
 	// Reload bravoUserSignup
@@ -515,7 +515,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		require.NoError(s.T(), err)
 
 		signup := &toolchainv1alpha1.UserSignup{}
@@ -539,7 +539,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, "", "employee085@kubesaw", "654321")
+		err := application.VerificationService().VerifyPhoneCode(ctx, "employee085@kubesaw", "654321")
 		require.NoError(s.T(), err)
 
 		signup := &toolchainv1alpha1.UserSignup{}
@@ -562,7 +562,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		require.Error(s.T(), err)
 		e := &crterrors.Error{}
 		require.ErrorAs(s.T(), err, &e)
@@ -583,7 +583,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		e := &crterrors.Error{}
 		require.ErrorAs(s.T(), err, &e)
 		require.Equal(s.T(), "expired: verification code expired", e.Error())
@@ -603,7 +603,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		require.EqualError(s.T(), err, "too many verification attempts", err.Error())
 	})
 
@@ -620,7 +620,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		require.EqualError(s.T(), err, "too many verification attempts", err.Error())
 
 		signup := &toolchainv1alpha1.UserSignup{}
@@ -643,7 +643,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+		err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 		require.EqualError(s.T(), err, "parsing time \"ABC\" as \"2006-01-02T15:04:05.000Z07:00\": cannot parse \"ABC\" as \"2006\": error parsing expiry timestamp", err.Error())
 	})
 
@@ -742,7 +742,7 @@ func (s *TestVerificationServiceSuite) TestVerifyPhoneCode() {
 				fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 				ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-				err := application.VerificationService().VerifyPhoneCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
+				err := application.VerificationService().VerifyPhoneCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "123456")
 
 				// then
 				signup := &toolchainv1alpha1.UserSignup{}
@@ -776,7 +776,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.NoError(s.T(), err)
@@ -794,7 +794,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.NoError(s.T(), err)
@@ -814,7 +814,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.EqualError(s.T(), err, "too many verification attempts: 3")
@@ -833,7 +833,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 			// when
-			err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "invalid")
+			err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "invalid")
 
 			// then
 			require.EqualError(s.T(), err, "invalid code: the provided code is invalid")
@@ -852,7 +852,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 			// when
-			err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, "invalid")
+			err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "invalid")
 
 			// then
 			require.EqualError(s.T(), err, "invalid code: the provided code is invalid")
@@ -871,7 +871,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.EqualError(s.T(), err, "invalid code: the event is full")
@@ -890,7 +890,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.EqualError(s.T(), err, "invalid code: the provided code is invalid")
@@ -909,7 +909,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
 
 		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, "", userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
+		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
 
 		// then
 		require.EqualError(s.T(), err, "invalid code: the provided code is invalid")

--- a/test/fake/proxy.go
+++ b/test/fake/proxy.go
@@ -31,29 +31,26 @@ func (m *SignupService) addSignup(identifier string, userSignup *signup.Signup) 
 }
 
 type SignupService struct {
-	MockGetSignup func(userID, username string) (*signup.Signup, error)
+	MockGetSignup func(username string) (*signup.Signup, error)
 	userSignups   map[string]*signup.Signup
 }
 
-func (m *SignupService) DefaultMockGetSignup() func(userID, username string) (*signup.Signup, error) {
-	return func(_, username string) (userSignup *signup.Signup, e error) {
+func (m *SignupService) DefaultMockGetSignup() func(username string) (*signup.Signup, error) {
+	return func(username string) (userSignup *signup.Signup, e error) {
 		return m.userSignups[username], nil
 	}
 }
 
-func (m *SignupService) GetSignup(_ *gin.Context, userID, username string, _ bool) (*signup.Signup, error) {
-	return m.MockGetSignup(userID, username)
+func (m *SignupService) GetSignup(_ *gin.Context, username string, _ bool) (*signup.Signup, error) {
+	return m.MockGetSignup(username)
 }
 
 func (m *SignupService) Signup(_ *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
 	return nil, nil
 }
-func (m *SignupService) GetUserSignupFromIdentifier(_, _ string) (*toolchainv1alpha1.UserSignup, error) {
-	return nil, nil
-}
 func (m *SignupService) UpdateUserSignup(_ *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
 	return nil, nil
 }
-func (m *SignupService) PhoneNumberAlreadyInUse(_, _, _ string) error {
+func (m *SignupService) PhoneNumberAlreadyInUse(_, _ string) error {
 	return nil
 }


### PR DESCRIPTION
The final PR of the whole effort of dropping support for using userIds as the names of UserSignups [KUBESAW-254](https://issues.redhat.com/browse/KUBESAW-254)

To simplify the code, the PR also removes the `GetUserSignupFromIdentifier` method as not needed anymore. Every caller that needs to get UserSignup resource can simply call `Get` with the encoded username.

paired PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/1105

