### PR TITLE
fix: populate values from SocialEvent before creating UserSignup

### DIFF
--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -29,4 +29,6 @@ const (
 	PublicViewerEnabled = "publicViewerEnabled"
 	// ImpersonateUser is the context key for the impersonated user in proxied call
 	ImpersonateUser = "impersonateUser"
+	// SocialEvent is the context key for the activation code provided in UI
+	SocialEvent = "socialEvent"
 )

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -142,6 +142,14 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 		userSignup.Annotations[toolchainv1alpha1.SkipAutoCreateSpaceAnnotationKey] = "true"
 	}
 
+	if socialEvent := ctx.GetString(context.SocialEvent); socialEvent != "" {
+		event, err := signup.GetAndValidateSocialEvent(ctx, s.Client, socialEvent)
+		if err != nil {
+			return nil, err
+		}
+		signup.UpdateUserSignupWithSocialEvent(event, userSignup)
+	}
+
 	return userSignup, nil
 }
 

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -197,6 +197,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 			signup := &toolchainv1alpha1.UserSignup{}
 			require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(returnedSignup), signup))
 			require.Equal(s.T(), "event-member", signup.Spec.TargetCluster)
+			assert.True(s.T(), states.ApprovedManually(signup))
 		})
 
 		s.Run("set target cluster when reactivating", func() {
@@ -215,6 +216,7 @@ func (s *TestSignupServiceSuite) TestSignup() {
 			require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(reactivatedSignup), signup))
 			require.Equal(s.T(), "event-member", signup.Spec.TargetCluster)
 			assert.False(s.T(), states.Deactivated(signup))
+			assert.True(s.T(), states.ApprovedManually(signup))
 		})
 
 		s.Run("when event not present", func() {

--- a/pkg/signup/socialevent.go
+++ b/pkg/signup/socialevent.go
@@ -43,8 +43,8 @@ func GetAndValidateSocialEvent(ctx *gin.Context, cl namespaced.Client, code stri
 
 // UpdateUserSignupWithSocialEvent updates fields in the userSignup with values from the given SocialEvent
 func UpdateUserSignupWithSocialEvent(event *toolchainv1alpha1.SocialEvent, userSignup *toolchainv1alpha1.UserSignup) {
-	if states.VerificationRequired(userSignup) {
-		states.SetVerificationRequired(userSignup, event.Spec.VerificationRequired)
+	if !event.Spec.VerificationRequired {
+		states.SetApprovedManually(userSignup, true)
 	}
 	// make sure that the user is not deactivated
 	states.SetDeactivated(userSignup, false)

--- a/pkg/signup/socialevent.go
+++ b/pkg/signup/socialevent.go
@@ -1,0 +1,60 @@
+package signup
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	crterrors "github.com/codeready-toolchain/registration-service/pkg/errors"
+	"github.com/codeready-toolchain/registration-service/pkg/log"
+	"github.com/codeready-toolchain/registration-service/pkg/namespaced"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+	"github.com/gin-gonic/gin"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetAndValidateSocialEvent returns a SocialEvent with the given name.
+// If the event is already full, not yet started, already finished, or not found then it returns error
+func GetAndValidateSocialEvent(ctx *gin.Context, cl namespaced.Client, code string) (*toolchainv1alpha1.SocialEvent, error) {
+	// look-up the SocialEvent
+	event := &toolchainv1alpha1.SocialEvent{}
+	if err := cl.Get(ctx, cl.NamespacedName(code), event); err != nil {
+		if apierrors.IsNotFound(err) {
+			// a SocialEvent was not found for the provided code
+			return nil, crterrors.NewForbiddenError("invalid code", "the provided code is invalid")
+		}
+		return nil, crterrors.NewInternalError(err, fmt.Sprintf("error retrieving event '%s'", code))
+	}
+	// if there is room for the user and if the "time window" to signup is valid
+	now := metav1.NewTime(time.Now())
+	log.Infof(ctx, "verifying activation code '%s': event.Status.ActivationCount=%d, event.Spec.MaxAttendees=%s, event.Spec.StartTime=%s, event.Spec.EndTime=%s",
+		code, strconv.Itoa(event.Status.ActivationCount), strconv.Itoa(event.Spec.MaxAttendees), event.Spec.StartTime.Format("2006-01-02:03:04:05"), event.Spec.EndTime.Format("2006-01-02:03:04:05"))
+
+	if event.Status.ActivationCount >= event.Spec.MaxAttendees {
+		return nil, crterrors.NewForbiddenError("invalid code", "the event is full")
+	} else if event.Spec.StartTime.After(now.Time) || event.Spec.EndTime.Before(&now) {
+		log.Infof(ctx, "the event with code '%s' has not started yet or is already past", code)
+		return nil, crterrors.NewForbiddenError("invalid code", "the provided code is invalid")
+	}
+	return event, nil
+}
+
+// UpdateUserSignupWithSocialEvent updates fields in the userSignup with values from the given SocialEvent
+func UpdateUserSignupWithSocialEvent(event *toolchainv1alpha1.SocialEvent, userSignup *toolchainv1alpha1.UserSignup) {
+	if states.VerificationRequired(userSignup) {
+		states.SetVerificationRequired(userSignup, event.Spec.VerificationRequired)
+	}
+	// make sure that the user is not deactivated
+	states.SetDeactivated(userSignup, false)
+
+	// label the UserSignup with the name of the SocialEvent (ie, the activation code)
+	if userSignup.Labels == nil {
+		userSignup.Labels = map[string]string{}
+	}
+	userSignup.Labels[toolchainv1alpha1.SocialEventUserSignupLabelKey] = event.Name
+	if event.Spec.TargetCluster != "" {
+		userSignup.Spec.TargetCluster = event.Spec.TargetCluster
+	}
+}

--- a/pkg/signup/socialevent.go
+++ b/pkg/signup/socialevent.go
@@ -34,9 +34,12 @@ func GetAndValidateSocialEvent(ctx *gin.Context, cl namespaced.Client, code stri
 
 	if event.Status.ActivationCount >= event.Spec.MaxAttendees {
 		return nil, crterrors.NewForbiddenError("invalid code", "the event is full")
-	} else if event.Spec.StartTime.After(now.Time) || event.Spec.EndTime.Before(&now) {
-		log.Infof(ctx, "the event with code '%s' has not started yet or is already past", code)
-		return nil, crterrors.NewForbiddenError("invalid code", "the provided code is invalid")
+	} else if event.Spec.StartTime.After(now.Time) {
+		log.Infof(ctx, "the event with code '%s' has not started yet", code)
+		return nil, crterrors.NewForbiddenError("invalid code", "the provided code is not valid yet")
+	} else if event.Spec.EndTime.Before(&now) {
+		log.Infof(ctx, "the event with code '%s' is already past", code)
+		return nil, crterrors.NewForbiddenError("invalid code", "the provided code has expired")
 	}
 	return event, nil
 }

--- a/pkg/signup/socialevent_test.go
+++ b/pkg/signup/socialevent_test.go
@@ -108,19 +108,25 @@ func TestUpdateUserSignupWithSocialEvent(t *testing.T) {
 		signupOptions           []usersignup.Modifier
 		expTargetCluster        string
 		expVerificationRequired bool
+		expManuallyApproved     bool
 	}{
-		"nothing set": {},
+		"nothing set": {
+			expManuallyApproved: true,
+		},
 		"reactivated": {
-			signupOptions: []usersignup.Modifier{usersignup.Deactivated()},
+			signupOptions:       []usersignup.Modifier{usersignup.Deactivated()},
+			expManuallyApproved: true,
 		},
 		"target cluster set": {
-			eventOptions:     []testsocialevent.Option{testsocialevent.WithTargetCluster("member")},
-			expTargetCluster: "member",
+			eventOptions:        []testsocialevent.Option{testsocialevent.WithTargetCluster("member")},
+			expTargetCluster:    "member",
+			expManuallyApproved: true,
 		},
 		"target cluster overridden": {
-			eventOptions:     []testsocialevent.Option{testsocialevent.WithTargetCluster("member1")},
-			signupOptions:    []usersignup.Modifier{usersignup.WithTargetCluster("member2")},
-			expTargetCluster: "member1",
+			eventOptions:        []testsocialevent.Option{testsocialevent.WithTargetCluster("member1")},
+			signupOptions:       []usersignup.Modifier{usersignup.WithTargetCluster("member2")},
+			expTargetCluster:    "member1",
+			expManuallyApproved: true,
 		},
 		"verification required when already required": {
 			eventOptions: []testsocialevent.Option{
@@ -153,9 +159,9 @@ func TestUpdateUserSignupWithSocialEvent(t *testing.T) {
 			assert.Equal(t, "event1", signup.Labels[toolchainv1alpha1.SocialEventUserSignupLabelKey])
 			assert.Equal(t, tc.expTargetCluster, signup.Spec.TargetCluster)
 			assert.Equal(t, tc.expVerificationRequired, states.VerificationRequired(signup))
+			assert.Equal(t, tc.expManuallyApproved, states.ApprovedManually(signup))
 			assert.False(t, states.Deactivating(signup))
 			assert.False(t, states.Deactivated(signup))
-			assert.False(t, states.ApprovedManually(signup))
 		})
 	}
 }

--- a/pkg/signup/socialevent_test.go
+++ b/pkg/signup/socialevent_test.go
@@ -1,0 +1,161 @@
+package signup
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/registration-service/pkg/log"
+	"github.com/codeready-toolchain/registration-service/pkg/namespaced"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	testsocialevent "github.com/codeready-toolchain/toolchain-common/pkg/test/socialevent"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSocialEvent(t *testing.T) {
+	// given
+	log.Init("social-code-testing")
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	t.Run("success", func(t *testing.T) {
+		// given
+		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event1",
+			testsocialevent.WithTargetCluster("member"),
+			testsocialevent.WithMaxAttendees(100),
+			testsocialevent.WithActivationCount(99),
+			testsocialevent.WithStartTime(time.Now().Add(-time.Hour)),
+			testsocialevent.WithEndTime(time.Now().Add(time.Hour)))
+		nsdClient := namespaced.NewClient(commontest.NewFakeClient(t, event), commontest.HostOperatorNs)
+
+		// when
+		event, err := GetAndValidateSocialEvent(ctx, nsdClient, "event1")
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, event)
+		assert.Equal(t, "deactivate30", event.Spec.UserTier)
+		assert.Equal(t, "base1ns", event.Spec.SpaceTier)
+		assert.Equal(t, 100, event.Spec.MaxAttendees)
+		assert.Equal(t, 99, event.Status.ActivationCount)
+		assert.Equal(t, "member", event.Spec.TargetCluster)
+	})
+
+	t.Run("when event is full", func(t *testing.T) {
+		// given
+		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event1",
+			testsocialevent.WithMaxAttendees(100),
+			testsocialevent.WithActivationCount(100))
+		nsdClient := namespaced.NewClient(commontest.NewFakeClient(t, event), commontest.HostOperatorNs)
+
+		// when
+		event, err := GetAndValidateSocialEvent(ctx, nsdClient, "event1")
+
+		// then
+		require.EqualError(t, err, "invalid code: the event is full")
+		require.Nil(t, event)
+	})
+
+	t.Run("when event not open yet", func(t *testing.T) {
+		// given
+		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event1",
+			testsocialevent.WithStartTime(time.Now().Add(time.Hour)))
+		nsdClient := namespaced.NewClient(commontest.NewFakeClient(t, event), commontest.HostOperatorNs)
+
+		// when
+		event, err := GetAndValidateSocialEvent(ctx, nsdClient, "event1")
+
+		// then
+		require.EqualError(t, err, "invalid code: the provided code is invalid")
+		require.Nil(t, event)
+	})
+
+	t.Run("when event already closed", func(t *testing.T) {
+		// given
+		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event1",
+			testsocialevent.WithEndTime(time.Now().Add(-time.Hour)))
+		nsdClient := namespaced.NewClient(commontest.NewFakeClient(t, event), commontest.HostOperatorNs)
+
+		// when
+		event, err := GetAndValidateSocialEvent(ctx, nsdClient, "event1")
+
+		// then
+		require.EqualError(t, err, "invalid code: the provided code is invalid")
+		require.Nil(t, event)
+	})
+
+	t.Run("when event does not exist", func(t *testing.T) {
+		// given
+		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event1")
+		nsdClient := namespaced.NewClient(commontest.NewFakeClient(t, event), commontest.HostOperatorNs)
+
+		// when
+		event, err := GetAndValidateSocialEvent(ctx, nsdClient, "unknown")
+
+		// then
+		require.EqualError(t, err, "invalid code: the provided code is invalid")
+		require.Nil(t, event)
+	})
+}
+
+func TestUpdateUserSignupWithSocialEvent(t *testing.T) {
+	tests := map[string]struct {
+		eventOptions            []testsocialevent.Option
+		signupOptions           []usersignup.Modifier
+		expTargetCluster        string
+		expVerificationRequired bool
+	}{
+		"nothing set": {},
+		"reactivated": {
+			signupOptions: []usersignup.Modifier{usersignup.Deactivated()},
+		},
+		"target cluster set": {
+			eventOptions:     []testsocialevent.Option{testsocialevent.WithTargetCluster("member")},
+			expTargetCluster: "member",
+		},
+		"target cluster overridden": {
+			eventOptions:     []testsocialevent.Option{testsocialevent.WithTargetCluster("member1")},
+			signupOptions:    []usersignup.Modifier{usersignup.WithTargetCluster("member2")},
+			expTargetCluster: "member1",
+		},
+		"verification required when already required": {
+			eventOptions: []testsocialevent.Option{
+				testsocialevent.WithTargetCluster("member"),
+				func(event *toolchainv1alpha1.SocialEvent) {
+					event.Spec.VerificationRequired = true
+				}},
+			signupOptions:           []usersignup.Modifier{usersignup.VerificationRequired()},
+			expTargetCluster:        "member",
+			expVerificationRequired: true,
+		},
+		"verification not required when already not required": {
+			eventOptions: []testsocialevent.Option{
+				func(event *toolchainv1alpha1.SocialEvent) {
+					event.Spec.VerificationRequired = true
+				}},
+			expVerificationRequired: false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given
+			event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event1", tc.eventOptions...)
+			signup := usersignup.NewUserSignup(tc.signupOptions...)
+
+			// when
+			UpdateUserSignupWithSocialEvent(event, signup)
+
+			// then
+			assert.Equal(t, "event1", signup.Labels[toolchainv1alpha1.SocialEventUserSignupLabelKey])
+			assert.Equal(t, tc.expTargetCluster, signup.Spec.TargetCluster)
+			assert.Equal(t, tc.expVerificationRequired, states.VerificationRequired(signup))
+			assert.False(t, states.Deactivating(signup))
+			assert.False(t, states.Deactivated(signup))
+			assert.False(t, states.ApprovedManually(signup))
+		})
+	}
+}

