### PR TITLE
drop verification-service option & use DefaultTransport instead

### DIFF
--- a/pkg/application/service/factory/service_factory.go
+++ b/pkg/application/service/factory/service_factory.go
@@ -34,12 +34,9 @@ func (s *serviceContextImpl) Services() service.Services {
 }
 
 type ServiceFactory struct {
-	contextProducer            servicecontext.ServiceContextProducer
-	serviceContextOptions      []ServiceContextOption
-	verificationServiceFunc    func(opts ...verificationservice.VerificationServiceOption) service.VerificationService
-	verificationServiceOptions []verificationservice.VerificationServiceOption
-	signupServiceFunc          func(opts ...signupservice.SignupServiceOption) service.SignupService
-	signupServiceOptions       []signupservice.SignupServiceOption
+	contextProducer       servicecontext.ServiceContextProducer
+	serviceContextOptions []ServiceContextOption
+	signupServiceOptions  []signupservice.SignupServiceOption
 }
 
 func (s *ServiceFactory) defaultServiceContextProducer() servicecontext.ServiceContextProducer {
@@ -51,7 +48,7 @@ func (s *ServiceFactory) defaultServiceContextProducer() servicecontext.ServiceC
 }
 
 func (s *ServiceFactory) SignupService() service.SignupService {
-	return s.signupServiceFunc(s.signupServiceOptions...)
+	return signupservice.NewSignupService(s.getContext().Client(), s.signupServiceOptions...)
 }
 
 func (s *ServiceFactory) WithSignupServiceOption(opt signupservice.SignupServiceOption) {
@@ -59,11 +56,7 @@ func (s *ServiceFactory) WithSignupServiceOption(opt signupservice.SignupService
 }
 
 func (s *ServiceFactory) VerificationService() service.VerificationService {
-	return s.verificationServiceFunc(s.verificationServiceOptions...)
-}
-
-func (s *ServiceFactory) WithVerificationServiceOption(opt verificationservice.VerificationServiceOption) {
-	s.verificationServiceOptions = append(s.verificationServiceOptions, opt)
+	return verificationservice.NewVerificationService(s.getContext())
 }
 
 // Option an option to configure the Service Factory
@@ -86,15 +79,6 @@ func NewServiceFactory(options ...Option) *ServiceFactory {
 
 	if !configuration.IsTestingMode() {
 		log.Info(nil, fmt.Sprintf("configuring a new service factory with %d options", len(options)))
-	}
-
-	// default function to return an instance of Verification service
-	f.verificationServiceFunc = func(_ ...verificationservice.VerificationServiceOption) service.VerificationService {
-		return verificationservice.NewVerificationService(f.getContext(), f.verificationServiceOptions...)
-	}
-
-	f.signupServiceFunc = func(_ ...signupservice.SignupServiceOption) service.SignupService {
-		return signupservice.NewSignupService(f.getContext().Client(), f.signupServiceOptions...)
 	}
 
 	return f

--- a/pkg/controller/signup_test.go
+++ b/pkg/controller/signup_test.go
@@ -14,13 +14,11 @@ import (
 	"time"
 
 	crtapi "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/registration-service/pkg/application/service/factory"
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/pkg/context"
 	"github.com/codeready-toolchain/registration-service/pkg/controller"
 	"github.com/codeready-toolchain/registration-service/pkg/signup"
 	"github.com/codeready-toolchain/registration-service/pkg/verification/service"
-	verification_service "github.com/codeready-toolchain/registration-service/pkg/verification/service"
 	"github.com/codeready-toolchain/registration-service/test"
 	testutil "github.com/codeready-toolchain/registration-service/test/util"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
@@ -47,21 +45,6 @@ type TestSignupSuite struct {
 
 func TestRunSignupSuite(t *testing.T) {
 	suite.Run(t, &TestSignupSuite{test.UnitTestSuite{}, nil})
-}
-
-func httpClientFactoryOption() func(serviceFactory *factory.ServiceFactory) {
-	httpClient := &http.Client{Transport: &http.Transport{}}
-	gock.InterceptClient(httpClient)
-
-	serviceOption := func(svc *verification_service.ServiceImpl) {
-		svc.HTTPClient = httpClient
-	}
-
-	opt := func(serviceFactory *factory.ServiceFactory) {
-		serviceFactory.WithVerificationServiceOption(serviceOption)
-	}
-
-	return opt
 }
 
 func (s *TestSignupSuite) TestSignupPostHandler() {
@@ -241,7 +224,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 		testusersignup.WithAnnotation(crtapi.UserSignupVerificationCounterAnnotationKey, "0"),
 		testusersignup.WithAnnotation(crtapi.UserSignupVerificationCodeAnnotationKey, ""),
 		testusersignup.VerificationRequiredAgo(time.Second))
-	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
+	fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 	defer gock.Off()
 
 	// Create Signup controller instance.
@@ -336,7 +319,7 @@ func (s *TestSignupSuite) TestInitVerificationHandler() {
 		// Create UserSignup
 		userSignup := testusersignup.NewUserSignup(testusersignup.WithEncodedName("johnny@kubesaw"))
 
-		_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
+		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		// Create Signup controller instance.
 		ctrl := controller.NewSignup(application)

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -49,19 +49,16 @@ type ServiceImpl struct { // nolint:revive
 type VerificationServiceOption func(svc *ServiceImpl)
 
 // NewVerificationService creates a service object for performing user verification
-func NewVerificationService(context servicecontext.ServiceContext, opts ...VerificationServiceOption) service.VerificationService {
-	s := &ServiceImpl{
-		BaseService: base.NewBaseService(context),
-		Client:      context.Client(),
+func NewVerificationService(context servicecontext.ServiceContext) service.VerificationService {
+	httpClient := &http.Client{
+		Timeout:   30*time.Second + 500*time.Millisecond, // taken from twilio code
+		Transport: http.DefaultTransport,
 	}
-
-	for _, opt := range opts {
-		opt(s)
+	return &ServiceImpl{
+		BaseService:         base.NewBaseService(context),
+		Client:              context.Client(),
+		NotificationService: sender.CreateNotificationSender(httpClient),
 	}
-
-	s.NotificationService = sender.CreateNotificationSender(s.HTTPClient)
-
-	return s
 }
 
 // InitVerification sends a verification message to the specified user, using the Twilio service.  If successful,

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/registration-service/pkg/application/service/factory"
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	crterrors "github.com/codeready-toolchain/registration-service/pkg/errors"
 	verificationservice "github.com/codeready-toolchain/registration-service/pkg/verification/service"
@@ -102,22 +101,6 @@ func (s *TestVerificationServiceSuite) ServiceConfiguration(accountSID, authToke
 	s.SetSecret(secret)
 }
 
-func httpClientFactoryOption() func(serviceFactory *factory.ServiceFactory) {
-
-	httpClient := &http.Client{Transport: &http.Transport{}}
-	gock.InterceptClient(httpClient)
-
-	serviceOption := func(svc *verificationservice.ServiceImpl) {
-		svc.HTTPClient = httpClient
-	}
-
-	opt := func(serviceFactory *factory.ServiceFactory) {
-		serviceFactory.WithVerificationServiceOption(serviceOption)
-	}
-
-	return opt
-}
-
 func (s *TestVerificationServiceSuite) TestInitVerification() {
 	s.ServiceConfiguration("xxx", "yyy", "CodeReady")
 
@@ -147,7 +130,7 @@ func (s *TestVerificationServiceSuite) TestInitVerification() {
 		testusersignup.VerificationRequiredAgo(time.Second))
 
 	// Add both UserSignups to the fake client
-	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup, userSignup2)
+	fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, userSignup2)
 
 	// Test the init verification for the first UserSignup
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
@@ -250,7 +233,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 		testusersignup.VerificationRequiredAgo(time.Second))
 
 	s.Run("when client GET call fails should return error", func() {
-		fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		// Cause the client GET call to fail
 		fakeClient.MockGet = func(ctx gocontext.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -266,7 +249,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 	})
 
 	s.Run("when client UPDATE call fails indefinitely should return error", func() {
-		fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 		fakeClient.MockUpdate = func(ctx gocontext.Context, obj client.Object, opts ...client.UpdateOption) error {
 			if _, ok := obj.(*toolchainv1alpha1.UserSignup); ok {
 				return errors.New("there was an error while updating your account - please wait a moment before trying again. If this error persists, please contact the Developer Sandbox team at devsandbox@redhat.com \"+\n\t\t\t\"for assistance: error while verifying phone code")
@@ -282,7 +265,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 	})
 
 	s.Run("when client UPDATE call fails twice should return ok", func() {
-		fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		failCount := 0
 		// Cause the client UPDATE call to fail just twice
@@ -344,7 +327,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPassesWhenMaxCountRea
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123456"),
 		testusersignup.VerificationRequiredAgo(time.Second))
 
-	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
+	fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	err := application.VerificationService().InitVerification(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
@@ -385,7 +368,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenCountContain
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
 		testusersignup.VerificationRequiredAgo(time.Second))
 
-	_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
+	_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	err := application.VerificationService().InitVerification(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
@@ -411,7 +394,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsDailyCounterExce
 		testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey, now.Format(verificationservice.TimestampLayout)),
 		testusersignup.VerificationRequiredAgo(time.Second))
 
-	_, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), userSignup)
+	_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	err := application.VerificationService().InitVerification(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
@@ -443,7 +426,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationFailsWhenPhoneNumberI
 		testusersignup.WithEncodedName("bravo@kubesaw"),
 		testusersignup.VerificationRequiredAgo(time.Second))
 
-	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), alphaUserSignup, bravoUserSignup)
+	fakeClient, application := testutil.PrepareInClusterApp(s.T(), alphaUserSignup, bravoUserSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	err := application.VerificationService().InitVerification(ctx, bravoUserSignup.Spec.IdentityClaims.PreferredUsername, e164PhoneNumber, "1")
@@ -483,7 +466,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationOKWhenPhoneNumberInUs
 		testusersignup.WithEncodedName("bravo@kubesaw"),
 		testusersignup.VerificationRequiredAgo(time.Second))
 
-	fakeClient, application := testutil.PrepareInClusterAppWithOption(s.T(), httpClientFactoryOption(), alphaUserSignup, bravoUserSignup)
+	fakeClient, application := testutil.PrepareInClusterApp(s.T(), alphaUserSignup, bravoUserSignup)
 
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	err := application.VerificationService().InitVerification(ctx, bravoUserSignup.Spec.IdentityClaims.PreferredUsername, e164PhoneNumber, "1")


### PR DESCRIPTION
when the `DefaultTransport` is used, then there is no need to mock the HTTP Client to make gock working, thus we can simplify the tests and the other related code.