### PR TITLE
build: switch to toolchain-cicd/govulncheck-action

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Go
       uses: actions/setup-go@v5
@@ -19,8 +19,8 @@ jobs:
         go-version-file: go.mod
 
     - name: Run govulncheck
-      uses: golang/govulncheck-action@v1
+      uses: codeready-toolchain/toolchain-cicd/govulncheck-action@master
       with:
-        go-version-input: ${{ steps.install-go.outputs.go-version }}
-        go-package: ./...
-        repo-checkout: false
+        go-version-file: go.mod
+        cache: false
+        config: .govulncheck.yaml 

--- a/.govulncheck.yaml
+++ b/.govulncheck.yaml
@@ -1,0 +1,28 @@
+ignored-vulnerabilities:
+  # Request smuggling due to acceptance of invalid chunked data in net/http
+  # Found in Found in: net/http/internal@go1.22.12
+  # Fixed in Fixed in: net/http/internal@go1.23.8
+  - id: GO-2025-3563
+    info: https://pkg.go.dev/vuln/GO-2025-3563
+    silence-until: 2025-09-17
+
+  # Incorrect Neutralization of Input During Web Page Generation in x/net in golang.org/x/net
+  # Found in Found in: golang.org/x/net/html@v0.33.0
+  # Fixed in Fixed in: golang.org/x/net/html@v0.38.0
+  - id: GO-2025-3595
+    info: https://pkg.go.dev/vuln/GO-2025-3595
+    silence-until: 2025-09-17
+
+  # Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in syscall
+  # Found in Found in: os@go1.22.12
+  # Fixed in Fixed in: os@go1.23.10
+  - id: GO-2025-3750
+    info: https://pkg.go.dev/vuln/GO-2025-3750
+    silence-until: 2025-09-17
+
+  # Sensitive headers not cleared on cross-origin redirect in net/http
+  # Found in Found in: net/http@go1.22.12
+  # Fixed in Fixed in: net/http@go1.23.10
+  - id: GO-2025-3751
+    info: https://pkg.go.dev/vuln/GO-2025-3751
+    silence-until: 2025-09-17


### PR DESCRIPTION
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated continuous integration dependencies to their latest major versions.
  - Refreshed vulnerability scanning to use newer tooling and to derive the Go version from the project manifest; disabled caching for this step.
  - Introduced a configuration file to temporarily silence a small set of specific advisories until 2025-09-17, with links documented for reference.
  - No user-facing changes; application behavior and release artifacts remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->