### PR TITLE
Update API & toolchain-common (to check removal of che config)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -174,3 +174,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20250924125641-c3fceab9da63
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250923073415-a1ecb04daf74

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,6 @@ github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtM
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/codeready-toolchain/api v0.0.0-20250916082953-4ecb3a4645e6 h1:3Z1nQ7CjBCphWyGkEUCSMrd4VfuxzOVYyEi9/7FjLPs=
-github.com/codeready-toolchain/api v0.0.0-20250916082953-4ecb3a4645e6/go.mod h1:TiQ/yNv3cGL4nxo3fgRtcHyYYuRf+nAgs6B1IAqvxOU=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250916085517-b50328535b99 h1:SsnXrGSvi7wMPbYmfXSWi5MCDLCsNovImaR5dahkX/k=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250916085517-b50328535b99/go.mod h1:okjVzS+73Z1nOjq0IUP1db0y2SY1fDq/nb3/t7zJLlE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -72,6 +68,10 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
+github.com/fbm3307/toolchain-common v0.0.0-20250923073415-a1ecb04daf74 h1:jG0jCum+M4P9ykAcKhC/kpSmDsb8nmHP0r/WBk3MlSw=
+github.com/fbm3307/toolchain-common v0.0.0-20250923073415-a1ecb04daf74/go.mod h1:eySMK8JR/Py9eoUJlAkOXqvfPp1vjl39scgrECr99XM=
+github.com/fbm3307/toolchainapi v0.0.0-20250924125641-c3fceab9da63 h1:8RpBze7D8bfXXvrTZ1k68OzNRnxVMa8w53/qMFghMw8=
+github.com/fbm3307/toolchainapi v0.0.0-20250924125641-c3fceab9da63/go.mod h1:TiQ/yNv3cGL4nxo3fgRtcHyYYuRf+nAgs6B1IAqvxOU=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=


### PR DESCRIPTION
The verify dependencies test case was failing for the PR to remove `che` related code from api and toolchain-common . 
This PR is updating the go dependencies for api and toolchain-common to make sure we are not breaking anything before we merge the api and tc PRs

Related PRs:
- API : https://github.com/codeready-toolchain/api/pull/488
- Toolchain-Common: https://github.com/codeready-toolchain/toolchain-common/pull/495

Similar PRs: 
- Member-Operator:  
- Host-Operator: 
- Toolchain-E2e: 