--- a/pkg/signup/socialevent_test.go
+++ b/pkg/signup/socialevent_test.go
@@ -70,7 +70,7 @@ func TestGetSocialEvent(t *testing.T) {
 		event, err := GetAndValidateSocialEvent(ctx, nsdClient, "event1")
 
 		// then
-		require.EqualError(t, err, "invalid code: the provided code is invalid")
+		require.EqualError(t, err, "invalid code: the provided code is not valid yet")
 		require.Nil(t, event)
 	})
 
@@ -84,7 +84,7 @@ func TestGetSocialEvent(t *testing.T) {
 		event, err := GetAndValidateSocialEvent(ctx, nsdClient, "event1")
 
 		// then
-		require.EqualError(t, err, "invalid code: the provided code is invalid")
+		require.EqualError(t, err, "invalid code: the provided code has expired")
 		require.Nil(t, event)
 	})
 

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -815,7 +815,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 			// given
 			userSignup := testusersignup.NewUserSignup(
 				testusersignup.VerificationRequiredAgo(time.Second), // just signed up
-				testusersignup.WithVerificationAttempts(2)) // already tried twice before
+				testusersignup.WithVerificationAttempts(2))          // already tried twice before
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 			// when

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -771,24 +771,6 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		assert.Equal(s.T(), targetCluster, signup.Spec.TargetCluster)
 	})
 
