### PR TITLE
feat: add route for getting sandbox segment key

### DIFF
--- a/pkg/controller/analytics_test.go
+++ b/pkg/controller/analytics_test.go
@@ -67,4 +67,40 @@ func (s *TestAnalyticsSuite) TestAnalyticsHandler() {
 			assert.Equal(s.T(), cfg.Analytics().DevSpacesSegmentWriteKey(), dataEnvelope, "wrong 'segment write key' in segment response")
 		})
 	})
+
+	s.Run("valid sandbox segment write key json", func() {
+
+		// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+		// pass 'nil' as the third parameter.
+		req, err := http.NewRequest(http.MethodGet, "/api/v1/analytics/segment-write-key", nil)
+		require.NoError(s.T(), err)
+
+		handler := gin.HandlerFunc(analyticsCtrl.GetSandboxSegmentWriteKey)
+
+		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Request = req
+
+		s.OverrideApplicationDefault(testconfig.RegistrationService().
+			Analytics().SegmentWriteKey("testing sandbox segment write key"))
+
+		cfg := configuration.GetRegistrationServiceConfig()
+
+		assert.Equal(s.T(), "testing sandbox segment write key", cfg.Analytics().SegmentWriteKey())
+
+		handler(ctx)
+
+		// Check the status code is what we expect.
+		require.Equal(s.T(), http.StatusOK, rr.Code)
+
+		// Check the response body is what we expect.
+		// get config values from endpoint response
+		dataEnvelope := rr.Body.String()
+		require.NoError(s.T(), err)
+
+		s.Run("envelope segment write key", func() {
+			assert.Equal(s.T(), cfg.Analytics().SegmentWriteKey(), dataEnvelope, "wrong 'segment write key' in segment response")
+		})
+	})
 }

--- a/pkg/controller/analytics_test.go
+++ b/pkg/controller/analytics_test.go
@@ -68,7 +68,7 @@ func (s *TestAnalyticsSuite) TestAnalyticsHandler() {
 		})
 	})
 
-	s.Run("valid sandbox segment write key json", func() {
+	s.Run("valid sandbox segment write key", func() {
 
 		// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
 		// pass 'nil' as the third parameter.
@@ -97,7 +97,6 @@ func (s *TestAnalyticsSuite) TestAnalyticsHandler() {
 		// Check the response body is what we expect.
 		// get config values from endpoint response
 		dataEnvelope := rr.Body.String()
-		require.NoError(s.T(), err)
 
 		s.Run("envelope segment write key", func() {
 			assert.Equal(s.T(), cfg.Analytics().SegmentWriteKey(), dataEnvelope, "wrong 'segment write key' in segment response")

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -69,8 +69,9 @@ func (srv *RegistrationServer) SetupRoutes(proxyPort string, reg *prometheus.Reg
 			middleware.InstrumentRoundTripperDuration(histVec))
 		unsecuredV1.GET("/health", healthCheckCtrl.GetHandler) // TODO: move to root (`/`)?
 		unsecuredV1.GET("/authconfig", authConfigCtrl.GetHandler)
-		unsecuredV1.GET("/segment-write-key", analyticsCtrl.GetDevSpacesSegmentWriteKey) //expose the devspaces segment key
-		unsecuredV1.GET("/analytics/segment-write-key", analyticsCtrl.GetSandboxSegmentWriteKey)
+		// segment keys endpoints
+		unsecuredV1.GET("/segment-write-key", analyticsCtrl.GetDevSpacesSegmentWriteKey)         // expose the devspaces segment key
+		unsecuredV1.GET("/analytics/segment-write-key", analyticsCtrl.GetSandboxSegmentWriteKey) // expose the sandbox segment key.We had the create a new analytics endpoint to keep backward compatibility with devspaces.
 
 		// create the auth middleware
 		var authMiddleware *middleware.JWTMiddleware

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -70,6 +70,7 @@ func (srv *RegistrationServer) SetupRoutes(proxyPort string, reg *prometheus.Reg
 		unsecuredV1.GET("/health", healthCheckCtrl.GetHandler) // TODO: move to root (`/`)?
 		unsecuredV1.GET("/authconfig", authConfigCtrl.GetHandler)
 		unsecuredV1.GET("/segment-write-key", analyticsCtrl.GetDevSpacesSegmentWriteKey) //expose the devspaces segment key
+		unsecuredV1.GET("/analytics/segment-write-key", analyticsCtrl.GetSandboxSegmentWriteKey)
 
 		// create the auth middleware
 		var authMiddleware *middleware.JWTMiddleware


### PR DESCRIPTION
see: https://redhat-internal.slack.com/archives/CHK0J6HT6/p1755618057521369

This is needed in order to send events from our new UI at https://sandbox.redhat.com/ to Amplitude.

Jira: https://issues.redhat.com/browse/SANDBOX-1394

e2e PR:  https://github.com/codeready-toolchain/toolchain-e2e/pull/1183

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an unsecured API endpoint GET /api/v1/analytics/segment-write-key to retrieve the sandbox analytics Segment write key (mirrors the existing devspaces key endpoint).

* **Tests**
  * Added tests verifying the new endpoint returns HTTP 200 and the configured sandbox key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->