### PR TITLE
feat: call account verifier when url is configured

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.13
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6
+	github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20260416204807-1fd670b5f220
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible
@@ -176,3 +176,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/codeready-toolchain/toolchain-common => ../toolchain-common

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.13
 require (
 	github.com/aws/aws-sdk-go v1.44.100
 	github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20260416204807-1fd670b5f220
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20260504133316-5fab46be70c1
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -176,5 +176,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/codeready-toolchain/toolchain-common => ../toolchain-common

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/T
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564 h1:RDdUR0OXjERY3yr0F9S5z2m99Nh6Ccfr+zcA6OXfjJQ=
 github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260504133316-5fab46be70c1 h1:+/VQDNw0OAJ9YqfuDMNWDV1Z6Ff+iCJqjbg349KYBws=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260504133316-5fab46be70c1/go.mod h1:oW0GW/5ztCbCE/hlpEwO+dvV+CsPiMje5oYhg+Nszd8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -50,10 +50,8 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
-github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6 h1:d4DTT/6zhDFTN9rlCggsz/PLZGUCRccbSATcDmdTjzI=
-github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260416204807-1fd670b5f220 h1:A/UBvfcZ7lsM9+7i9nb0zxUykpaUBOdFX4Jf1+RFXkg=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260416204807-1fd670b5f220/go.mod h1:/cQ7VFb2eU3CXHqAPODQUeJjUpRSbSHMNJU8X/9NJSA=
+github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564 h1:RDdUR0OXjERY3yr0F9S5z2m99Nh6Ccfr+zcA6OXfjJQ=
+github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -140,6 +140,10 @@ func (r RegistrationServiceConfig) WorkatoWebHookURL() string {
 	return commonconfig.GetString(r.cfg.Host.RegistrationService.WorkatoWebHookURL, "")
 }
 
+func (r RegistrationServiceConfig) AccountVerifierURL() string {
+	return commonconfig.GetString(r.cfg.Host.RegistrationService.AccountVerifierURL, "")
+}
+
 func (r RegistrationServiceConfig) DisabledIntegrations() []string {
 	disabledIntegrations := r.cfg.Host.RegistrationService.DisabledIntegrations
 

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -70,6 +70,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.True(t, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
+		assert.Empty(t, regServiceCfg.AccountVerifierURL())
 	})
 	t.Run("non-default", func(t *testing.T) {
 		// given
@@ -106,6 +107,9 @@ func TestRegistrationService(t *testing.T) {
 			AWSAccessKeyID("aws.accesskeyid").
 			AWSSecretAccessKey("aws.secretaccesskey").
 			RecaptchaServiceAccountFile("captcha.json"))
+
+		verifierURL := "https://verifier.example.com"
+		cfg.Spec.Host.RegistrationService.AccountVerifierURL = &verifierURL
 
 		verificationSecretValues := make(map[string]string)
 		verificationSecretValues["twilio.sid"] = "def"
@@ -154,6 +158,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.False(t, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Equal(t, "example-content", regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
+		assert.Equal(t, "https://verifier.example.com", regServiceCfg.AccountVerifierURL())
 	})
 }
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -258,16 +258,17 @@ type accountVerifierReason struct {
 	Detail string `json:"detail"`
 }
 
+var accountVerifierHTTPClient = &http.Client{Timeout: 3 * time.Second}
+
 // callAccountVerifier calls the account verifier service to check the user's email domain.
 // For now this is used only for monitoring — the result is logged but not acted upon.
-func callAccountVerifier(verifierURL, email string) error {
+func callAccountVerifier(ctx *gin.Context, verifierURL, email string) error {
 	reqBody, err := json.Marshal(accountVerifierRequest{Email: email})
 	if err != nil {
 		return errs.Wrap(err, "failed to marshal account verifier request")
 	}
 
-	httpClient := &http.Client{Timeout: 3 * time.Second}
-	resp, err := httpClient.Post(verifierURL+"/verify-account", "application/json", bytes.NewReader(reqBody))
+	resp, err := accountVerifierHTTPClient.Post(verifierURL+"/verify-account", "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return errs.Wrapf(err, "failed to call account verifier for email %s", email)
 	}
@@ -287,7 +288,8 @@ func callAccountVerifier(verifierURL, email string) error {
 		return errs.Wrapf(err, "failed to unmarshal account verifier response for email %s", email)
 	}
 
-	log.Info(nil, fmt.Sprintf("account verifier result for %s: %s", email, verifierResp.Result))
+	log.Info(ctx, fmt.Sprintf("account verifier result for %s: result=%s, reasons=%v, error=%s",
+		email, verifierResp.Result, verifierResp.Reasons, verifierResp.Error))
 	return nil
 }
 
@@ -301,8 +303,8 @@ func (s *ServiceImpl) verifyAccount(ctx *gin.Context) {
 	if email == "" {
 		return
 	}
-	if err := callAccountVerifier(verifierURL, email); err != nil {
-		log.Error(nil, err, "account verifier call failed")
+	if err := callAccountVerifier(ctx, verifierURL, email); err != nil {
+		log.Error(ctx, err, "account verifier call failed")
 	}
 }
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -266,7 +266,7 @@ func callAccountVerifier(verifierURL, email string) error {
 		return errs.Wrap(err, "failed to marshal account verifier request")
 	}
 
-	httpClient := &http.Client{Timeout: 10 * time.Second}
+	httpClient := &http.Client{Timeout: 3 * time.Second}
 	resp, err := httpClient.Post(verifierURL+"/verify-account", "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return errs.Wrapf(err, "failed to call account verifier for email %s", email)

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -1,8 +1,12 @@
 package service
 
 import (
+	"bytes"
 	gocontext "context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"regexp"
 	"sort"
 	"strings"
@@ -239,6 +243,69 @@ func extractEmailHost(email string) string {
 	return email[i+1:]
 }
 
+type accountVerifierRequest struct {
+	Email string `json:"email"`
+}
+
+type accountVerifierResponse struct {
+	Result  string                  `json:"result"`
+	Reasons []accountVerifierReason `json:"reasons"`
+	Error   string                  `json:"error"`
+}
+
+type accountVerifierReason struct {
+	Check  string `json:"check"`
+	Detail string `json:"detail"`
+}
+
+func callAccountVerifier(verifierURL, email string) {
+	reqBody, err := json.Marshal(accountVerifierRequest{Email: email})
+	if err != nil {
+		log.Error(nil, err, "failed to marshal account verifier request")
+		return
+	}
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Post(verifierURL+"/verify-account", "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		log.Error(nil, err, fmt.Sprintf("failed to call account verifier for email %s", email))
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(nil, err, fmt.Sprintf("failed to read account verifier response for email %s", email))
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.Info(nil, fmt.Sprintf("account verifier returned status %d for email %s: %s", resp.StatusCode, email, string(respBody)))
+		return
+	}
+
+	var verifierResp accountVerifierResponse
+	if err := json.Unmarshal(respBody, &verifierResp); err != nil {
+		log.Error(nil, err, fmt.Sprintf("failed to unmarshal account verifier response for email %s", email))
+		return
+	}
+
+	log.Info(nil, fmt.Sprintf("account verifier result for %s: %s", email, verifierResp.Result))
+}
+
+func (s *ServiceImpl) verifyAccount(ctx *gin.Context) {
+	cfg := configuration.GetRegistrationServiceConfig()
+	verifierURL := cfg.AccountVerifierURL()
+	if verifierURL == "" {
+		return
+	}
+	email := ctx.GetString(context.EmailKey)
+	if email == "" {
+		return
+	}
+	callAccountVerifier(verifierURL, email)
+}
+
 // Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username
 // if doesn't exist yet.
 func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
@@ -251,6 +318,7 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 		if apierrors.IsNotFound(err) {
 			// New Signup
 			log.WithValues(map[string]interface{}{"encoded_username": encodedUsername}).Info(ctx, "user not found, creating a new one")
+			s.verifyAccount(ctx)
 			return s.createUserSignup(ctx)
 		}
 		return nil, err
@@ -260,6 +328,7 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 	signupCondition, found := condition.FindConditionByType(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupComplete)
 	if found && signupCondition.Status == apiv1.ConditionTrue && signupCondition.Reason == toolchainv1alpha1.UserSignupUserDeactivatedReason {
 		// Signup is deactivated. We need to reactivate it
+		s.verifyAccount(ctx)
 		return s.reactivateUserSignup(ctx, userSignup)
 	}
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -258,39 +258,37 @@ type accountVerifierReason struct {
 	Detail string `json:"detail"`
 }
 
-func callAccountVerifier(verifierURL, email string) {
+// callAccountVerifier calls the account verifier service to check the user's email domain.
+// For now this is used only for monitoring — the result is logged but not acted upon.
+func callAccountVerifier(verifierURL, email string) error {
 	reqBody, err := json.Marshal(accountVerifierRequest{Email: email})
 	if err != nil {
-		log.Error(nil, err, "failed to marshal account verifier request")
-		return
+		return errs.Wrap(err, "failed to marshal account verifier request")
 	}
 
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 	resp, err := httpClient.Post(verifierURL+"/verify-account", "application/json", bytes.NewReader(reqBody))
 	if err != nil {
-		log.Error(nil, err, fmt.Sprintf("failed to call account verifier for email %s", email))
-		return
+		return errs.Wrapf(err, "failed to call account verifier for email %s", email)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Error(nil, err, fmt.Sprintf("failed to read account verifier response for email %s", email))
-		return
+		return errs.Wrapf(err, "failed to read account verifier response for email %s", email)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		log.Info(nil, fmt.Sprintf("account verifier returned status %d for email %s: %s", resp.StatusCode, email, string(respBody)))
-		return
+		return fmt.Errorf("account verifier returned status %d for email %s: %s", resp.StatusCode, email, string(respBody))
 	}
 
 	var verifierResp accountVerifierResponse
 	if err := json.Unmarshal(respBody, &verifierResp); err != nil {
-		log.Error(nil, err, fmt.Sprintf("failed to unmarshal account verifier response for email %s", email))
-		return
+		return errs.Wrapf(err, "failed to unmarshal account verifier response for email %s", email)
 	}
 
 	log.Info(nil, fmt.Sprintf("account verifier result for %s: %s", email, verifierResp.Result))
+	return nil
 }
 
 func (s *ServiceImpl) verifyAccount(ctx *gin.Context) {
@@ -303,7 +301,9 @@ func (s *ServiceImpl) verifyAccount(ctx *gin.Context) {
 	if email == "" {
 		return
 	}
-	callAccountVerifier(verifierURL, email)
+	if err := callAccountVerifier(verifierURL, email); err != nil {
+		log.Error(nil, err, "account verifier call failed")
+	}
 }
 
 // Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"bytes"
 	gocontext "context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/crc32"
@@ -1404,6 +1405,94 @@ func (s *TestSignupServiceSuite) newSpaceBinding(murName, spaceName string) *too
 	require.NoError(s.T(), err)
 
 	return fake.NewSpaceBinding(name.String(), murName, spaceName, "admin")
+}
+
+func (s *TestSignupServiceSuite) TestSignupCallsAccountVerifier() {
+	s.Run("calls account verifier when URL is configured", func() {
+		// given
+		var receivedEmail string
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(s.T(), http.MethodPost, r.Method)
+			require.Equal(s.T(), "/verify-account", r.URL.Path)
+
+			var reqBody map[string]string
+			err := json.NewDecoder(r.Body).Decode(&reqBody)
+			require.NoError(s.T(), err)
+			receivedEmail = reqBody["email"]
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"result":"approved","reasons":[],"error":""}`))
+		}))
+		defer verifierServer.Close()
+
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().
+				AccountVerifierURL(verifierServer.URL).
+				Verification().Enabled(true).
+				Verification().CodeExpiresInMin(5))
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "verifier-test@kubesaw")
+		ctx.Set(context.SubKey, "987654321")
+		ctx.Set(context.OriginalSubKey, "original-sub-value")
+		ctx.Set(context.EmailKey, "verifier-test@gmail.com")
+		ctx.Set(context.GivenNameKey, "jane")
+		ctx.Set(context.FamilyNameKey, "doe")
+		ctx.Set(context.CompanyKey, "red hat")
+		ctx.Set(context.UserIDKey, "13349822")
+		ctx.Set(context.AccountIDKey, "45983711")
+		ctx.Set(context.AccountNumberKey, "123456789")
+		ctx.Set(context.RequestReceivedTime, time.Now())
+
+		_, application := testutil.PrepareInClusterApp(s.T())
+
+		// when
+		_, err := application.SignupService().Signup(ctx)
+
+		// then
+		require.NoError(s.T(), err)
+		assert.Equal(s.T(), "verifier-test@gmail.com", receivedEmail)
+	})
+
+	s.Run("does not call account verifier when URL is not configured", func() {
+		// given
+		verifierCalled := false
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			verifierCalled = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer verifierServer.Close()
+
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().
+				Verification().Enabled(true).
+				Verification().CodeExpiresInMin(5))
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "no-verifier@kubesaw")
+		ctx.Set(context.SubKey, "987654321")
+		ctx.Set(context.OriginalSubKey, "original-sub-value")
+		ctx.Set(context.EmailKey, "no-verifier@gmail.com")
+		ctx.Set(context.GivenNameKey, "jane")
+		ctx.Set(context.FamilyNameKey, "doe")
+		ctx.Set(context.CompanyKey, "red hat")
+		ctx.Set(context.UserIDKey, "13349822")
+		ctx.Set(context.AccountIDKey, "45983711")
+		ctx.Set(context.AccountNumberKey, "123456789")
+		ctx.Set(context.RequestReceivedTime, time.Now())
+
+		_, application := testutil.PrepareInClusterApp(s.T())
+
+		// when
+		_, err := application.SignupService().Signup(ctx)
+
+		// then
+		require.NoError(s.T(), err)
+		assert.False(s.T(), verifierCalled)
+	})
 }
 
 type FakeCaptchaChecker struct {

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -1412,13 +1412,13 @@ func (s *TestSignupServiceSuite) TestSignupCallsAccountVerifier() {
 		// given
 		var receivedEmail string
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(s.T(), http.MethodPost, r.Method)
-			require.Equal(s.T(), "/verify-account", r.URL.Path)
+			assert.Equal(s.T(), http.MethodPost, r.Method)
+			assert.Equal(s.T(), "/verify-account", r.URL.Path)
 
 			var reqBody map[string]string
-			err := json.NewDecoder(r.Body).Decode(&reqBody)
-			require.NoError(s.T(), err)
-			receivedEmail = reqBody["email"]
+			if err := json.NewDecoder(r.Body).Decode(&reqBody); assert.NoError(s.T(), err) {
+				receivedEmail = reqBody["email"]
+			}
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -1459,7 +1459,7 @@ func (s *TestSignupServiceSuite) TestSignupCallsAccountVerifier() {
 	s.Run("does not call account verifier when URL is not configured", func() {
 		// given
 		verifierCalled := false
-		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			verifierCalled = true
 			w.WriteHeader(http.StatusOK)
 		}))


### PR DESCRIPTION
For now let's only log the account verifier response.

Jira: https://redhat.atlassian.net/browse/SANDBOX-1824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional account verification during signup and reactivation: when configured, user emails are POSTed to an external verifier before completing account operations.

* **Tests**
  * Added tests validating verifier integration and behavior when the verifier is enabled or disabled.

* **Chores**
  * Updated internal dependency versions.

* **Configuration**
  * New configurable AccountVerifierURL (defaults to empty).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->