-	s.Run("last user to signup", func() {
-		// given
-		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second))                                                                       // just signed up
-		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithActivationCount(9), testsocialevent.WithTargetCluster(targetCluster)) // one seat left
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
-
-		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
-
-		// then
-		require.NoError(s.T(), err)
-		signup := &toolchainv1alpha1.UserSignup{}
-		err = fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), signup)
-		require.NoError(s.T(), err)
-		require.False(s.T(), states.VerificationRequired(signup))
-		assert.Equal(s.T(), targetCluster, signup.Spec.TargetCluster)
-	})
-
 	s.Run("when too many attempts made", func() {
 		// given
 		userSignup := testusersignup.NewUserSignup(
@@ -848,62 +830,6 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		})
 	})
 
-	s.Run("when max attendees reached", func() {
-		// given
-		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second))                                                                        // just signed up
-		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithActivationCount(10), testsocialevent.WithTargetCluster(targetCluster)) // same as default `spec.MaxAttendees`
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
-
-		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
-
-		// then
-		require.EqualError(s.T(), err, "invalid code: the event is full")
-		signup := &toolchainv1alpha1.UserSignup{}
-		err = fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), signup)
-		require.NoError(s.T(), err)
-		require.True(s.T(), states.VerificationRequired(signup))
-		assert.Equal(s.T(), "1", signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey]) // incremented
-		assert.Empty(s.T(), signup.Spec.TargetCluster)
-	})
-
-	s.Run("when event not open yet", func() {
-		// given
-		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second))                                                                                         // just signed up
-		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithStartTime(time.Now().Add(time.Hour)), testsocialevent.WithTargetCluster(targetCluster)) // starting in 1hr
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
-
-		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
-
-		// then
-		require.EqualError(s.T(), err, "invalid code: the provided code is invalid")
-		signup := &toolchainv1alpha1.UserSignup{}
-		err = fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), signup)
-		require.NoError(s.T(), err)
-		require.True(s.T(), states.VerificationRequired(signup))
-		assert.Equal(s.T(), "1", signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey]) // incremented
-		assert.Empty(s.T(), signup.Spec.TargetCluster)
-	})
-
-	s.Run("when event already closed", func() {
-		// given
-		userSignup := testusersignup.NewUserSignup(testusersignup.VerificationRequiredAgo(time.Second))                                                                                        // just signed up
-		event := testsocialevent.NewSocialEvent(commontest.HostOperatorNs, "event", testsocialevent.WithEndTime(time.Now().Add(-time.Hour)), testsocialevent.WithTargetCluster(targetCluster)) // ended 1hr ago
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup, event)
-
-		// when
-		err := application.VerificationService().VerifyActivationCode(ctx, userSignup.Spec.IdentityClaims.PreferredUsername, event.Name)
-
-		// then
-		require.EqualError(s.T(), err, "invalid code: the provided code is invalid")
-		signup := &toolchainv1alpha1.UserSignup{}
-		err = fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), signup)
-		require.NoError(s.T(), err)
-		require.True(s.T(), states.VerificationRequired(signup))
-		assert.Equal(s.T(), "1", signup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey]) // incremented
-		assert.Empty(s.T(), signup.Spec.TargetCluster)
-	})
 }
 
 func (s *TestVerificationServiceSuite) TestPhoneNumberAlreadyInUse() {

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -769,6 +769,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 		require.NoError(s.T(), err)
 		require.False(s.T(), states.VerificationRequired(signup))
 		assert.Equal(s.T(), targetCluster, signup.Spec.TargetCluster)
+		assert.True(s.T(), states.ApprovedManually(signup))
 	})
 
 	s.Run("when too many attempts made", func() {
@@ -814,7 +815,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 			// given
 			userSignup := testusersignup.NewUserSignup(
 				testusersignup.VerificationRequiredAgo(time.Second), // just signed up
-				testusersignup.WithVerificationAttempts(2))          // already tried twice before
+				testusersignup.WithVerificationAttempts(2)) // already tried twice before
 			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 			// when


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/CHK0J6HT6/p1750929477560779

The values from the SocialEvent should be set before we create the UserSignup in the cluster

It also sets the states of the UserSignup to be approved manually, unless the verification is required for the given SocialEvent

paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/1164