### PR TITLE
drop 'Install Go' step from govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,11 +13,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v5
 
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-
     - name: Run govulncheck
       uses: codeready-toolchain/toolchain-cicd/govulncheck-action@master
       with:


### PR DESCRIPTION
drop 'Install Go' step from govulncheck workflow because it's done in the GHA composite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined vulnerability scanning workflow by consolidating configuration and removing redundant setup.
  * Standardized Go version sourcing from the project configuration during scans for consistent results.
  * Ensured scans use explicit options managed via a repository config file.
  * Disabled caching in the scan process to guarantee up-to-date vulnerability checks.
  * No user-facing changes; functionality remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->