### PR TITLE
Sandbox-1225: Fix issue with phone verification metric

### DIFF
--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -302,6 +302,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 	})
 
 	s.Run("when notification sending fails should still set phone hash label", func() {
+		// given
 		// Create a fresh UserSignup without phone hash label to test the new behavior
 		userSignupWithoutPhoneHash := testusersignup.NewUserSignup(
 			testusersignup.WithEncodedName("johnny@kubesaw"),
@@ -315,9 +316,12 @@ func (s *TestVerificationServiceSuite) TestInitVerificationClientFailure() {
 			Reply(http.StatusInternalServerError).
 			BodyString("Internal Server Error")
 
+		// when:
+		// InitVerification is called and notification sending fails
 		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 		err := application.VerificationService().InitVerification(ctx, userSignupWithoutPhoneHash.Spec.IdentityClaims.PreferredUsername, "+1NUMBER", "1")
 
+		// then
 		// The function should return an error because notification sending failed
 		require.Error(s.T(), err)
 		require.Contains(s.T(), err.Error(), "error while sending verification code")


### PR DESCRIPTION
The [PR](https://github.com/codeready-toolchain/host-operator/pull/1188) , did not completely fix the issue.
This PR updates the phones hash label when the phone verification is initiated and hence this will give us the correct updated label and correct metrix for more info [slack](https://redhat-internal.slack.com/archives/CHK0J6HT6/p1753795798760329)

Assisted-By: cursor