### PR TITLE
Removing unsupported service

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,3 @@
-service:
-  project-path: github.com/codeready-toolchain/registration-service
-  prepare: # see https://github.com/golangci/golangci/wiki/Configuration#config-directives
-    - make generate
-
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m


### PR DESCRIPTION
remove unsupported service:

`$ golangci-lint config verify --config=./.golangci.yml
jsonschema: "" does not validate with "/additionalProperties": additional properties 'service' not allowed`

Similar Prs
- Member-operator - https://github.com/codeready-toolchain/member-operator/pull/626
- Host Operator - https://github.com/codeready-toolchain/host-operator/pull/1143
- Toolchain-e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1120
- Toolchain - common - https://github.com/codeready-toolchain/toolchain-common/pull/458
- Api - https://github.com/codeready-toolchain/api/pull/461 
- Registration Service - https://github.com/codeready-toolchain/registration-service/pull/511