### PR TITLE
feat: signup service acts based on the response from account verifier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.24.13
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20260521064641-bbb0ba885e7c
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20260521063813-9fd33e839ee7
+	github.com/codeready-toolchain/api v0.0.0-20260529071923-8f3b54022740
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20260529075345-a459d007c226
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -175,4 +175,9 @@ require (
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
+)
+
+replace (
+	github.com/codeready-toolchain/api => ../api
+	github.com/codeready-toolchain/toolchain-common => ../toolchain-common
 )

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.24.13
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20260504133316-5fab46be70c1
+	github.com/codeready-toolchain/api v0.0.0-20260521064641-bbb0ba885e7c
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20260521063813-9fd33e839ee7
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.13
 require (
 	github.com/aws/aws-sdk-go v1.44.100
 	github.com/codeready-toolchain/api v0.0.0-20260603082246-cfa3dd9db9cc
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20260529075345-a459d007c226
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20260603091009-6db0c02f4506
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -175,9 +175,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
-)
-
-replace (
-	github.com/codeready-toolchain/api => ../api
-	github.com/codeready-toolchain/toolchain-common => ../toolchain-common
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.13
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20260529071923-8f3b54022740
+	github.com/codeready-toolchain/api v0.0.0-20260603082246-cfa3dd9db9cc
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20260529075345-a459d007c226
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -50,10 +50,6 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
-github.com/codeready-toolchain/api v0.0.0-20260521064641-bbb0ba885e7c h1:/DjXBFRmRT1gAM/bTOs/UZ8VwRCYN+wiau5+OTUvlcg=
-github.com/codeready-toolchain/api v0.0.0-20260521064641-bbb0ba885e7c/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260521063813-9fd33e839ee7 h1:YGSQ7dh61qWXO4WOAxpB67UtFRd/HO6cGj0LG94Mc4s=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260521063813-9fd33e839ee7/go.mod h1:Sd9NIEwugkM4OB2k4D2iBnu3pSCYMUsmPxg1wT7BO/Q=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -50,10 +50,10 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
-github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564 h1:RDdUR0OXjERY3yr0F9S5z2m99Nh6Ccfr+zcA6OXfjJQ=
-github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260504133316-5fab46be70c1 h1:+/VQDNw0OAJ9YqfuDMNWDV1Z6Ff+iCJqjbg349KYBws=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260504133316-5fab46be70c1/go.mod h1:oW0GW/5ztCbCE/hlpEwO+dvV+CsPiMje5oYhg+Nszd8=
+github.com/codeready-toolchain/api v0.0.0-20260521064641-bbb0ba885e7c h1:/DjXBFRmRT1gAM/bTOs/UZ8VwRCYN+wiau5+OTUvlcg=
+github.com/codeready-toolchain/api v0.0.0-20260521064641-bbb0ba885e7c/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260521063813-9fd33e839ee7 h1:YGSQ7dh61qWXO4WOAxpB67UtFRd/HO6cGj0LG94Mc4s=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260521063813-9fd33e839ee7/go.mod h1:Sd9NIEwugkM4OB2k4D2iBnu3pSCYMUsmPxg1wT7BO/Q=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,10 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
+github.com/codeready-toolchain/api v0.0.0-20260603082246-cfa3dd9db9cc h1:Xwt43SDrCQ3cxwetRijdFrDwRp1yoam6j+36HazNivg=
+github.com/codeready-toolchain/api v0.0.0-20260603082246-cfa3dd9db9cc/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260603091009-6db0c02f4506 h1:FYOvK015wTBSh9J+T/yr4zjcVMpT1eKL1D/oS8yF1Lk=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260603091009-6db0c02f4506/go.mod h1:V3Ah7YRoTIHkU0G4Ynvj/6AVgOH3Ss0fw/B/Gurr3AA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -144,8 +144,8 @@ func (r RegistrationServiceConfig) AccountVerifierURL() string {
 	return commonconfig.GetString(r.cfg.Host.RegistrationService.AccountVerifierURL, "")
 }
 
-func (r RegistrationServiceConfig) AccountVerifierEnabled() bool {
-	return commonconfig.GetBool(r.cfg.Host.RegistrationService.AccountVerifierEnabled, false)
+func (r RegistrationServiceConfig) AccountVerifierMode() string {
+	return commonconfig.GetString(r.cfg.Host.RegistrationService.AccountVerifierMode, "log")
 }
 
 func (r RegistrationServiceConfig) DisabledIntegrations() []string {

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -144,6 +144,10 @@ func (r RegistrationServiceConfig) AccountVerifierURL() string {
 	return commonconfig.GetString(r.cfg.Host.RegistrationService.AccountVerifierURL, "")
 }
 
+func (r RegistrationServiceConfig) AccountVerifierEnabled() bool {
+	return commonconfig.GetBool(r.cfg.Host.RegistrationService.AccountVerifierEnabled, false)
+}
+
 func (r RegistrationServiceConfig) DisabledIntegrations() []string {
 	disabledIntegrations := r.cfg.Host.RegistrationService.DisabledIntegrations
 

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -71,7 +71,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.Empty(t, regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Empty(t, regServiceCfg.AccountVerifierURL())
-		assert.False(t, regServiceCfg.AccountVerifierEnabled())
+		assert.Equal(t, "log", regServiceCfg.AccountVerifierMode())
 	})
 	t.Run("non-default", func(t *testing.T) {
 		// given
@@ -80,7 +80,7 @@ func TestRegistrationService(t *testing.T) {
 			LogLevel("debug").
 			RegistrationServiceURL("www.crtregservice.com").
 			AccountVerifierURL("https://verifier.example.com").
-			AccountVerifierEnabled(true).
+			AccountVerifierMode("enabled").
 			Analytics().SegmentWriteKey("keyabc").
 			Auth().AuthClientLibraryURL("https://sso.openshift.com/auth/js/keycloak.js").
 			Auth().AuthClientConfigContentType("application/xml").
@@ -159,7 +159,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.Equal(t, "example-content", regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Equal(t, "https://verifier.example.com", regServiceCfg.AccountVerifierURL())
-		assert.True(t, regServiceCfg.AccountVerifierEnabled())
+		assert.Equal(t, "enabled", regServiceCfg.AccountVerifierMode())
 	})
 }
 

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -79,6 +79,8 @@ func TestRegistrationService(t *testing.T) {
 			Environment("e2e-tests").
 			LogLevel("debug").
 			RegistrationServiceURL("www.crtregservice.com").
+			AccountVerifierURL("https://verifier.example.com").
+			AccountVerifierEnabled(true).
 			Analytics().SegmentWriteKey("keyabc").
 			Auth().AuthClientLibraryURL("https://sso.openshift.com/auth/js/keycloak.js").
 			Auth().AuthClientConfigContentType("application/xml").
@@ -108,11 +110,6 @@ func TestRegistrationService(t *testing.T) {
 			AWSAccessKeyID("aws.accesskeyid").
 			AWSSecretAccessKey("aws.secretaccesskey").
 			RecaptchaServiceAccountFile("captcha.json"))
-
-		verifierURL := "https://verifier.example.com"
-		cfg.Spec.Host.RegistrationService.AccountVerifierURL = &verifierURL
-		accountVerifierEnabled := true
-		cfg.Spec.Host.RegistrationService.AccountVerifierEnabled = &accountVerifierEnabled
 
 		verificationSecretValues := make(map[string]string)
 		verificationSecretValues["twilio.sid"] = "def"

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -71,6 +71,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.Empty(t, regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Empty(t, regServiceCfg.AccountVerifierURL())
+		assert.False(t, regServiceCfg.AccountVerifierEnabled())
 	})
 	t.Run("non-default", func(t *testing.T) {
 		// given
@@ -110,6 +111,8 @@ func TestRegistrationService(t *testing.T) {
 
 		verifierURL := "https://verifier.example.com"
 		cfg.Spec.Host.RegistrationService.AccountVerifierURL = &verifierURL
+		accountVerifierEnabled := true
+		cfg.Spec.Host.RegistrationService.AccountVerifierEnabled = &accountVerifierEnabled
 
 		verificationSecretValues := make(map[string]string)
 		verificationSecretValues["twilio.sid"] = "def"
@@ -159,6 +162,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.Equal(t, "example-content", regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Equal(t, "https://verifier.example.com", regServiceCfg.AccountVerifierURL())
+		assert.True(t, regServiceCfg.AccountVerifierEnabled())
 	})
 }
 

--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -33,4 +33,6 @@ const (
 	ImpersonateUser = "impersonateUser"
 	// SocialEvent is the context key for the activation code provided in UI
 	SocialEvent = "socialEvent"
+	// AccountVerifierResult is the context key for the account verifier response
+	AccountVerifierResult = "accountVerifierResult"
 )

--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -33,6 +33,4 @@ const (
 	ImpersonateUser = "impersonateUser"
 	// SocialEvent is the context key for the activation code provided in UI
 	SocialEvent = "socialEvent"
-	// AccountVerifierResult is the context key for the account verifier response
-	AccountVerifierResult = "accountVerifierResult"
 )

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -154,6 +154,9 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context, accountVerifierResp *accou
 		if accountVerifierResp.Result == accountVerifierResultPhoneVerification {
 			states.SetVerificationRequired(userSignup, true)
 		}
+		if accountVerifierResp.Result == accountVerifierResultReject {
+			states.SetRejected(userSignup, true)
+		}
 	}
 
 	// set the skip-auto-create-space annotation to true if the no-space query parameter was set to true
@@ -354,26 +357,42 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 	userSignup := &toolchainv1alpha1.UserSignup{}
 	if err := s.Get(ctx, s.NamespacedName(encodedUsername), userSignup); err != nil {
 		if apierrors.IsNotFound(err) {
-			// New Signup
+			// New Signup — always create the UserSignup so that a rejected user is recorded in K8s
+			// (enables metrics and prevents repeated verifier calls on retries).
 			log.WithValues(map[string]interface{}{"encoded_username": encodedUsername}).Info(ctx, "user not found, creating a new one")
 			accountVerifierResp := s.verifyAccount(ctx)
+			userSignup, err := s.createUserSignup(ctx, accountVerifierResp)
+			if err != nil {
+				return nil, err
+			}
 			if isAccountVerifierRejected(accountVerifierResp) {
 				return nil, ForbiddenBannedError
 			}
-			return s.createUserSignup(ctx, accountVerifierResp)
+			return userSignup, nil
 		}
 		return nil, err
+	}
+
+	// If the existing UserSignup was rejected by the account verifier, block the user immediately
+	// without calling the verifier again.
+	if states.Rejected(userSignup) {
+		return nil, ForbiddenBannedError
 	}
 
 	// Check UserSignup status to determine whether user signup is deactivated
 	signupCondition, found := condition.FindConditionByType(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupComplete)
 	if found && signupCondition.Status == apiv1.ConditionTrue && signupCondition.Reason == toolchainv1alpha1.UserSignupUserDeactivatedReason {
-		// Signup is deactivated. We need to reactivate it
+		// Signup is deactivated. We need to reactivate it — always update the UserSignup so
+		// that a rejected reactivation is also recorded.
 		accountVerifierResp := s.verifyAccount(ctx)
+		userSignup, err := s.reactivateUserSignup(ctx, userSignup, accountVerifierResp)
+		if err != nil {
+			return nil, err
+		}
 		if isAccountVerifierRejected(accountVerifierResp) {
 			return nil, ForbiddenBannedError
 		}
-		return s.reactivateUserSignup(ctx, userSignup, accountVerifierResp)
+		return userSignup, nil
 	}
 
 	return nil, apierrors.NewConflict(schema.GroupResource{}, "", fmt.Errorf(
@@ -512,7 +531,9 @@ func (s *ServiceImpl) DoGetSignup(ctx *gin.Context, cl namespaced.Client, userna
 		return nil, nil
 	} else if completeCondition.Reason == toolchainv1alpha1.UserSignupUserBannedReason {
 		log.Info(nil, fmt.Sprintf("usersignup: %s is banned", userSignup.GetName()))
-		// UserSignup is banned, let's return a forbidden error
+		return nil, ForbiddenBannedError
+	} else if completeCondition.Reason == toolchainv1alpha1.UserSignupUserRejectedReason {
+		log.Info(nil, fmt.Sprintf("usersignup: %s is rejected by account verifier", userSignup.GetName()))
 		return nil, ForbiddenBannedError
 	}
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -40,6 +40,9 @@ const (
 var ForbiddenBannedError = apierrors.NewForbidden(schema.GroupResource{}, "",
 	errs.New("Access to the Developer Sandbox has been suspended due to suspicious activity or detected abuse."))
 
+var ForbiddenRejectedError = apierrors.NewForbidden(schema.GroupResource{}, "",
+	errs.New("Access to the Developer Sandbox has been denied."))
+
 var annotationsToRetain = []string{
 	toolchainv1alpha1.UserSignupActivationCounterAnnotationKey,
 	toolchainv1alpha1.UserSignupLastTargetClusterAnnotationKey,
@@ -366,7 +369,7 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 				return nil, err
 			}
 			if isAccountVerifierRejected(accountVerifierResp) {
-				return nil, ForbiddenBannedError
+				return nil, ForbiddenRejectedError
 			}
 			return userSignup, nil
 		}
@@ -376,7 +379,7 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 	// If the existing UserSignup was rejected by the account verifier, block the user immediately
 	// without calling the verifier again.
 	if states.Rejected(userSignup) {
-		return nil, ForbiddenBannedError
+		return nil, ForbiddenRejectedError
 	}
 
 	// Check UserSignup status to determine whether user signup is deactivated
@@ -390,7 +393,7 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 			return nil, err
 		}
 		if isAccountVerifierRejected(accountVerifierResp) {
-			return nil, ForbiddenBannedError
+			return nil, ForbiddenRejectedError
 		}
 		return userSignup, nil
 	}
@@ -534,7 +537,7 @@ func (s *ServiceImpl) DoGetSignup(ctx *gin.Context, cl namespaced.Client, userna
 		return nil, ForbiddenBannedError
 	} else if completeCondition.Reason == toolchainv1alpha1.UserSignupUserRejectedReason {
 		log.Info(nil, fmt.Sprintf("usersignup: %s is rejected by account verifier", userSignup.GetName()))
-		return nil, ForbiddenBannedError
+		return nil, ForbiddenRejectedError
 	}
 
 	if !userSignup.Status.ScheduledDeactivationTimestamp.IsZero() {

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -261,6 +261,10 @@ func extractEmailHost(email string) string {
 const (
 	accountVerifierResultReject            = "reject"
 	accountVerifierResultPhoneVerification = "phone-verification"
+
+	accountVerifierModeDisabled = "disabled"
+	accountVerifierModeLog      = "log"
+	accountVerifierModeEnabled  = "enabled"
 )
 
 type accountVerifierRequest struct {
@@ -313,6 +317,9 @@ func callAccountVerifier(ctx *gin.Context, verifierURL, email string) (*accountV
 
 func (s *ServiceImpl) verifyAccount(ctx *gin.Context) *accountVerifierResponse {
 	cfg := configuration.GetRegistrationServiceConfig()
+	if cfg.AccountVerifierMode() == accountVerifierModeDisabled {
+		return nil
+	}
 	verifierURL := cfg.AccountVerifierURL()
 	if verifierURL == "" {
 		return nil
@@ -326,9 +333,10 @@ func (s *ServiceImpl) verifyAccount(ctx *gin.Context) *accountVerifierResponse {
 		log.Error(ctx, err, "account verifier call failed")
 		return nil
 	}
-	if cfg.AccountVerifierEnabled() {
+	if cfg.AccountVerifierMode() == accountVerifierModeEnabled {
 		return resp
 	}
+	// log mode: callAccountVerifier already logged the response; discard it
 	return nil
 }
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -141,6 +141,23 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 
 	states.SetVerificationRequired(userSignup, verificationRequired)
 
+	if val, exists := ctx.Get(context.AccountVerifierResult); exists {
+		if resp, ok := val.(*accountVerifierResponse); ok {
+			userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey] = resp.Result
+			if len(resp.Reasons) > 0 {
+				reasonsJSON, err := json.Marshal(resp.Reasons)
+				if err == nil {
+					userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey] = string(reasonsJSON)
+				} else {
+					log.Error(ctx, err, "failed to marshal account verifier reasons")
+				}
+			}
+			if resp.Result == "phone-verification" {
+				states.SetVerificationRequired(userSignup, true)
+			}
+		}
+	}
+
 	// set the skip-auto-create-space annotation to true if the no-space query parameter was set to true
 	if param, _ := ctx.GetQuery(NoSpaceKey); param == "true" {
 		log.Info(ctx, fmt.Sprintf("setting '%s' annotation to true", toolchainv1alpha1.SkipAutoCreateSpaceAnnotationKey))
@@ -260,37 +277,35 @@ type accountVerifierReason struct {
 
 var accountVerifierHTTPClient = &http.Client{Timeout: 3 * time.Second}
 
-// callAccountVerifier calls the account verifier service to check the user's email domain.
-// For now this is used only for monitoring — the result is logged but not acted upon.
-func callAccountVerifier(ctx *gin.Context, verifierURL, email string) error {
+func callAccountVerifier(ctx *gin.Context, verifierURL, email string) (*accountVerifierResponse, error) {
 	reqBody, err := json.Marshal(accountVerifierRequest{Email: email})
 	if err != nil {
-		return errs.Wrap(err, "failed to marshal account verifier request")
+		return nil, errs.Wrap(err, "failed to marshal account verifier request")
 	}
 
 	resp, err := accountVerifierHTTPClient.Post(verifierURL+"/verify-account", "application/json", bytes.NewReader(reqBody))
 	if err != nil {
-		return errs.Wrapf(err, "failed to call account verifier for email %s", email)
+		return nil, errs.Wrapf(err, "failed to call account verifier for email %s", email)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return errs.Wrapf(err, "failed to read account verifier response for email %s", email)
+		return nil, errs.Wrapf(err, "failed to read account verifier response for email %s", email)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("account verifier returned status %d for email %s: %s", resp.StatusCode, email, string(respBody))
+		return nil, fmt.Errorf("account verifier returned status %d for email %s: %s", resp.StatusCode, email, string(respBody))
 	}
 
 	var verifierResp accountVerifierResponse
 	if err := json.Unmarshal(respBody, &verifierResp); err != nil {
-		return errs.Wrapf(err, "failed to unmarshal account verifier response for email %s", email)
+		return nil, errs.Wrapf(err, "failed to unmarshal account verifier response for email %s", email)
 	}
 
 	log.Info(ctx, fmt.Sprintf("account verifier result for %s: result=%s, reasons=%v, error=%s",
 		email, verifierResp.Result, verifierResp.Reasons, verifierResp.Error))
-	return nil
+	return &verifierResp, nil
 }
 
 func (s *ServiceImpl) verifyAccount(ctx *gin.Context) {
@@ -303,9 +318,23 @@ func (s *ServiceImpl) verifyAccount(ctx *gin.Context) {
 	if email == "" {
 		return
 	}
-	if err := callAccountVerifier(ctx, verifierURL, email); err != nil {
+	resp, err := callAccountVerifier(ctx, verifierURL, email)
+	if err != nil {
 		log.Error(ctx, err, "account verifier call failed")
+		return
 	}
+	if cfg.AccountVerifierEnabled() && resp != nil {
+		ctx.Set(context.AccountVerifierResult, resp)
+	}
+}
+
+func isAccountVerifierRejected(ctx *gin.Context) bool {
+	val, exists := ctx.Get(context.AccountVerifierResult)
+	if !exists {
+		return false
+	}
+	resp, ok := val.(*accountVerifierResponse)
+	return ok && resp.Result == "reject"
 }
 
 // Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username
@@ -321,6 +350,9 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 			// New Signup
 			log.WithValues(map[string]interface{}{"encoded_username": encodedUsername}).Info(ctx, "user not found, creating a new one")
 			s.verifyAccount(ctx)
+			if isAccountVerifierRejected(ctx) {
+				return nil, ForbiddenBannedError
+			}
 			return s.createUserSignup(ctx)
 		}
 		return nil, err
@@ -331,6 +363,9 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 	if found && signupCondition.Status == apiv1.ConditionTrue && signupCondition.Reason == toolchainv1alpha1.UserSignupUserDeactivatedReason {
 		// Signup is deactivated. We need to reactivate it
 		s.verifyAccount(ctx)
+		if isAccountVerifierRejected(ctx) {
+			return nil, ForbiddenBannedError
+		}
 		return s.reactivateUserSignup(ctx, userSignup)
 	}
 

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -63,7 +63,7 @@ func NewSignupService(client namespaced.Client) *ServiceImpl {
 
 // newUserSignup generates a new UserSignup resource with the specified username and available claims.
 // This resource then can be used to create a new UserSignup in the host cluster or to update the existing one.
-func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
+func (s *ServiceImpl) newUserSignup(ctx *gin.Context, accountVerifierResp *accountVerifierResponse) (*toolchainv1alpha1.UserSignup, error) {
 	username := ctx.GetString(context.UsernameKey)
 
 	userID := ctx.GetString(context.UserIDKey)
@@ -141,20 +141,18 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSi
 
 	states.SetVerificationRequired(userSignup, verificationRequired)
 
-	if val, exists := ctx.Get(context.AccountVerifierResult); exists {
-		if resp, ok := val.(*accountVerifierResponse); ok {
-			userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey] = resp.Result
-			if len(resp.Reasons) > 0 {
-				reasonsJSON, err := json.Marshal(resp.Reasons)
-				if err == nil {
-					userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey] = string(reasonsJSON)
-				} else {
-					log.Error(ctx, err, "failed to marshal account verifier reasons")
-				}
+	if accountVerifierResp != nil {
+		userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey] = accountVerifierResp.Result
+		if len(accountVerifierResp.Reasons) > 0 {
+			reasonsJSON, err := json.Marshal(accountVerifierResp.Reasons)
+			if err == nil {
+				userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey] = string(reasonsJSON)
+			} else {
+				log.Error(ctx, err, "failed to marshal account verifier reasons")
 			}
-			if resp.Result == "phone-verification" {
-				states.SetVerificationRequired(userSignup, true)
-			}
+		}
+		if accountVerifierResp.Result == accountVerifierResultPhoneVerification {
+			states.SetVerificationRequired(userSignup, true)
 		}
 	}
 
@@ -260,6 +258,11 @@ func extractEmailHost(email string) string {
 	return email[i+1:]
 }
 
+const (
+	accountVerifierResultReject            = "reject"
+	accountVerifierResultPhoneVerification = "phone-verification"
+)
+
 type accountVerifierRequest struct {
 	Email string `json:"email"`
 }
@@ -308,33 +311,29 @@ func callAccountVerifier(ctx *gin.Context, verifierURL, email string) (*accountV
 	return &verifierResp, nil
 }
 
-func (s *ServiceImpl) verifyAccount(ctx *gin.Context) {
+func (s *ServiceImpl) verifyAccount(ctx *gin.Context) *accountVerifierResponse {
 	cfg := configuration.GetRegistrationServiceConfig()
 	verifierURL := cfg.AccountVerifierURL()
 	if verifierURL == "" {
-		return
+		return nil
 	}
 	email := ctx.GetString(context.EmailKey)
 	if email == "" {
-		return
+		return nil
 	}
 	resp, err := callAccountVerifier(ctx, verifierURL, email)
 	if err != nil {
 		log.Error(ctx, err, "account verifier call failed")
-		return
+		return nil
 	}
-	if cfg.AccountVerifierEnabled() && resp != nil {
-		ctx.Set(context.AccountVerifierResult, resp)
+	if cfg.AccountVerifierEnabled() {
+		return resp
 	}
+	return nil
 }
 
-func isAccountVerifierRejected(ctx *gin.Context) bool {
-	val, exists := ctx.Get(context.AccountVerifierResult)
-	if !exists {
-		return false
-	}
-	resp, ok := val.(*accountVerifierResponse)
-	return ok && resp.Result == "reject"
+func isAccountVerifierRejected(resp *accountVerifierResponse) bool {
+	return resp != nil && resp.Result == accountVerifierResultReject
 }
 
 // Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username
@@ -349,11 +348,11 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 		if apierrors.IsNotFound(err) {
 			// New Signup
 			log.WithValues(map[string]interface{}{"encoded_username": encodedUsername}).Info(ctx, "user not found, creating a new one")
-			s.verifyAccount(ctx)
-			if isAccountVerifierRejected(ctx) {
+			accountVerifierResp := s.verifyAccount(ctx)
+			if isAccountVerifierRejected(accountVerifierResp) {
 				return nil, ForbiddenBannedError
 			}
-			return s.createUserSignup(ctx)
+			return s.createUserSignup(ctx, accountVerifierResp)
 		}
 		return nil, err
 	}
@@ -362,11 +361,11 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 	signupCondition, found := condition.FindConditionByType(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupComplete)
 	if found && signupCondition.Status == apiv1.ConditionTrue && signupCondition.Reason == toolchainv1alpha1.UserSignupUserDeactivatedReason {
 		// Signup is deactivated. We need to reactivate it
-		s.verifyAccount(ctx)
-		if isAccountVerifierRejected(ctx) {
+		accountVerifierResp := s.verifyAccount(ctx)
+		if isAccountVerifierRejected(accountVerifierResp) {
 			return nil, ForbiddenBannedError
 		}
-		return s.reactivateUserSignup(ctx, userSignup)
+		return s.reactivateUserSignup(ctx, userSignup, accountVerifierResp)
 	}
 
 	return nil, apierrors.NewConflict(schema.GroupResource{}, "", fmt.Errorf(
@@ -374,8 +373,8 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 }
 
 // createUserSignup creates a new UserSignup resource with the specified username
-func (s *ServiceImpl) createUserSignup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, error) {
-	userSignup, err := s.newUserSignup(ctx)
+func (s *ServiceImpl) createUserSignup(ctx *gin.Context, accountVerifierResp *accountVerifierResponse) (*toolchainv1alpha1.UserSignup, error) {
+	userSignup, err := s.newUserSignup(ctx, accountVerifierResp)
 	if err != nil {
 		return nil, err
 	}
@@ -384,11 +383,11 @@ func (s *ServiceImpl) createUserSignup(ctx *gin.Context) (*toolchainv1alpha1.Use
 }
 
 // reactivateUserSignup reactivates the deactivated UserSignup resource with the specified username
-func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing *toolchainv1alpha1.UserSignup) (*toolchainv1alpha1.UserSignup, error) {
+func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing *toolchainv1alpha1.UserSignup, accountVerifierResp *accountVerifierResponse) (*toolchainv1alpha1.UserSignup, error) {
 	// Update the existing usersignup's spec and annotations/labels by new values from a freshly generated one.
 	// We don't want to deal with merging/patching the usersignup resource
 	// and just want to reset the spec and annotations/labels so they are the same as in a freshly created usersignup resource.
-	newUserSignup, err := s.newUserSignup(ctx)
+	newUserSignup, err := s.newUserSignup(ctx, accountVerifierResp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type TestSignupServiceSuite struct {
@@ -1538,7 +1539,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		assert.JSONEq(s.T(), `[{"check":"check-1","detail":"passed"}]`, userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
 	})
 
-	s.Run("reject result returns forbidden error", func() {
+	s.Run("reject result creates rejected UserSignup and returns forbidden error", func() {
 		// given
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -1578,11 +1579,62 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		assert.Nil(s.T(), userSignup)
 		assert.Equal(s.T(), service.ForbiddenBannedError, err)
 
-		// verify no UserSignup was created
+		// verify UserSignup WAS created with rejected state and annotation
 		userSignups := &toolchainv1alpha1.UserSignupList{}
 		listErr := fakeClient.List(gocontext.TODO(), userSignups, client.InNamespace(commontest.HostOperatorNs))
 		require.NoError(s.T(), listErr)
-		assert.Empty(s.T(), userSignups.Items)
+		require.Len(s.T(), userSignups.Items, 1)
+		createdUS := userSignups.Items[0]
+		assert.True(s.T(), states.Rejected(&createdUS))
+		assert.Equal(s.T(), "reject", createdUS.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
+		assert.JSONEq(s.T(), `[{"check":"check-1","detail":"failed"}]`, createdUS.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
+	})
+
+	s.Run("repeat signup attempt on rejected UserSignup returns forbidden error without calling verifier", func() {
+		// given
+		verifierCalled := false
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			verifierCalled = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer verifierServer.Close()
+
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().
+				AccountVerifierURL(verifierServer.URL).
+				AccountVerifierMode("enabled").
+				Verification().Enabled(true).
+				Verification().CodeExpiresInMin(5))
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "rejected-repeat@kubesaw")
+		ctx.Set(context.SubKey, "987654321")
+		ctx.Set(context.OriginalSubKey, "original-sub-value")
+		ctx.Set(context.EmailKey, "rejected-repeat@disposable.com")
+		ctx.Set(context.GivenNameKey, "jane")
+		ctx.Set(context.FamilyNameKey, "doe")
+		ctx.Set(context.CompanyKey, "red hat")
+		ctx.Set(context.UserIDKey, "13349822")
+		ctx.Set(context.AccountIDKey, "45983711")
+		ctx.Set(context.AccountNumberKey, "123456789")
+		ctx.Set(context.RequestReceivedTime, time.Now())
+
+		// pre-existing UserSignup already in rejected state (as if a prior signup attempt was rejected)
+		rejectedUS := testusersignup.NewUserSignup(
+			testusersignup.WithName(signupcommon.EncodeUserIdentifier("rejected-repeat@kubesaw")),
+		)
+		states.SetRejected(rejectedUS, true)
+		_, application := testutil.PrepareInClusterApp(s.T(), rejectedUS)
+
+		// when
+		userSignup, err := application.SignupService().Signup(ctx)
+
+		// then
+		require.Error(s.T(), err)
+		assert.Nil(s.T(), userSignup)
+		assert.Equal(s.T(), service.ForbiddenBannedError, err)
+		assert.False(s.T(), verifierCalled, "account verifier should not be called for an already-rejected UserSignup")
 	})
 
 	s.Run("phone-verification result forces verification required", func() {
@@ -1743,7 +1795,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 			testusersignup.WithName(signupcommon.EncodeUserIdentifier("reactivate-reject@kubesaw")),
 			testusersignup.DeactivatedAgo(0),
 		)
-		_, application := testutil.PrepareInClusterApp(s.T(), deactivatedUS)
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), deactivatedUS)
 
 		// when
 		userSignup, err := application.SignupService().Signup(ctx)
@@ -1752,6 +1804,15 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		require.Error(s.T(), err)
 		assert.Nil(s.T(), userSignup)
 		assert.Equal(s.T(), service.ForbiddenBannedError, err)
+
+		// verify the UserSignup was updated with rejected state
+		updatedUS := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), types.NamespacedName{
+			Name:      signupcommon.EncodeUserIdentifier("reactivate-reject@kubesaw"),
+			Namespace: commontest.HostOperatorNs,
+		}, updatedUS))
+		assert.True(s.T(), states.Rejected(updatedUS))
+		assert.Equal(s.T(), "reject", updatedUS.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
 	})
 
 	s.Run("disabled mode does not call account verifier", func() {

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -1577,7 +1577,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		// then
 		require.Error(s.T(), err)
 		assert.Nil(s.T(), userSignup)
-		assert.Equal(s.T(), service.ForbiddenBannedError, err)
+		assert.Equal(s.T(), service.ForbiddenRejectedError, err)
 
 		// verify UserSignup WAS created with rejected state and annotation
 		userSignups := &toolchainv1alpha1.UserSignupList{}
@@ -1633,7 +1633,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		// then
 		require.Error(s.T(), err)
 		assert.Nil(s.T(), userSignup)
-		assert.Equal(s.T(), service.ForbiddenBannedError, err)
+		assert.Equal(s.T(), service.ForbiddenRejectedError, err)
 		assert.False(s.T(), verifierCalled, "account verifier should not be called for an already-rejected UserSignup")
 	})
 
@@ -1803,7 +1803,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		// then
 		require.Error(s.T(), err)
 		assert.Nil(s.T(), userSignup)
-		assert.Equal(s.T(), service.ForbiddenBannedError, err)
+		assert.Equal(s.T(), service.ForbiddenRejectedError, err)
 
 		// verify the UserSignup was updated with rejected state
 		updatedUS := &toolchainv1alpha1.UserSignup{}

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -1501,7 +1501,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"result":"approved","reasons":[{"check":"email-domain","detail":"domain is trusted"}],"error":""}`))
+			_, _ = w.Write([]byte(`{"result":"approved","reasons":[{"check":"check-1","detail":"passed"}],"error":""}`))
 		}))
 		defer verifierServer.Close()
 
@@ -1535,7 +1535,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), userSignup)
 		assert.Equal(s.T(), "approved", userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
-		assert.JSONEq(s.T(), `[{"check":"email-domain","detail":"domain is trusted"}]`, userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
+		assert.JSONEq(s.T(), `[{"check":"check-1","detail":"passed"}]`, userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
 	})
 
 	s.Run("reject result returns forbidden error", func() {
@@ -1543,7 +1543,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"result":"reject","reasons":[{"check":"disposable-email","detail":"email domain is disposable"}],"error":""}`))
+			_, _ = w.Write([]byte(`{"result":"reject","reasons":[{"check":"check-1","detail":"failed"}],"error":""}`))
 		}))
 		defer verifierServer.Close()
 
@@ -1590,7 +1590,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"result":"phone-verification","reasons":[{"check":"risk-score","detail":"high risk"}],"error":""}`))
+			_, _ = w.Write([]byte(`{"result":"phone-verification","reasons":[{"check":"check-1","detail":"needs verification"}],"error":""}`))
 		}))
 		defer verifierServer.Close()
 
@@ -1714,7 +1714,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"result":"reject","reasons":[{"check":"fraud","detail":"known bad actor"}],"error":""}`))
+			_, _ = w.Write([]byte(`{"result":"reject","reasons":[{"check":"check-1","detail":"failed"}],"error":""}`))
 		}))
 		defer verifierServer.Close()
 

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -1495,6 +1495,266 @@ func (s *TestSignupServiceSuite) TestSignupCallsAccountVerifier() {
 	})
 }
 
+func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
+	s.Run("approved result sets annotations and proceeds normally", func() {
+		// given
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"result":"approved","reasons":[{"check":"email-domain","detail":"domain is trusted"}],"error":""}`))
+		}))
+		defer verifierServer.Close()
+
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().
+				AccountVerifierURL(verifierServer.URL).
+				AccountVerifierEnabled(true).
+				Verification().Enabled(true).
+				Verification().CodeExpiresInMin(5))
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "approved-user@kubesaw")
+		ctx.Set(context.SubKey, "987654321")
+		ctx.Set(context.OriginalSubKey, "original-sub-value")
+		ctx.Set(context.EmailKey, "approved-user@gmail.com")
+		ctx.Set(context.GivenNameKey, "jane")
+		ctx.Set(context.FamilyNameKey, "doe")
+		ctx.Set(context.CompanyKey, "red hat")
+		ctx.Set(context.UserIDKey, "13349822")
+		ctx.Set(context.AccountIDKey, "45983711")
+		ctx.Set(context.AccountNumberKey, "123456789")
+		ctx.Set(context.RequestReceivedTime, time.Now())
+
+		_, application := testutil.PrepareInClusterApp(s.T())
+
+		// when
+		userSignup, err := application.SignupService().Signup(ctx)
+
+		// then
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), userSignup)
+		assert.Equal(s.T(), "approved", userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
+		assert.JSONEq(s.T(), `[{"check":"email-domain","detail":"domain is trusted"}]`, userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
+	})
+
+	s.Run("reject result returns forbidden error", func() {
+		// given
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"result":"reject","reasons":[{"check":"disposable-email","detail":"email domain is disposable"}],"error":""}`))
+		}))
+		defer verifierServer.Close()
+
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().
+				AccountVerifierURL(verifierServer.URL).
+				AccountVerifierEnabled(true).
+				Verification().Enabled(true).
+				Verification().CodeExpiresInMin(5))
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "rejected-user@kubesaw")
+		ctx.Set(context.SubKey, "987654321")
+		ctx.Set(context.OriginalSubKey, "original-sub-value")
+		ctx.Set(context.EmailKey, "rejected-user@disposable.com")
+		ctx.Set(context.GivenNameKey, "jane")
+		ctx.Set(context.FamilyNameKey, "doe")
+		ctx.Set(context.CompanyKey, "red hat")
+		ctx.Set(context.UserIDKey, "13349822")
+		ctx.Set(context.AccountIDKey, "45983711")
+		ctx.Set(context.AccountNumberKey, "123456789")
+		ctx.Set(context.RequestReceivedTime, time.Now())
+
+		fakeClient, application := testutil.PrepareInClusterApp(s.T())
+
+		// when
+		userSignup, err := application.SignupService().Signup(ctx)
+
+		// then
+		require.Error(s.T(), err)
+		assert.Nil(s.T(), userSignup)
+		assert.Equal(s.T(), service.ForbiddenBannedError, err)
+
+		// verify no UserSignup was created
+		userSignups := &toolchainv1alpha1.UserSignupList{}
+		listErr := fakeClient.List(gocontext.TODO(), userSignups, client.InNamespace(commontest.HostOperatorNs))
+		require.NoError(s.T(), listErr)
+		assert.Empty(s.T(), userSignups.Items)
+	})
+
+	s.Run("phone-verification result forces verification required", func() {
+		// given
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"result":"phone-verification","reasons":[{"check":"risk-score","detail":"high risk"}],"error":""}`))
+		}))
+		defer verifierServer.Close()
+
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().
+				AccountVerifierURL(verifierServer.URL).
+				AccountVerifierEnabled(true).
+				Verification().Enabled(false))
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "phone-ver-user@kubesaw")
+		ctx.Set(context.SubKey, "987654321")
+		ctx.Set(context.OriginalSubKey, "original-sub-value")
+		ctx.Set(context.EmailKey, "phone-ver-user@gmail.com")
+		ctx.Set(context.GivenNameKey, "jane")
+		ctx.Set(context.FamilyNameKey, "doe")
+		ctx.Set(context.CompanyKey, "red hat")
+		ctx.Set(context.UserIDKey, "13349822")
+		ctx.Set(context.AccountIDKey, "45983711")
+		ctx.Set(context.AccountNumberKey, "123456789")
+		ctx.Set(context.RequestReceivedTime, time.Now())
+
+		_, application := testutil.PrepareInClusterApp(s.T())
+
+		// when
+		userSignup, err := application.SignupService().Signup(ctx)
+
+		// then
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), userSignup)
+		assert.Equal(s.T(), "phone-verification", userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
+		assert.True(s.T(), states.VerificationRequired(userSignup))
+	})
+
+	s.Run("verifier error with enabled flag fails open", func() {
+		// given
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`internal server error`))
+		}))
+		defer verifierServer.Close()
+
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().
+				AccountVerifierURL(verifierServer.URL).
+				AccountVerifierEnabled(true).
+				Verification().Enabled(true).
+				Verification().CodeExpiresInMin(5))
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "failopen-user@kubesaw")
+		ctx.Set(context.SubKey, "987654321")
+		ctx.Set(context.OriginalSubKey, "original-sub-value")
+		ctx.Set(context.EmailKey, "failopen-user@gmail.com")
+		ctx.Set(context.GivenNameKey, "jane")
+		ctx.Set(context.FamilyNameKey, "doe")
+		ctx.Set(context.CompanyKey, "red hat")
+		ctx.Set(context.UserIDKey, "13349822")
+		ctx.Set(context.AccountIDKey, "45983711")
+		ctx.Set(context.AccountNumberKey, "123456789")
+		ctx.Set(context.RequestReceivedTime, time.Now())
+
+		_, application := testutil.PrepareInClusterApp(s.T())
+
+		// when
+		userSignup, err := application.SignupService().Signup(ctx)
+
+		// then
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), userSignup)
+		assert.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
+		assert.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
+	})
+
+	s.Run("enabled flag false does not set annotations", func() {
+		// given
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"result":"approved","reasons":[],"error":""}`))
+		}))
+		defer verifierServer.Close()
+
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().
+				AccountVerifierURL(verifierServer.URL).
+				Verification().Enabled(true).
+				Verification().CodeExpiresInMin(5))
+		// AccountVerifierEnabled defaults to false — not setting it
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "noflag-user@kubesaw")
+		ctx.Set(context.SubKey, "987654321")
+		ctx.Set(context.OriginalSubKey, "original-sub-value")
+		ctx.Set(context.EmailKey, "noflag-user@gmail.com")
+		ctx.Set(context.GivenNameKey, "jane")
+		ctx.Set(context.FamilyNameKey, "doe")
+		ctx.Set(context.CompanyKey, "red hat")
+		ctx.Set(context.UserIDKey, "13349822")
+		ctx.Set(context.AccountIDKey, "45983711")
+		ctx.Set(context.AccountNumberKey, "123456789")
+		ctx.Set(context.RequestReceivedTime, time.Now())
+
+		_, application := testutil.PrepareInClusterApp(s.T())
+
+		// when
+		userSignup, err := application.SignupService().Signup(ctx)
+
+		// then
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), userSignup)
+		assert.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
+		assert.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
+	})
+
+	s.Run("reject on reactivation returns forbidden error", func() {
+		// given
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"result":"reject","reasons":[{"check":"fraud","detail":"known bad actor"}],"error":""}`))
+		}))
+		defer verifierServer.Close()
+
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().
+				AccountVerifierURL(verifierServer.URL).
+				AccountVerifierEnabled(true).
+				Verification().Enabled(true).
+				Verification().CodeExpiresInMin(5))
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "reactivate-reject@kubesaw")
+		ctx.Set(context.SubKey, "987654321")
+		ctx.Set(context.OriginalSubKey, "original-sub-value")
+		ctx.Set(context.EmailKey, "reactivate-reject@gmail.com")
+		ctx.Set(context.GivenNameKey, "jane")
+		ctx.Set(context.FamilyNameKey, "doe")
+		ctx.Set(context.CompanyKey, "red hat")
+		ctx.Set(context.UserIDKey, "13349822")
+		ctx.Set(context.AccountIDKey, "45983711")
+		ctx.Set(context.AccountNumberKey, "123456789")
+		ctx.Set(context.RequestReceivedTime, time.Now())
+
+		deactivatedUS := testusersignup.NewUserSignup(
+			testusersignup.WithName(signupcommon.EncodeUserIdentifier("reactivate-reject@kubesaw")),
+			testusersignup.DeactivatedAgo(0),
+		)
+		_, application := testutil.PrepareInClusterApp(s.T(), deactivatedUS)
+
+		// when
+		userSignup, err := application.SignupService().Signup(ctx)
+
+		// then
+		require.Error(s.T(), err)
+		assert.Nil(s.T(), userSignup)
+		assert.Equal(s.T(), service.ForbiddenBannedError, err)
+	})
+}
+
 type FakeCaptchaChecker struct {
 	score  float32
 	result error

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -1495,7 +1495,7 @@ func (s *TestSignupServiceSuite) TestSignupCallsAccountVerifier() {
 	})
 }
 
-func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
+func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 	s.Run("approved result sets annotations and proceeds normally", func() {
 		// given
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1508,7 +1508,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		s.OverrideApplicationDefault(
 			testconfig.RegistrationService().
 				AccountVerifierURL(verifierServer.URL).
-				AccountVerifierEnabled(true).
+				AccountVerifierMode("enabled").
 				Verification().Enabled(true).
 				Verification().CodeExpiresInMin(5))
 
@@ -1550,7 +1550,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		s.OverrideApplicationDefault(
 			testconfig.RegistrationService().
 				AccountVerifierURL(verifierServer.URL).
-				AccountVerifierEnabled(true).
+				AccountVerifierMode("enabled").
 				Verification().Enabled(true).
 				Verification().CodeExpiresInMin(5))
 
@@ -1597,7 +1597,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		s.OverrideApplicationDefault(
 			testconfig.RegistrationService().
 				AccountVerifierURL(verifierServer.URL).
-				AccountVerifierEnabled(true).
+				AccountVerifierMode("enabled").
 				Verification().Enabled(false))
 
 		rr := httptest.NewRecorder()
@@ -1637,7 +1637,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		s.OverrideApplicationDefault(
 			testconfig.RegistrationService().
 				AccountVerifierURL(verifierServer.URL).
-				AccountVerifierEnabled(true).
+				AccountVerifierMode("enabled").
 				Verification().Enabled(true).
 				Verification().CodeExpiresInMin(5))
 
@@ -1667,7 +1667,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		assert.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
 	})
 
-	s.Run("enabled flag false does not set annotations", func() {
+	s.Run("log mode does not set annotations", func() {
 		// given
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -1679,9 +1679,9 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		s.OverrideApplicationDefault(
 			testconfig.RegistrationService().
 				AccountVerifierURL(verifierServer.URL).
+				AccountVerifierMode("log").
 				Verification().Enabled(true).
 				Verification().CodeExpiresInMin(5))
-		// AccountVerifierEnabled defaults to false — not setting it
 
 		rr := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(rr)
@@ -1721,7 +1721,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		s.OverrideApplicationDefault(
 			testconfig.RegistrationService().
 				AccountVerifierURL(verifierServer.URL).
-				AccountVerifierEnabled(true).
+				AccountVerifierMode("enabled").
 				Verification().Enabled(true).
 				Verification().CodeExpiresInMin(5))
 
@@ -1752,6 +1752,48 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierEnabled() {
 		require.Error(s.T(), err)
 		assert.Nil(s.T(), userSignup)
 		assert.Equal(s.T(), service.ForbiddenBannedError, err)
+	})
+
+	s.Run("disabled mode does not call account verifier", func() {
+		// given
+		verifierCalled := false
+		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			verifierCalled = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer verifierServer.Close()
+
+		s.OverrideApplicationDefault(
+			testconfig.RegistrationService().
+				AccountVerifierURL(verifierServer.URL).
+				AccountVerifierMode("disabled").
+				Verification().Enabled(true).
+				Verification().CodeExpiresInMin(5))
+
+		rr := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rr)
+		ctx.Set(context.UsernameKey, "disabled-mode-user@kubesaw")
+		ctx.Set(context.SubKey, "987654321")
+		ctx.Set(context.OriginalSubKey, "original-sub-value")
+		ctx.Set(context.EmailKey, "disabled-mode-user@gmail.com")
+		ctx.Set(context.GivenNameKey, "jane")
+		ctx.Set(context.FamilyNameKey, "doe")
+		ctx.Set(context.CompanyKey, "red hat")
+		ctx.Set(context.UserIDKey, "13349822")
+		ctx.Set(context.AccountIDKey, "45983711")
+		ctx.Set(context.AccountNumberKey, "123456789")
+		ctx.Set(context.RequestReceivedTime, time.Now())
+
+		_, application := testutil.PrepareInClusterApp(s.T())
+
+		// when
+		userSignup, err := application.SignupService().Signup(ctx)
+
+		// then
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), userSignup)
+		assert.False(s.T(), verifierCalled)
+		assert.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
 	})
 }
 


### PR DESCRIPTION
When AccountVerifierEnabled is true, the signup flow now checks the account-verifier response and acts accordingly. The result and reasons are stored as annotations on the UserSignup. 

Jira: https://redhat.atlassian.net/browse/SANDBOX-1848

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account verification on signup records verifier results and reasons; outcomes can approve, reject (blocks signup), or require phone verification.
  * Configurable verifier mode exposed with default "log".

* **Bug Fixes**
  * Verifier errors are treated permissively (fails‑open) to avoid blocking signups.
  * Rejected signups (including reactivations) are consistently blocked from re-signup.

* **Tests**
  * Added comprehensive tests for verifier outcomes, modes, reactivation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->