### PR TITLE
SANDBOX-1769 | feature: expose "disabled integrations" in the UIConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.24.13
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20260305144813-52d9242e8c74
+	github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20260416204807-1fd670b5f220
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -50,10 +50,10 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
-github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174 h1:hed3ZyardxswS6yMB0ME9l3vEkO+pFouyk4dvIiAQOo=
-github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260305144813-52d9242e8c74 h1:yxKX0m6Kk1AIWwaGpf25flTfTrYrEJ9TyLW5NEQSq0Y=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260305144813-52d9242e8c74/go.mod h1:NEnnq2R5GYoWdN0b0iaSdX7L1ndrzxl3ML0m7XLsSqk=
+github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6 h1:d4DTT/6zhDFTN9rlCggsz/PLZGUCRccbSATcDmdTjzI=
+github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260416204807-1fd670b5f220 h1:A/UBvfcZ7lsM9+7i9nb0zxUykpaUBOdFX4Jf1+RFXkg=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260416204807-1fd670b5f220/go.mod h1:/cQ7VFb2eU3CXHqAPODQUeJjUpRSbSHMNJU8X/9NJSA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -140,6 +140,15 @@ func (r RegistrationServiceConfig) WorkatoWebHookURL() string {
 	return commonconfig.GetString(r.cfg.Host.RegistrationService.WorkatoWebHookURL, "")
 }
 
+func (r RegistrationServiceConfig) DisabledIntegrations() []string {
+	disabledIntegrations := r.cfg.Host.RegistrationService.DisabledIntegrations
+
+	if disabledIntegrations == nil {
+		return []string{}
+	}
+	return disabledIntegrations
+}
+
 type AnalyticsConfig struct {
 	c toolchainv1alpha1.RegistrationServiceAnalyticsConfig
 }

--- a/pkg/controller/uiconfig.go
+++ b/pkg/controller/uiconfig.go
@@ -13,6 +13,8 @@ type UIConfigResponse struct {
 	UICanaryDeploymentWeight int `json:"uiCanaryDeploymentWeight"`
 
 	WorkatoWebHookURL string `json:"workatoWebHookURL"`
+
+	DisabledIntegrations []string `json:"disabledIntegrations"`
 }
 
 // UIConfig implements the ui config endpoint, which is invoked to
@@ -31,6 +33,7 @@ func (uic *UIConfig) GetHandler(ctx *gin.Context) {
 	configRespData := UIConfigResponse{
 		UICanaryDeploymentWeight: cfg.UICanaryDeploymentWeight(),
 		WorkatoWebHookURL:        cfg.WorkatoWebHookURL(),
+		DisabledIntegrations:     cfg.DisabledIntegrations(),
 	}
 	ctx.JSON(http.StatusOK, configRespData)
 }

--- a/pkg/controller/uiconfig_test.go
+++ b/pkg/controller/uiconfig_test.go
@@ -68,5 +68,38 @@ func (s *TestUIConfigSuite) TestUIConfigHandler() {
 		s.Run("workatoWebHookURL", func() {
 			assert.Equal(s.T(), cfg.WorkatoWebHookURL(), data.WorkatoWebHookURL, "wrong 'WorkatoWebHookURL' in uiconfig response")
 		})
+
+		s.Run("disabledIntegrations defaults to empty array", func() {
+			assert.Equal(s.T(), []string{}, data.DisabledIntegrations, "disabledIntegrations should be an empty array when not configured")
+		})
 	})
+}
+
+func (s *TestUIConfigSuite) TestUIConfigHandlerWithDisabledIntegrations() {
+	req, err := http.NewRequest(http.MethodGet, "/api/v1/uiconfig", nil)
+	require.NoError(s.T(), err)
+
+	integrations := []string{"openshift", "devspaces"}
+	s.OverrideApplicationDefault(testconfig.RegistrationService().
+		RegistrationServiceURL("https://signup.domain.com").
+		DisabledIntegrations(integrations),
+	)
+	defer s.DefaultConfig()
+
+	uiConfigCtrl := NewUIConfig()
+	handler := gin.HandlerFunc(uiConfigCtrl.GetHandler)
+
+	rr := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rr)
+	ctx.Request = req
+
+	handler(ctx)
+
+	require.Equal(s.T(), http.StatusOK, rr.Code)
+
+	var data *UIConfigResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &data)
+	require.NoError(s.T(), err)
+
+	assert.Equal(s.T(), integrations, data.DisabledIntegrations, "disabledIntegrations should match configured values")
 }


### PR DESCRIPTION
In order for the UI to be able to consume the field, the registration service needs to expose it via the REST API.

## Related PRs

- https://github.com/codeready-toolchain/api/pull/502
  - https://github.com/codeready-toolchain/api/pull/503 (this one)
- https://github.com/codeready-toolchain/toolchain-common/pull/524
- https://github.com/codeready-toolchain/host-operator/pull/1255
- https://github.com/codeready-toolchain/host-operator/pull/1256
- https://github.com/codeready-toolchain/registration-service/pull/590

## Jira ticket
[[SANDBOX-1769]](https://redhat.atlassian.net/browse/SANDBOX-1769)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API configuration endpoint now exposes a disabled integrations list in its response (clients receive an empty list when none are configured).
* **Tests**
  * Added/updated tests to verify the disabled integrations field defaults to an empty list and reflects configured values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->