### PR TITLE
expose --replace-version flag via REPLACE_OPERATOR_VERSION variable

### DIFF
--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -8,6 +8,7 @@ INDEX_IMAGE_TAG=latest
 NEXT_VERSION=0.0.1
 OTHER_REPO_PATH=""
 BUNDLE_TAG=""
+REPLACE_OPERATOR_VERSION=""
 
 .PHONY: push-to-quay-staging
 ## Creates a new version of operator bundle, adds it into an index and pushes it to quay

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -19,7 +19,10 @@ generate-cd-release-manifests:
 ifneq (${OTHER_REPO_PATH},"")
 	$(eval OTHER_REPO_PATH_PARAM = -orp ${OTHER_REPO_PATH})
 endif
-	$(MAKE) run-cicd-script SCRIPT_PATH=scripts/cd/generate-cd-release-manifests.sh SCRIPT_PARAMS="-pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/ -qn ${QUAY_NAMESPACE} -td ${TMP_DIR} -fr ${FIRST_RELEASE} -ch ${CHANNEL} -il ${IMAGE} ${OTHER_REPO_PATH_PARAM}"
+ifneq (${REPLACE_OPERATOR_VERSION},"")
+	$(eval REPLACE_OPERATOR_VERSION_PARAM = -rv ${REPLACE_OPERATOR_VERSION})
+endif
+	$(MAKE) run-cicd-script SCRIPT_PATH=scripts/cd/generate-cd-release-manifests.sh SCRIPT_PARAMS="-pr ../registration-service/ -mr https://github.com/codeready-toolchain/host-operator/ -qn ${QUAY_NAMESPACE} -td ${TMP_DIR} -fr ${FIRST_RELEASE} -ch ${CHANNEL} -il ${IMAGE} ${OTHER_REPO_PATH_PARAM} ${REPLACE_OPERATOR_VERSION_PARAM}"
 
 .PHONY: push-bundle-and-index-image
 ## Pushes generated manifests as a bundle image to quay and adds is to the image index


### PR DESCRIPTION
exposes `--replace-version` flag via `REPLACE_OPERATOR_VERSION` variable
related PR: https://github.com/codeready-toolchain/toolchain-cicd/pull/133