### PR TITLE
feat: add Twilio Lookup v2 API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -179,6 +179,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260608073802-89362d94dca4
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260608074508-590711573ffe
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.24.13
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20260603082246-cfa3dd9db9cc
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20260603091009-6db0c02f4506
+	github.com/codeready-toolchain/api v0.0.0-20260609071155-c8f486b1a581
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -178,7 +178,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91

--- a/go.mod
+++ b/go.mod
@@ -179,6 +179,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260604095004-7254759589cb
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260608073802-89362d94dca4
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260604095108-e1b8464eda32
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260608074508-590711573ffe

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.13
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564
+	github.com/codeready-toolchain/api v0.0.0-20260603082246-cfa3dd9db9cc
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20260504133316-5fab46be70c1
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible
@@ -36,6 +36,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.62.0
 	github.com/spf13/pflag v1.0.6
+	github.com/twilio/twilio-go v1.30.9
 	go.uber.org/zap v1.27.0
 	gopkg.in/go-jose/go-jose.v2 v2.6.3
 	gotest.tools v2.2.0+incompatible
@@ -69,6 +70,7 @@ require (
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
@@ -176,3 +178,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8

--- a/go.mod
+++ b/go.mod
@@ -179,6 +179,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260604095004-7254759589cb
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260604095108-e1b8464eda32

--- a/go.sum
+++ b/go.sum
@@ -50,10 +50,6 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
-github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564 h1:RDdUR0OXjERY3yr0F9S5z2m99Nh6Ccfr+zcA6OXfjJQ=
-github.com/codeready-toolchain/api v0.0.0-20260504080314-cf8d9a0df564/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260504133316-5fab46be70c1 h1:+/VQDNw0OAJ9YqfuDMNWDV1Z6Ff+iCJqjbg349KYBws=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260504133316-5fab46be70c1/go.mod h1:oW0GW/5ztCbCE/hlpEwO+dvV+CsPiMje5oYhg+Nszd8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -79,6 +75,10 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
+github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8 h1:sObsn7DQTpOV3xFUjz3CukBbV0yBbocoy7oY44lmohI=
+github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8/go.mod h1:pcEdk1XDpioLNGX3/p10q6TG+JiM1fpNGksjUGN4j+8=
+github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc h1:uqVQWx9dBBUQ63BuyinZX8UYPDPiPzUmOrinw+Luw/M=
+github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
@@ -148,6 +148,8 @@ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -265,6 +267,8 @@ github.com/lestrrat-go/jwx v1.2.29/go.mod h1:hU8k2l6WF0ncx20uQdOmik/Gjg6E3/wIRtX
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
+github.com/localtunnel/go-localtunnel v0.0.0-20170326223115-8a804488f275 h1:IZycmTpoUtQK3PD60UYBwjaCUHUP7cML494ao9/O8+Q=
+github.com/localtunnel/go-localtunnel v0.0.0-20170326223115-8a804488f275/go.mod h1:zt6UU74K6Z6oMOYJbJzYpYucqdcQwSMPBEdSvGiaUMw=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
@@ -363,6 +367,8 @@ github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 h1:5u+EJUQiosu3JFX0
 github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2/go.mod h1:4kyMkleCiLkgY6z8gK5BkI01ChBtxR0ro3I1ZDcGM3w=
 github.com/ttacon/libphonenumber v1.2.1 h1:fzOfY5zUADkCkbIafAed11gL1sW+bJ26p6zWLBMElR4=
 github.com/ttacon/libphonenumber v1.2.1/go.mod h1:E0TpmdVMq5dyVlQ7oenAkhsLu86OkUl+yR4OAxyEg/M=
+github.com/twilio/twilio-go v1.30.9 h1:4W4GEV2q0sLQ9xsr1N/97JQlt0c82hZ0ij4qTErstv8=
+github.com/twilio/twilio-go v1.30.9/go.mod h1:QbitvbvtkV77Jn4BABAKVmxabYSjMyQG4tHey9gfPqg=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
@@ -381,6 +387,7 @@ github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
@@ -426,6 +433,7 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -439,6 +447,7 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
@@ -458,6 +467,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
@@ -468,6 +478,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -518,6 +530,7 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.39.0 h1:ik4ho21kwuQln40uelmciQPp9SipgNDdrafrYA4TmQQ=

--- a/go.sum
+++ b/go.sum
@@ -50,10 +50,10 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
-github.com/codeready-toolchain/api v0.0.0-20260603082246-cfa3dd9db9cc h1:Xwt43SDrCQ3cxwetRijdFrDwRp1yoam6j+36HazNivg=
-github.com/codeready-toolchain/api v0.0.0-20260603082246-cfa3dd9db9cc/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260603091009-6db0c02f4506 h1:FYOvK015wTBSh9J+T/yr4zjcVMpT1eKL1D/oS8yF1Lk=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260603091009-6db0c02f4506/go.mod h1:V3Ah7YRoTIHkU0G4Ynvj/6AVgOH3Ss0fw/B/Gurr3AA=
+github.com/codeready-toolchain/api v0.0.0-20260609071155-c8f486b1a581 h1:KE14RYWzMatSrwGa2wOB4SoVkbvpTm8hfnUH/nrpnfw=
+github.com/codeready-toolchain/api v0.0.0-20260609071155-c8f486b1a581/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579 h1:1qfOdNV6gRQSE0xOmJggqQxAiEjOpV7nZ6Xph75Mb1I=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579/go.mod h1:aYvTzEtTuw3O+kjWMMkH/1YgV4pgUPC3v3X2Li3ixlM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -79,10 +79,6 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
-github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91 h1:ZRjnFxN8UIcmJo+BjNTiaCpyYVCj7TclarGbRRko3mE=
-github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91/go.mod h1:xcm86+meY59A4Rs62c8wVAznTuPk2QQW/yijPWZxHLw=
-github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621 h1:4Ga0w0uuWUw8Q3KgJsgMncH+1F2S048y0eCAzSSlYbA=
-github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=

--- a/go.sum
+++ b/go.sum
@@ -75,10 +75,10 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
-github.com/fbm3307/toolchain-common v0.0.0-20260604095108-e1b8464eda32 h1:0hDjq6yEF3IfohFQayMKvBLHCRXfDrrfuqmA3qdkL/s=
-github.com/fbm3307/toolchain-common v0.0.0-20260604095108-e1b8464eda32/go.mod h1:oTa3Nrm18nLZoY288yT0iNK9BWYtyZiEC6kpBbQuSk0=
-github.com/fbm3307/toolchainapi v0.0.0-20260604095004-7254759589cb h1:bXPET+ypBRQzmSUdUvL963GLYFNc4eZmh7a5LyxbLBc=
-github.com/fbm3307/toolchainapi v0.0.0-20260604095004-7254759589cb/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/fbm3307/toolchain-common v0.0.0-20260608074508-590711573ffe h1:ZcRGUQ4PQ5jdklG+sjbNiRcWDWZRJTnAw7sMzhUFMcE=
+github.com/fbm3307/toolchain-common v0.0.0-20260608074508-590711573ffe/go.mod h1:qM3O9UX4HOWPYW4QT7G3cZxO91+XKQBUZaxlOIN73Uo=
+github.com/fbm3307/toolchainapi v0.0.0-20260608073802-89362d94dca4 h1:iMRDRRzSq9Ie33g3WqfzDvvnLzesgTRKEnI3AhTTIfs=
+github.com/fbm3307/toolchainapi v0.0.0-20260608073802-89362d94dca4/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=

--- a/go.sum
+++ b/go.sum
@@ -75,10 +75,10 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
-github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8 h1:sObsn7DQTpOV3xFUjz3CukBbV0yBbocoy7oY44lmohI=
-github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8/go.mod h1:pcEdk1XDpioLNGX3/p10q6TG+JiM1fpNGksjUGN4j+8=
-github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc h1:uqVQWx9dBBUQ63BuyinZX8UYPDPiPzUmOrinw+Luw/M=
-github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/fbm3307/toolchain-common v0.0.0-20260604095108-e1b8464eda32 h1:0hDjq6yEF3IfohFQayMKvBLHCRXfDrrfuqmA3qdkL/s=
+github.com/fbm3307/toolchain-common v0.0.0-20260604095108-e1b8464eda32/go.mod h1:oTa3Nrm18nLZoY288yT0iNK9BWYtyZiEC6kpBbQuSk0=
+github.com/fbm3307/toolchainapi v0.0.0-20260604095004-7254759589cb h1:bXPET+ypBRQzmSUdUvL963GLYFNc4eZmh7a5LyxbLBc=
+github.com/fbm3307/toolchainapi v0.0.0-20260604095004-7254759589cb/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=

--- a/go.sum
+++ b/go.sum
@@ -75,10 +75,10 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
-github.com/fbm3307/toolchain-common v0.0.0-20260608074508-590711573ffe h1:ZcRGUQ4PQ5jdklG+sjbNiRcWDWZRJTnAw7sMzhUFMcE=
-github.com/fbm3307/toolchain-common v0.0.0-20260608074508-590711573ffe/go.mod h1:qM3O9UX4HOWPYW4QT7G3cZxO91+XKQBUZaxlOIN73Uo=
-github.com/fbm3307/toolchainapi v0.0.0-20260608073802-89362d94dca4 h1:iMRDRRzSq9Ie33g3WqfzDvvnLzesgTRKEnI3AhTTIfs=
-github.com/fbm3307/toolchainapi v0.0.0-20260608073802-89362d94dca4/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91 h1:ZRjnFxN8UIcmJo+BjNTiaCpyYVCj7TclarGbRRko3mE=
+github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91/go.mod h1:xcm86+meY59A4Rs62c8wVAznTuPk2QQW/yijPWZxHLw=
+github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621 h1:4Ga0w0uuWUw8Q3KgJsgMncH+1F2S048y0eCAzSSlYbA=
+github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -331,3 +331,7 @@ func (r VerificationConfig) PhoneLookupMode() toolchainv1alpha1.PhoneLookupMode 
 	}
 	return toolchainv1alpha1.PhoneLookupModeLog
 }
+
+func (r VerificationConfig) PhoneLookupExcludedCountries() []string {
+	return r.c.PhoneLookupExcludedCountries
+}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -324,3 +324,7 @@ func (r VerificationConfig) CaptchaServiceAccountFileContents() string {
 	content := r.registrationServiceSecret(key)
 	return string(content)
 }
+
+func (r VerificationConfig) PhoneLookupMode() string {
+	return commonconfig.GetString(r.c.PhoneLookupMode, "log")
+}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -325,6 +325,9 @@ func (r VerificationConfig) CaptchaServiceAccountFileContents() string {
 	return string(content)
 }
 
-func (r VerificationConfig) PhoneLookupMode() string {
-	return commonconfig.GetString(r.c.PhoneLookupMode, "log")
+func (r VerificationConfig) PhoneLookupMode() toolchainv1alpha1.PhoneLookupMode {
+	if r.c.PhoneLookupMode != nil {
+		return *r.c.PhoneLookupMode
+	}
+	return toolchainv1alpha1.PhoneLookupModeLog
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -3,7 +3,7 @@ package configuration_test
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/registration-service/pkg/configuration"
 	"github.com/codeready-toolchain/registration-service/test"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
@@ -69,7 +69,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.InDelta(t, float32(0), regServiceCfg.Verification().CaptchaRequiredScore(), 0.01)
 		assert.True(t, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaServiceAccountFileContents())
-		assert.Equal(t, "log", regServiceCfg.Verification().PhoneLookupMode())
+		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeLog, regServiceCfg.Verification().PhoneLookupMode())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Empty(t, regServiceCfg.AccountVerifierURL())
 	})
@@ -101,7 +101,7 @@ func TestRegistrationService(t *testing.T) {
 			Verification().CaptchaScoreThreshold("0.7").
 			Verification().CaptchaRequiredScore("0.5").
 			Verification().CaptchaAllowLowScoreReactivation(false).
-			Verification().PhoneLookupMode("enabled").
+			Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled).
 			Verification().Secret().Ref("verification-secrets").
 			TwilioAccountSID("twilio.sid").
 			TwilioAuthToken("twilio.token").
@@ -159,7 +159,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.InDelta(t, float32(0.5), regServiceCfg.Verification().CaptchaRequiredScore(), 0.01)
 		assert.False(t, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Equal(t, "example-content", regServiceCfg.Verification().CaptchaServiceAccountFileContents())
-		assert.Equal(t, "enabled", regServiceCfg.Verification().PhoneLookupMode())
+		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeEnabled, regServiceCfg.Verification().PhoneLookupMode())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Equal(t, "https://verifier.example.com", regServiceCfg.AccountVerifierURL())
 	})
@@ -168,15 +168,15 @@ func TestRegistrationService(t *testing.T) {
 func TestPhoneLookupMode(t *testing.T) {
 	t.Run("returns configured value", func(t *testing.T) {
 		cfg := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.RegistrationService().
-			Verification().PhoneLookupMode("disabled"))
+			Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeDisabled))
 		regServiceCfg := configuration.NewRegistrationServiceConfig(cfg, map[string]map[string]string{})
-		assert.Equal(t, "disabled", regServiceCfg.Verification().PhoneLookupMode())
+		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeDisabled, regServiceCfg.Verification().PhoneLookupMode())
 	})
 
 	t.Run("defaults to log when unset", func(t *testing.T) {
 		cfg := commonconfig.NewToolchainConfigObjWithReset(t)
 		regServiceCfg := configuration.NewRegistrationServiceConfig(cfg, map[string]map[string]string{})
-		assert.Equal(t, "log", regServiceCfg.Verification().PhoneLookupMode())
+		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeLog, regServiceCfg.Verification().PhoneLookupMode())
 	})
 }
 
@@ -184,15 +184,15 @@ func TestPublicViewerConfiguration(t *testing.T) {
 	tt := map[string]struct {
 		name               string
 		expectedValue      bool
-		publicViewerConfig *v1alpha1.PublicViewerConfiguration
+		publicViewerConfig *toolchainv1alpha1.PublicViewerConfiguration
 	}{
 		"public-viewer is explicitly enabled": {
 			expectedValue:      true,
-			publicViewerConfig: &v1alpha1.PublicViewerConfiguration{Enabled: true},
+			publicViewerConfig: &toolchainv1alpha1.PublicViewerConfiguration{Enabled: true},
 		},
 		"public-viewer is explicitly disabled": {
 			expectedValue:      false,
-			publicViewerConfig: &v1alpha1.PublicViewerConfiguration{Enabled: false},
+			publicViewerConfig: &toolchainv1alpha1.PublicViewerConfiguration{Enabled: false},
 		},
 		"public-viewer config not set, assume disabled": {
 			expectedValue:      false,

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -70,6 +70,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.True(t, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeLog, regServiceCfg.Verification().PhoneLookupMode())
+		assert.Empty(t, regServiceCfg.Verification().PhoneLookupExcludedCountries())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Empty(t, regServiceCfg.AccountVerifierURL())
 		assert.Equal(t, "log", regServiceCfg.AccountVerifierMode())
@@ -105,6 +106,7 @@ func TestRegistrationService(t *testing.T) {
 			Verification().CaptchaRequiredScore("0.5").
 			Verification().CaptchaAllowLowScoreReactivation(false).
 			Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled).
+			Verification().PhoneLookupExcludedCountries([]string{"US", "CA"}).
 			Verification().Secret().Ref("verification-secrets").
 			TwilioAccountSID("twilio.sid").
 			TwilioAuthToken("twilio.token").
@@ -160,26 +162,13 @@ func TestRegistrationService(t *testing.T) {
 		assert.False(t, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Equal(t, "example-content", regServiceCfg.Verification().CaptchaServiceAccountFileContents())
 		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeEnabled, regServiceCfg.Verification().PhoneLookupMode())
+		assert.Equal(t, []string{"US", "CA"}, regServiceCfg.Verification().PhoneLookupExcludedCountries())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Equal(t, "https://verifier.example.com", regServiceCfg.AccountVerifierURL())
 		assert.Equal(t, "enabled", regServiceCfg.AccountVerifierMode())
 	})
 }
 
-func TestPhoneLookupMode(t *testing.T) {
-	t.Run("returns configured value", func(t *testing.T) {
-		cfg := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.RegistrationService().
-			Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeDisabled))
-		regServiceCfg := configuration.NewRegistrationServiceConfig(cfg, map[string]map[string]string{})
-		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeDisabled, regServiceCfg.Verification().PhoneLookupMode())
-	})
-
-	t.Run("defaults to log when unset", func(t *testing.T) {
-		cfg := commonconfig.NewToolchainConfigObjWithReset(t)
-		regServiceCfg := configuration.NewRegistrationServiceConfig(cfg, map[string]map[string]string{})
-		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeLog, regServiceCfg.Verification().PhoneLookupMode())
-	})
-}
 
 func TestPublicViewerConfiguration(t *testing.T) {
 	tt := map[string]struct {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -69,6 +69,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.InDelta(t, float32(0), regServiceCfg.Verification().CaptchaRequiredScore(), 0.01)
 		assert.True(t, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaServiceAccountFileContents())
+		assert.Equal(t, "log", regServiceCfg.Verification().PhoneLookupMode())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Empty(t, regServiceCfg.AccountVerifierURL())
 	})
@@ -100,6 +101,7 @@ func TestRegistrationService(t *testing.T) {
 			Verification().CaptchaScoreThreshold("0.7").
 			Verification().CaptchaRequiredScore("0.5").
 			Verification().CaptchaAllowLowScoreReactivation(false).
+			Verification().PhoneLookupMode("enabled").
 			Verification().Secret().Ref("verification-secrets").
 			TwilioAccountSID("twilio.sid").
 			TwilioAuthToken("twilio.token").
@@ -157,8 +159,24 @@ func TestRegistrationService(t *testing.T) {
 		assert.InDelta(t, float32(0.5), regServiceCfg.Verification().CaptchaRequiredScore(), 0.01)
 		assert.False(t, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Equal(t, "example-content", regServiceCfg.Verification().CaptchaServiceAccountFileContents())
+		assert.Equal(t, "enabled", regServiceCfg.Verification().PhoneLookupMode())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Equal(t, "https://verifier.example.com", regServiceCfg.AccountVerifierURL())
+	})
+}
+
+func TestPhoneLookupMode(t *testing.T) {
+	t.Run("returns configured value", func(t *testing.T) {
+		cfg := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.RegistrationService().
+			Verification().PhoneLookupMode("disabled"))
+		regServiceCfg := configuration.NewRegistrationServiceConfig(cfg, map[string]map[string]string{})
+		assert.Equal(t, "disabled", regServiceCfg.Verification().PhoneLookupMode())
+	})
+
+	t.Run("defaults to log when unset", func(t *testing.T) {
+		cfg := commonconfig.NewToolchainConfigObjWithReset(t)
+		regServiceCfg := configuration.NewRegistrationServiceConfig(cfg, map[string]map[string]string{})
+		assert.Equal(t, "log", regServiceCfg.Verification().PhoneLookupMode())
 	})
 }
 

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -169,7 +169,6 @@ func TestRegistrationService(t *testing.T) {
 	})
 }
 
-
 func TestPublicViewerConfiguration(t *testing.T) {
 	tt := map[string]struct {
 		name               string

--- a/pkg/verification/sender/phone_lookup.go
+++ b/pkg/verification/sender/phone_lookup.go
@@ -20,18 +20,18 @@ type PhoneLookupResult struct {
 	CountryCode         string
 }
 
-// PhoneLookupService checks phone numbers for fraud risk before SMS verification.
-type PhoneLookupService interface {
+// PhoneLooker checks phone numbers for fraud risk before SMS verification.
+type PhoneLooker interface {
 	LookupPhone(ctx context.Context, phoneNumber string) (*PhoneLookupResult, error)
 }
 
-// TwilioPhoneLookup implements PhoneLookupService using the Twilio Lookup v2 API.
+// TwilioPhoneLookup implements PhoneLooker using the Twilio Lookup v2 API.
 type TwilioPhoneLookup struct {
 	client *twilioclient.RestClient
 }
 
-// NewTwilioPhoneLookup creates a PhoneLookupService backed by the Twilio Lookup v2 API.
-func NewTwilioPhoneLookup(accountSID, authToken string, httpClient *http.Client) PhoneLookupService {
+// NewTwilioPhoneLookup creates a PhoneLooker backed by the Twilio Lookup v2 API.
+func NewTwilioPhoneLookup(accountSID, authToken string, httpClient *http.Client) PhoneLooker {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}

--- a/pkg/verification/sender/phone_lookup.go
+++ b/pkg/verification/sender/phone_lookup.go
@@ -10,13 +10,18 @@ import (
 	openapi "github.com/twilio/twilio-go/rest/lookups/v2"
 )
 
+// PhoneLookupResultDetails holds supplementary lookup data stored as a JSON annotation.
+type PhoneLookupResultDetails struct {
+	RiskScore   int    `json:"risk_score"`
+	CarrierName string `json:"carrier_name"`
+	LineType    string `json:"line_type"`
+}
+
 // PhoneLookupResult holds the parsed response from a Twilio Lookup v2 API call.
 type PhoneLookupResult struct {
+	PhoneLookupResultDetails
 	CarrierRiskCategory string
 	NumberBlocked       bool
-	RiskScore           int
-	CarrierName         string
-	LineType            string
 	CountryCode         string
 }
 
@@ -48,8 +53,8 @@ func NewTwilioPhoneLookup(accountSID, authToken string, httpClient *http.Client)
 }
 
 // LookupPhone fetches sms_pumping_risk and line_type_intelligence for the given E.164 number.
-func (t *TwilioPhoneLookup) LookupPhone(ctx context.Context, phoneNumber string) (*PhoneLookupResult, error) {
-	_ = ctx
+// ctx is accepted for interface consistency; the Twilio Go SDK does not yet support per-call context.
+func (t *TwilioPhoneLookup) LookupPhone(_ context.Context, phoneNumber string) (*PhoneLookupResult, error) {
 	params := &openapi.FetchPhoneNumberParams{}
 	params.SetFields("sms_pumping_risk,line_type_intelligence")
 

--- a/pkg/verification/sender/phone_lookup.go
+++ b/pkg/verification/sender/phone_lookup.go
@@ -1,7 +1,6 @@
 package sender
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -27,7 +26,7 @@ type PhoneLookupResult struct {
 
 // PhoneLooker checks phone numbers for fraud risk before SMS verification.
 type PhoneLooker interface {
-	LookupPhone(ctx context.Context, phoneNumber string) (*PhoneLookupResult, error)
+	LookupPhone(phoneNumber string) (*PhoneLookupResult, error)
 }
 
 // TwilioPhoneLookup implements PhoneLooker using the Twilio Lookup v2 API.
@@ -53,8 +52,7 @@ func NewTwilioPhoneLookup(accountSID, authToken string, httpClient *http.Client)
 }
 
 // LookupPhone fetches sms_pumping_risk and line_type_intelligence for the given E.164 number.
-// ctx is accepted for interface consistency; the Twilio Go SDK does not yet support per-call context.
-func (t *TwilioPhoneLookup) LookupPhone(_ context.Context, phoneNumber string) (*PhoneLookupResult, error) {
+func (t *TwilioPhoneLookup) LookupPhone(phoneNumber string) (*PhoneLookupResult, error) {
 	params := &openapi.FetchPhoneNumberParams{}
 	params.SetFields("sms_pumping_risk,line_type_intelligence")
 

--- a/pkg/verification/sender/phone_lookup.go
+++ b/pkg/verification/sender/phone_lookup.go
@@ -1,0 +1,72 @@
+package sender
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	twilioclient "github.com/twilio/twilio-go"
+	twiliohttp "github.com/twilio/twilio-go/client"
+	openapi "github.com/twilio/twilio-go/rest/lookups/v2"
+)
+
+// PhoneLookupResult holds the parsed response from a Twilio Lookup v2 API call.
+type PhoneLookupResult struct {
+	CarrierRiskCategory string
+	NumberBlocked       bool
+	RiskScore           int
+	CarrierName         string
+	LineType            string
+	CountryCode         string
+}
+
+// PhoneLookupService checks phone numbers for fraud risk before SMS verification.
+type PhoneLookupService interface {
+	LookupPhone(ctx context.Context, phoneNumber string) (*PhoneLookupResult, error)
+}
+
+// TwilioPhoneLookup implements PhoneLookupService using the Twilio Lookup v2 API.
+type TwilioPhoneLookup struct {
+	client *twilioclient.RestClient
+}
+
+// NewTwilioPhoneLookup creates a PhoneLookupService backed by the Twilio Lookup v2 API.
+func NewTwilioPhoneLookup(accountSID, authToken string, httpClient *http.Client) PhoneLookupService {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	baseClient := &twiliohttp.Client{
+		Credentials: twiliohttp.NewCredentials(accountSID, authToken),
+		HTTPClient:  httpClient,
+	}
+	client := twilioclient.NewRestClientWithParams(twilioclient.ClientParams{
+		Username: accountSID,
+		Password: authToken,
+		Client:   baseClient,
+	})
+	return &TwilioPhoneLookup{client: client}
+}
+
+// LookupPhone fetches sms_pumping_risk and line_type_intelligence for the given E.164 number.
+func (t *TwilioPhoneLookup) LookupPhone(ctx context.Context, phoneNumber string) (*PhoneLookupResult, error) {
+	_ = ctx
+	params := &openapi.FetchPhoneNumberParams{}
+	params.SetFields("sms_pumping_risk,line_type_intelligence")
+
+	resp, err := t.client.LookupsV2.FetchPhoneNumber(phoneNumber, params)
+	if err != nil {
+		return nil, fmt.Errorf("twilio phone lookup: %w", err)
+	}
+
+	result := &PhoneLookupResult{}
+	if resp.CountryCode != nil {
+		result.CountryCode = *resp.CountryCode
+	}
+	result.CarrierRiskCategory = resp.SmsPumpingRisk.CarrierRiskCategory
+	result.NumberBlocked = resp.SmsPumpingRisk.NumberBlocked
+	result.RiskScore = resp.SmsPumpingRisk.SmsPumpingRiskScore
+	result.CarrierName = resp.LineTypeIntelligence.CarrierName
+	result.LineType = resp.LineTypeIntelligence.Type
+
+	return result, nil
+}

--- a/pkg/verification/sender/phone_lookup_test.go
+++ b/pkg/verification/sender/phone_lookup_test.go
@@ -48,7 +48,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		})
 
 		// when
-		result, err := lookup.LookupPhone(t.Context(), phone)
+		result, err := lookup.LookupPhone(phone)
 
 		// then
 		require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		})
 
 		// when
-		result, err := lookup.LookupPhone(t.Context(), phone)
+		result, err := lookup.LookupPhone(phone)
 
 		// then
 		require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		})
 
 		// when
-		result, err := lookup.LookupPhone(t.Context(), phone)
+		result, err := lookup.LookupPhone(phone)
 
 		// then
 		require.Error(t, err)
@@ -109,7 +109,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		})
 
 		// when
-		result, err := lookup.LookupPhone(t.Context(), phone)
+		result, err := lookup.LookupPhone(phone)
 
 		// then
 		require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		})
 
 		// when
-		result, err := lookup.LookupPhone(t.Context(), phone)
+		result, err := lookup.LookupPhone(phone)
 
 		// then
 		require.NoError(t, err)
@@ -150,7 +150,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		})
 
 		// when
-		result, err := lookup.LookupPhone(t.Context(), phone)
+		result, err := lookup.LookupPhone(phone)
 
 		// then
 		require.NoError(t, err)

--- a/pkg/verification/sender/phone_lookup_test.go
+++ b/pkg/verification/sender/phone_lookup_test.go
@@ -33,6 +33,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 	}
 
 	t.Run("high-risk response parsing", func(t *testing.T) {
+		// given
 		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
 			"country_code": "GB",
 			"sms_pumping_risk": map[string]interface{}{
@@ -46,7 +47,10 @@ func TestTwilioPhoneLookup(t *testing.T) {
 			},
 		})
 
+		// when
 		result, err := lookup.LookupPhone(t.Context(), phone)
+
+		// then
 		require.NoError(t, err)
 		assert.Equal(t, "high", result.CarrierRiskCategory)
 		assert.True(t, result.NumberBlocked)
@@ -57,6 +61,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 	})
 
 	t.Run("low-risk response parsing", func(t *testing.T) {
+		// given
 		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
 			"sms_pumping_risk": map[string]interface{}{
 				"carrier_risk_category":  "low",
@@ -69,7 +74,10 @@ func TestTwilioPhoneLookup(t *testing.T) {
 			},
 		})
 
+		// when
 		result, err := lookup.LookupPhone(t.Context(), phone)
+
+		// then
 		require.NoError(t, err)
 		assert.Equal(t, "low", result.CarrierRiskCategory)
 		assert.False(t, result.NumberBlocked)
@@ -80,22 +88,30 @@ func TestTwilioPhoneLookup(t *testing.T) {
 	})
 
 	t.Run("API error handling", func(t *testing.T) {
+		// given
 		lookup := setupLookup(t, http.StatusInternalServerError, map[string]interface{}{
 			"message": "Internal Server Error",
 		})
 
+		// when
 		result, err := lookup.LookupPhone(t.Context(), phone)
+
+		// then
 		require.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "twilio phone lookup")
 	})
 
 	t.Run("response with missing fields", func(t *testing.T) {
+		// given
 		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
 			"phone_number": phone,
 		})
 
+		// when
 		result, err := lookup.LookupPhone(t.Context(), phone)
+
+		// then
 		require.NoError(t, err)
 		assert.Empty(t, result.CarrierRiskCategory)
 		assert.False(t, result.NumberBlocked)
@@ -106,13 +122,17 @@ func TestTwilioPhoneLookup(t *testing.T) {
 	})
 
 	t.Run("response with null nested objects", func(t *testing.T) {
+		// given
 		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
 			"phone_number":           phone,
 			"sms_pumping_risk":       nil,
 			"line_type_intelligence": nil,
 		})
 
+		// when
 		result, err := lookup.LookupPhone(t.Context(), phone)
+
+		// then
 		require.NoError(t, err)
 		assert.Empty(t, result.CarrierRiskCategory)
 		assert.False(t, result.NumberBlocked)
@@ -122,13 +142,17 @@ func TestTwilioPhoneLookup(t *testing.T) {
 	})
 
 	t.Run("response with empty nested objects", func(t *testing.T) {
+		// given
 		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
 			"phone_number":           phone,
 			"sms_pumping_risk":       map[string]interface{}{},
 			"line_type_intelligence": map[string]interface{}{},
 		})
 
+		// when
 		result, err := lookup.LookupPhone(t.Context(), phone)
+
+		// then
 		require.NoError(t, err)
 		assert.Empty(t, result.CarrierRiskCategory)
 		assert.False(t, result.NumberBlocked)

--- a/pkg/verification/sender/phone_lookup_test.go
+++ b/pkg/verification/sender/phone_lookup_test.go
@@ -17,7 +17,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		phone      = "+447700900000"
 	)
 
-	setupLookup := func(t *testing.T, status int, body interface{}) sender2.PhoneLookupService {
+	setupLookup := func(t *testing.T, status int, body interface{}) sender2.PhoneLooker {
 		t.Helper()
 		httpClient := &http.Client{Transport: &http.Transport{}}
 		gock.InterceptClient(httpClient)

--- a/pkg/verification/sender/phone_lookup_test.go
+++ b/pkg/verification/sender/phone_lookup_test.go
@@ -24,7 +24,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		t.Cleanup(gock.Off)
 
 		gock.New("https://lookups.twilio.com").
-			Get("/v2/PhoneNumbers/" + phone).
+			Get("/v2/PhoneNumbers/"+phone).
 			MatchParam("Fields", "sms_pumping_risk,line_type_intelligence").
 			Reply(status).
 			JSON(body).
@@ -36,8 +36,8 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
 			"country_code": "GB",
 			"sms_pumping_risk": map[string]interface{}{
-				"carrier_risk_category": "high",
-				"number_blocked":        true,
+				"carrier_risk_category":  "high",
+				"number_blocked":         true,
 				"sms_pumping_risk_score": 34,
 			},
 			"line_type_intelligence": map[string]interface{}{
@@ -59,8 +59,8 @@ func TestTwilioPhoneLookup(t *testing.T) {
 	t.Run("low-risk response parsing", func(t *testing.T) {
 		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
 			"sms_pumping_risk": map[string]interface{}{
-				"carrier_risk_category": "low",
-				"number_blocked":        false,
+				"carrier_risk_category":  "low",
+				"number_blocked":         false,
 				"sms_pumping_risk_score": 2,
 			},
 			"line_type_intelligence": map[string]interface{}{

--- a/pkg/verification/sender/phone_lookup_test.go
+++ b/pkg/verification/sender/phone_lookup_test.go
@@ -104,4 +104,36 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		assert.Empty(t, result.LineType)
 		assert.Empty(t, result.CountryCode)
 	})
+
+	t.Run("response with null nested objects", func(t *testing.T) {
+		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
+			"phone_number":           phone,
+			"sms_pumping_risk":       nil,
+			"line_type_intelligence": nil,
+		})
+
+		result, err := lookup.LookupPhone(t.Context(), phone)
+		require.NoError(t, err)
+		assert.Empty(t, result.CarrierRiskCategory)
+		assert.False(t, result.NumberBlocked)
+		assert.Zero(t, result.RiskScore)
+		assert.Empty(t, result.CarrierName)
+		assert.Empty(t, result.LineType)
+	})
+
+	t.Run("response with empty nested objects", func(t *testing.T) {
+		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
+			"phone_number":           phone,
+			"sms_pumping_risk":       map[string]interface{}{},
+			"line_type_intelligence": map[string]interface{}{},
+		})
+
+		result, err := lookup.LookupPhone(t.Context(), phone)
+		require.NoError(t, err)
+		assert.Empty(t, result.CarrierRiskCategory)
+		assert.False(t, result.NumberBlocked)
+		assert.Zero(t, result.RiskScore)
+		assert.Empty(t, result.CarrierName)
+		assert.Empty(t, result.LineType)
+	})
 }

--- a/pkg/verification/sender/phone_lookup_test.go
+++ b/pkg/verification/sender/phone_lookup_test.go
@@ -1,0 +1,107 @@
+package sender_test
+
+import (
+	"net/http"
+	"testing"
+
+	sender2 "github.com/codeready-toolchain/registration-service/pkg/verification/sender"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestTwilioPhoneLookup(t *testing.T) {
+	const (
+		accountSID = "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		authToken  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		phone      = "+447700900000"
+	)
+
+	setupLookup := func(t *testing.T, status int, body interface{}) sender2.PhoneLookupService {
+		t.Helper()
+		httpClient := &http.Client{Transport: &http.Transport{}}
+		gock.InterceptClient(httpClient)
+		t.Cleanup(gock.Off)
+
+		gock.New("https://lookups.twilio.com").
+			Get("/v2/PhoneNumbers/" + phone).
+			MatchParam("Fields", "sms_pumping_risk,line_type_intelligence").
+			Reply(status).
+			JSON(body).
+			SetHeader("Content-Type", "application/json")
+		return sender2.NewTwilioPhoneLookup(accountSID, authToken, httpClient)
+	}
+
+	t.Run("high-risk response parsing", func(t *testing.T) {
+		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
+			"country_code": "GB",
+			"sms_pumping_risk": map[string]interface{}{
+				"carrier_risk_category": "high",
+				"number_blocked":        true,
+				"sms_pumping_risk_score": 34,
+			},
+			"line_type_intelligence": map[string]interface{}{
+				"carrier_name": "Test Carrier",
+				"type":         "mobile",
+			},
+		})
+
+		result, err := lookup.LookupPhone(t.Context(), phone)
+		require.NoError(t, err)
+		assert.Equal(t, "high", result.CarrierRiskCategory)
+		assert.True(t, result.NumberBlocked)
+		assert.Equal(t, 34, result.RiskScore)
+		assert.Equal(t, "Test Carrier", result.CarrierName)
+		assert.Equal(t, "mobile", result.LineType)
+		assert.Equal(t, "GB", result.CountryCode)
+	})
+
+	t.Run("low-risk response parsing", func(t *testing.T) {
+		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
+			"sms_pumping_risk": map[string]interface{}{
+				"carrier_risk_category": "low",
+				"number_blocked":        false,
+				"sms_pumping_risk_score": 2,
+			},
+			"line_type_intelligence": map[string]interface{}{
+				"carrier_name": "O2",
+				"type":         "landline",
+			},
+		})
+
+		result, err := lookup.LookupPhone(t.Context(), phone)
+		require.NoError(t, err)
+		assert.Equal(t, "low", result.CarrierRiskCategory)
+		assert.False(t, result.NumberBlocked)
+		assert.Equal(t, 2, result.RiskScore)
+		assert.Equal(t, "O2", result.CarrierName)
+		assert.Equal(t, "landline", result.LineType)
+		assert.Empty(t, result.CountryCode)
+	})
+
+	t.Run("API error handling", func(t *testing.T) {
+		lookup := setupLookup(t, http.StatusInternalServerError, map[string]interface{}{
+			"message": "Internal Server Error",
+		})
+
+		result, err := lookup.LookupPhone(t.Context(), phone)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "twilio phone lookup")
+	})
+
+	t.Run("response with missing fields", func(t *testing.T) {
+		lookup := setupLookup(t, http.StatusOK, map[string]interface{}{
+			"phone_number": phone,
+		})
+
+		result, err := lookup.LookupPhone(t.Context(), phone)
+		require.NoError(t, err)
+		assert.Empty(t, result.CarrierRiskCategory)
+		assert.False(t, result.NumberBlocked)
+		assert.Zero(t, result.RiskScore)
+		assert.Empty(t, result.CarrierName)
+		assert.Empty(t, result.LineType)
+		assert.Empty(t, result.CountryCode)
+	})
+}

--- a/pkg/verification/sender/phone_lookup_test.go
+++ b/pkg/verification/sender/phone_lookup_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	sender2 "github.com/codeready-toolchain/registration-service/pkg/verification/sender"
+	"github.com/codeready-toolchain/registration-service/pkg/verification/sender"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -17,10 +17,8 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		phone      = "+447700900000"
 	)
 
-	setupLookup := func(t *testing.T, status int, body interface{}) sender2.PhoneLooker {
+	setupLookup := func(t *testing.T, status int, body interface{}) sender.PhoneLooker {
 		t.Helper()
-		httpClient := &http.Client{Transport: &http.Transport{}}
-		gock.InterceptClient(httpClient)
 		t.Cleanup(gock.Off)
 
 		gock.New("https://lookups.twilio.com").
@@ -29,7 +27,7 @@ func TestTwilioPhoneLookup(t *testing.T) {
 			Reply(status).
 			JSON(body).
 			SetHeader("Content-Type", "application/json")
-		return sender2.NewTwilioPhoneLookup(accountSID, authToken, httpClient)
+		return sender.NewTwilioPhoneLookup(accountSID, authToken, nil)
 	}
 
 	t.Run("high-risk response parsing", func(t *testing.T) {

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"slices"
 	"strconv"
 	"time"
 
@@ -94,7 +95,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 		return crterrors.NewBadRequest("forbidden request", "verification code will not be sent")
 	}
 
-	if isLookupRejected(signup) {
+	if states.Rejected(signup) {
 		return crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
 	}
 
@@ -151,6 +152,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 	}
 
 	var initError error
+	rejectSignup := false
 
 	// check if counter has exceeded the limit of daily limit - if at limit error out
 	if counter >= dailyLimit {
@@ -159,8 +161,11 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 	} else {
 		mode := cfg.Verification().PhoneLookupMode()
 		excludedCountries := cfg.Verification().PhoneLookupExcludedCountries()
-		regionCode := regionCodeFromE164(e164PhoneNumber)
-		if mode != toolchainv1alpha1.PhoneLookupModeDisabled && !isCountryExcluded(regionCode, excludedCountries) {
+		isoCountryCode, parseErr := countryCodeFromE164(e164PhoneNumber)
+		if parseErr != nil {
+			log.Error(ctx, parseErr, fmt.Sprintf("failed to parse country code from phone number %q", e164PhoneNumber))
+		}
+		if mode != toolchainv1alpha1.PhoneLookupModeDisabled && !slices.Contains(excludedCountries, isoCountryCode) {
 			existingLookupHash := signup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey]
 			if existingLookupHash != phoneHash {
 				lookupCtx := gocontext.Background()
@@ -173,23 +178,16 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 				} else {
 					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey] = result.CarrierRiskCategory
 					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey] = strconv.FormatBool(result.NumberBlocked)
-					details := map[string]string{
-						"risk_score":   strconv.Itoa(result.RiskScore),
-						"carrier_name": result.CarrierName,
-						"line_type":    result.LineType,
-					}
 					if isHighRiskPhone(result) {
-						details["result"] = "rejected"
 						if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
 							initError = crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
+							rejectSignup = true
 						} else {
 							log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t), proceeding (phone lookup mode=%s)",
 								result.CarrierRiskCategory, result.NumberBlocked, mode))
 						}
-					} else {
-						details["result"] = "allowed"
 					}
-					detailsJSON, err := json.Marshal(details)
+					detailsJSON, err := json.Marshal(result.PhoneLookupResultDetails)
 					if err != nil {
 						log.Error(ctx, err, "failed to marshal phone lookup details")
 					}
@@ -247,6 +245,10 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 			signup.Annotations[k] = v
 		}
 
+		if rejectSignup {
+			states.SetRejected(signup, true)
+		}
+
 		return s.Update(gocontext.TODO(), signup)
 	}
 
@@ -267,37 +269,13 @@ func isHighRiskPhone(result *sender.PhoneLookupResult) bool {
 	return result.CarrierRiskCategory == "high" || result.NumberBlocked
 }
 
-// regionCodeFromE164 parses an E.164 phone number and returns its ISO 3166-1 alpha-2 region code.
-// Returns empty string if parsing fails.
-func regionCodeFromE164(number string) string {
+// countryCodeFromE164 parses an E.164 phone number and returns its ISO 3166-1 alpha-2 country code.
+func countryCodeFromE164(number string) (string, error) {
 	parsed, err := phonenumbers.Parse(number, "")
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("parse E.164 number: %w", err)
 	}
-	return phonenumbers.GetRegionCodeForNumber(parsed)
-}
-
-// isCountryExcluded returns true if the given region code is in the excluded list.
-func isCountryExcluded(regionCode string, excluded []string) bool {
-	for _, c := range excluded {
-		if c == regionCode {
-			return true
-		}
-	}
-	return false
-}
-
-// isLookupRejected checks whether the phone lookup details annotation indicates rejection.
-func isLookupRejected(signup *toolchainv1alpha1.UserSignup) bool {
-	raw := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey]
-	if raw == "" {
-		return false
-	}
-	var details map[string]string
-	if err := json.Unmarshal([]byte(raw), &details); err != nil {
-		return false
-	}
-	return details["result"] == "rejected"
+	return phonenumbers.GetRegionCodeForNumber(parsed), nil
 }
 
 func generateVerificationCode() (string, error) {

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -255,19 +255,19 @@ func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.Reg
 	annotationValues[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey] = result.CarrierRiskCategory
 	annotationValues[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey] = strconv.FormatBool(result.NumberBlocked)
 	if isHighRiskPhone(result) {
+		log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t, phone_lookup_mode=%s)",
+			result.CarrierRiskCategory, result.NumberBlocked, mode))
 		if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
 			initError = crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
 			rejectSignup = true
-		} else {
-			log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t), proceeding (phone lookup mode=%s)",
-				result.CarrierRiskCategory, result.NumberBlocked, mode))
 		}
 	}
 	detailsJSON, err := json.Marshal(result.PhoneLookupResultDetails)
 	if err != nil {
 		log.Error(ctx, err, "failed to marshal phone lookup details")
+	} else {
+		annotationValues[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = string(detailsJSON)
 	}
-	annotationValues[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = string(detailsJSON)
 	return rejectSignup, initError
 }
 

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -156,7 +156,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 		initError = crterrors.NewForbiddenError("daily limit exceeded", "cannot generate new verification code")
 	} else {
 		mode := cfg.Verification().PhoneLookupMode()
-		if mode != "disabled" && countryCode != "1" {
+		if mode != toolchainv1alpha1.PhoneLookupModeDisabled && countryCode != "1" {
 			existingLookupHash := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey]
 			if existingLookupHash != phoneHash {
 				lookupCtx := gocontext.Background()
@@ -175,7 +175,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupLineTypeAnnotationKey] = result.LineType
 					if isHighRiskPhone(result) {
 						annotationValues[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey] = "rejected"
-						if mode == "enabled" {
+						if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
 							initError = crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
 						} else {
 							log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t), proceeding (phone lookup mode=%s)",

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -42,6 +42,7 @@ type ServiceImpl struct { // nolint:revive
 	namespaced.Client
 	HTTPClient          *http.Client
 	NotificationService sender.NotificationSender
+	PhoneLookupService  sender.PhoneLookupService
 	SignupService       service.SignupService
 }
 
@@ -53,10 +54,18 @@ func NewVerificationService(client namespaced.Client) service.VerificationServic
 		Timeout:   30*time.Second + 500*time.Millisecond, // taken from twilio code
 		Transport: http.DefaultTransport,
 	}
+	cfg := configuration.GetRegistrationServiceConfig()
+	verCfg := cfg.Verification()
 	return &ServiceImpl{
 		Client:              client,
+		HTTPClient:          httpClient,
 		NotificationService: sender.CreateNotificationSender(httpClient),
-		SignupService:       signupsvc.NewSignupService(client),
+		PhoneLookupService: sender.NewTwilioPhoneLookup(
+			verCfg.TwilioAccountSID(),
+			verCfg.TwilioAuthToken(),
+			httpClient,
+		),
+		SignupService: signupsvc.NewSignupService(client),
 	}
 }
 
@@ -81,6 +90,10 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 	if !states.VerificationRequired(signup) {
 		log.Info(ctx, fmt.Sprintf("phone verification attempted for user without verification requirement: '%s'", signup.Name))
 		return crterrors.NewBadRequest("forbidden request", "verification code will not be sent")
+	}
+
+	if signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey] == "rejected" {
+		return crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
 	}
 
 	// Check if the provided phone number is already being used by another user
@@ -142,27 +155,62 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 		log.Error(ctx, err, fmt.Sprintf("%d attempts made. the daily limit of %d has been exceeded", counter, dailyLimit))
 		initError = crterrors.NewForbiddenError("daily limit exceeded", "cannot generate new verification code")
 	} else {
-		// generate verification code
-		verificationCode, err := generateVerificationCode()
-		if err != nil {
-			return crterrors.NewInternalError(err, "error while generating verification code")
+		mode := cfg.Verification().PhoneLookupMode()
+		if mode != "disabled" && countryCode != "1" {
+			existingLookupHash := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey]
+			if existingLookupHash != phoneHash {
+				lookupCtx := gocontext.Background()
+				if ctx.Request != nil {
+					lookupCtx = ctx.Request.Context()
+				}
+				result, lookupErr := s.PhoneLookupService.LookupPhone(lookupCtx, e164PhoneNumber)
+				if lookupErr != nil {
+					log.Error(ctx, lookupErr, "phone lookup failed, proceeding (fail-open)")
+				} else {
+					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey] = phoneHash
+					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey] = result.CarrierRiskCategory
+					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey] = strconv.FormatBool(result.NumberBlocked)
+					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupRiskScoreAnnotationKey] = strconv.Itoa(result.RiskScore)
+					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupCarrierNameAnnotationKey] = result.CarrierName
+					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupLineTypeAnnotationKey] = result.LineType
+					if isHighRiskPhone(result) {
+						annotationValues[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey] = "rejected"
+						if mode == "enabled" {
+							initError = crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
+						} else {
+							log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t), proceeding (phone lookup mode=%s)",
+								result.CarrierRiskCategory, result.NumberBlocked, mode))
+						}
+					} else {
+						annotationValues[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey] = "allowed"
+					}
+				}
+			}
 		}
 
-		// Generate the verification message with the new verification code
-		content := fmt.Sprintf(cfg.Verification().MessageTemplate(), verificationCode)
+		if initError == nil {
+			// generate verification code
+			verificationCode, err := generateVerificationCode()
+			if err != nil {
+				return crterrors.NewInternalError(err, "error while generating verification code")
+			}
 
-		// Attempt to send notification
-		err = s.NotificationService.SendNotification(ctx, content, e164PhoneNumber, countryCode)
-		if err != nil {
-			log.Error(ctx, err, "error while sending notification")
-			initError = crterrors.NewInternalError(err, "error while sending verification code")
-		} else {
-			// Notification sent successfully, set the verification annotations
-			annotationValues[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = "0"
-			annotationValues[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = strconv.Itoa(counter + 1)
-			annotationValues[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey] = verificationCode
-			annotationValues[toolchainv1alpha1.UserVerificationExpiryAnnotationKey] = now.Add(
-				time.Duration(cfg.Verification().CodeExpiresInMin()) * time.Minute).Format(TimestampLayout)
+			// Generate the verification message with the new verification code
+			content := fmt.Sprintf(cfg.Verification().MessageTemplate(), verificationCode)
+
+			// Attempt to send notification
+			err = s.NotificationService.SendNotification(ctx, content, e164PhoneNumber, countryCode)
+			if err != nil {
+				log.Error(ctx, err, "error while sending notification")
+				initError = crterrors.NewInternalError(err, "error while sending verification code")
+			} else {
+				// Notification sent successfully, set the verification annotations
+				annotationValues[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey] = "0"
+				annotationValues[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey] = strconv.Itoa(counter + 1)
+				annotationValues[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey] = verificationCode
+				annotationValues[toolchainv1alpha1.UserVerificationExpiryAnnotationKey] = now.Add(
+					time.Duration(cfg.Verification().CodeExpiresInMin()) * time.Minute).Format(TimestampLayout)
+			}
 		}
 	}
 
@@ -201,6 +249,10 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 	}
 
 	return initError
+}
+
+func isHighRiskPhone(result *sender.PhoneLookupResult) bool {
+	return result.CarrierRiskCategory == "high" || result.NumberBlocked
 }
 
 func generateVerificationCode() (string, error) {

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -156,6 +156,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 		initError = crterrors.NewForbiddenError("daily limit exceeded", "cannot generate new verification code")
 	} else {
 		mode := cfg.Verification().PhoneLookupMode()
+		// Country code "1" is NANP (North American Numbering Plan), covering both US and Canada.
 		if mode != toolchainv1alpha1.PhoneLookupModeDisabled && countryCode != "1" {
 			existingLookupHash := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey]
 			if existingLookupHash != phoneHash {
@@ -251,6 +252,8 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 	return initError
 }
 
+// isHighRiskPhone returns true when Twilio Lookup reports the highest risk category ("high";
+// available categories are low, mild, moderate, high) or when the number is blocked.
 func isHighRiskPhone(result *sender.PhoneLookupResult) bool {
 	return result.CarrierRiskCategory == "high" || result.NumberBlocked
 }

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	gocontext "context"
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	signuppkg "github.com/codeready-toolchain/registration-service/pkg/signup"
 	signupsvc "github.com/codeready-toolchain/registration-service/pkg/signup/service"
 	"github.com/codeready-toolchain/registration-service/pkg/verification/sender"
+	"github.com/nyaruka/phonenumbers"
 	signupcommon "github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -42,7 +44,7 @@ type ServiceImpl struct { // nolint:revive
 	namespaced.Client
 	HTTPClient          *http.Client
 	NotificationService sender.NotificationSender
-	PhoneLookupService  sender.PhoneLookupService
+	PhoneLookupService  sender.PhoneLooker
 	SignupService       service.SignupService
 }
 
@@ -92,7 +94,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 		return crterrors.NewBadRequest("forbidden request", "verification code will not be sent")
 	}
 
-	if signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey] == "rejected" {
+	if isLookupRejected(signup) {
 		return crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
 	}
 
@@ -156,9 +158,10 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 		initError = crterrors.NewForbiddenError("daily limit exceeded", "cannot generate new verification code")
 	} else {
 		mode := cfg.Verification().PhoneLookupMode()
-		// Country code "1" is NANP (North American Numbering Plan), covering both US and Canada.
-		if mode != toolchainv1alpha1.PhoneLookupModeDisabled && countryCode != "1" {
-			existingLookupHash := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey]
+		excludedCountries := cfg.Verification().PhoneLookupExcludedCountries()
+		regionCode := regionCodeFromE164(e164PhoneNumber)
+		if mode != toolchainv1alpha1.PhoneLookupModeDisabled && !isCountryExcluded(regionCode, excludedCountries) {
+			existingLookupHash := phoneHashFromDetails(signup)
 			if existingLookupHash != phoneHash {
 				lookupCtx := gocontext.Background()
 				if ctx.Request != nil {
@@ -168,14 +171,16 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 				if lookupErr != nil {
 					log.Error(ctx, lookupErr, "phone lookup failed, proceeding (fail-open)")
 				} else {
-					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey] = phoneHash
 					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey] = result.CarrierRiskCategory
 					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey] = strconv.FormatBool(result.NumberBlocked)
-					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupRiskScoreAnnotationKey] = strconv.Itoa(result.RiskScore)
-					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupCarrierNameAnnotationKey] = result.CarrierName
-					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupLineTypeAnnotationKey] = result.LineType
+					details := map[string]string{
+						"risk_score":   strconv.Itoa(result.RiskScore),
+						"carrier_name": result.CarrierName,
+						"line_type":    result.LineType,
+						"phone_hash":   phoneHash,
+					}
 					if isHighRiskPhone(result) {
-						annotationValues[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey] = "rejected"
+						details["result"] = "rejected"
 						if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
 							initError = crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
 						} else {
@@ -183,8 +188,10 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 								result.CarrierRiskCategory, result.NumberBlocked, mode))
 						}
 					} else {
-						annotationValues[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey] = "allowed"
+						details["result"] = "allowed"
 					}
+					detailsJSON, _ := json.Marshal(details)
+					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = string(detailsJSON)
 				}
 			}
 		}
@@ -256,6 +263,52 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 // available categories are low, mild, moderate, high) or when the number is blocked.
 func isHighRiskPhone(result *sender.PhoneLookupResult) bool {
 	return result.CarrierRiskCategory == "high" || result.NumberBlocked
+}
+
+// regionCodeFromE164 parses an E.164 phone number and returns its ISO 3166-1 alpha-2 region code.
+// Returns empty string if parsing fails.
+func regionCodeFromE164(number string) string {
+	parsed, err := phonenumbers.Parse(number, "")
+	if err != nil {
+		return ""
+	}
+	return phonenumbers.GetRegionCodeForNumber(parsed)
+}
+
+// isCountryExcluded returns true if the given region code is in the excluded list.
+func isCountryExcluded(regionCode string, excluded []string) bool {
+	for _, c := range excluded {
+		if c == regionCode {
+			return true
+		}
+	}
+	return false
+}
+
+// isLookupRejected checks whether the phone lookup details annotation indicates rejection.
+func isLookupRejected(signup *toolchainv1alpha1.UserSignup) bool {
+	raw := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey]
+	if raw == "" {
+		return false
+	}
+	var details map[string]string
+	if err := json.Unmarshal([]byte(raw), &details); err != nil {
+		return false
+	}
+	return details["result"] == "rejected"
+}
+
+// phoneHashFromDetails extracts the phone_hash from the JSON details annotation.
+func phoneHashFromDetails(signup *toolchainv1alpha1.UserSignup) string {
+	raw := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey]
+	if raw == "" {
+		return ""
+	}
+	var details map[string]string
+	if err := json.Unmarshal([]byte(raw), &details); err != nil {
+		return ""
+	}
+	return details["phone_hash"]
 }
 
 func generateVerificationCode() (string, error) {

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -159,42 +159,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 		log.Error(ctx, err, fmt.Sprintf("%d attempts made. the daily limit of %d has been exceeded", counter, dailyLimit))
 		initError = crterrors.NewForbiddenError("daily limit exceeded", "cannot generate new verification code")
 	} else {
-		mode := cfg.Verification().PhoneLookupMode()
-		excludedCountries := cfg.Verification().PhoneLookupExcludedCountries()
-		isoCountryCode, parseErr := countryCodeFromE164(e164PhoneNumber)
-		if parseErr != nil {
-			log.Error(ctx, parseErr, fmt.Sprintf("failed to parse country code from phone number %q", e164PhoneNumber))
-		}
-		if mode != toolchainv1alpha1.PhoneLookupModeDisabled && !slices.Contains(excludedCountries, isoCountryCode) {
-			existingLookupHash := signup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey]
-			if existingLookupHash != phoneHash {
-				lookupCtx := gocontext.Background()
-				if ctx.Request != nil {
-					lookupCtx = ctx.Request.Context()
-				}
-				result, lookupErr := s.PhoneLookupService.LookupPhone(lookupCtx, e164PhoneNumber)
-				if lookupErr != nil {
-					log.Error(ctx, lookupErr, "phone lookup failed, proceeding (fail-open)")
-				} else {
-					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey] = result.CarrierRiskCategory
-					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey] = strconv.FormatBool(result.NumberBlocked)
-					if isHighRiskPhone(result) {
-						if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
-							initError = crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
-							rejectSignup = true
-						} else {
-							log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t), proceeding (phone lookup mode=%s)",
-								result.CarrierRiskCategory, result.NumberBlocked, mode))
-						}
-					}
-					detailsJSON, err := json.Marshal(result.PhoneLookupResultDetails)
-					if err != nil {
-						log.Error(ctx, err, "failed to marshal phone lookup details")
-					}
-					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = string(detailsJSON)
-				}
-			}
-		}
+		rejectSignup, initError = s.performPhoneLookup(ctx, cfg, signup, e164PhoneNumber, phoneHash, annotationValues)
 
 		if initError == nil {
 			// generate verification code
@@ -261,6 +226,53 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 	}
 
 	return initError
+}
+
+// performPhoneLookup runs the Twilio Lookup API check if applicable and populates annotationValues.
+// Returns whether the signup should be rejected and any blocking error.
+func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.RegistrationServiceConfig,
+	signup *toolchainv1alpha1.UserSignup, e164PhoneNumber, phoneHash string,
+	annotationValues map[string]string) (rejectSignup bool, initError error) {
+
+	mode := cfg.Verification().PhoneLookupMode()
+	excludedCountries := cfg.Verification().PhoneLookupExcludedCountries()
+	isoCountryCode, parseErr := countryCodeFromE164(e164PhoneNumber)
+	if parseErr != nil {
+		log.Error(ctx, parseErr, fmt.Sprintf("failed to parse country code from phone number %q", e164PhoneNumber))
+	}
+	if mode == toolchainv1alpha1.PhoneLookupModeDisabled || slices.Contains(excludedCountries, isoCountryCode) {
+		return false, nil
+	}
+	existingLookupHash := signup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey]
+	if existingLookupHash == phoneHash {
+		return false, nil
+	}
+	lookupCtx := gocontext.Background()
+	if ctx.Request != nil {
+		lookupCtx = ctx.Request.Context()
+	}
+	result, lookupErr := s.PhoneLookupService.LookupPhone(lookupCtx, e164PhoneNumber)
+	if lookupErr != nil {
+		log.Error(ctx, lookupErr, "phone lookup failed, proceeding (fail-open)")
+		return false, nil
+	}
+	annotationValues[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey] = result.CarrierRiskCategory
+	annotationValues[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey] = strconv.FormatBool(result.NumberBlocked)
+	if isHighRiskPhone(result) {
+		if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
+			initError = crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
+			rejectSignup = true
+		} else {
+			log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t), proceeding (phone lookup mode=%s)",
+				result.CarrierRiskCategory, result.NumberBlocked, mode))
+		}
+	}
+	detailsJSON, err := json.Marshal(result.PhoneLookupResultDetails)
+	if err != nil {
+		log.Error(ctx, err, "failed to marshal phone lookup details")
+	}
+	annotationValues[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = string(detailsJSON)
+	return rejectSignup, initError
 }
 
 // isHighRiskPhone returns true when Twilio Lookup reports the highest risk category ("high";

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -232,7 +232,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 // Returns whether the signup should be rejected and any blocking error.
 func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.RegistrationServiceConfig,
 	signup *toolchainv1alpha1.UserSignup, e164PhoneNumber, phoneHash string,
-	annotationValues map[string]string) (rejectSignup bool, initError error) {
+	annotationValues map[string]string) (bool, error) {
 
 	mode := cfg.Verification().PhoneLookupMode()
 	excludedCountries := cfg.Verification().PhoneLookupExcludedCountries()
@@ -254,21 +254,20 @@ func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.Reg
 	}
 	annotationValues[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey] = result.CarrierRiskCategory
 	annotationValues[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey] = strconv.FormatBool(result.NumberBlocked)
-	if isHighRiskPhone(result) {
-		log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t, phone_lookup_mode=%s)",
-			result.CarrierRiskCategory, result.NumberBlocked, mode))
-		if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
-			initError = crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
-			rejectSignup = true
-		}
-	}
 	detailsJSON, err := json.Marshal(result.PhoneLookupResultDetails)
 	if err != nil {
 		log.Error(ctx, err, "failed to marshal phone lookup details")
 	} else {
 		annotationValues[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = string(detailsJSON)
 	}
-	return rejectSignup, initError
+	if isHighRiskPhone(result) {
+		log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t, phone_lookup_mode=%s)",
+			result.CarrierRiskCategory, result.NumberBlocked, mode))
+		if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
+			return true, crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
+		}
+	}
+	return false, nil
 }
 
 // isHighRiskPhone returns true when Twilio Lookup reports the highest risk category ("high";

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -16,7 +16,6 @@ import (
 	signuppkg "github.com/codeready-toolchain/registration-service/pkg/signup"
 	signupsvc "github.com/codeready-toolchain/registration-service/pkg/signup/service"
 	"github.com/codeready-toolchain/registration-service/pkg/verification/sender"
-	"github.com/nyaruka/phonenumbers"
 	signupcommon "github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 
 	"github.com/gin-gonic/gin"
+	"github.com/nyaruka/phonenumbers"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -190,7 +190,10 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 					} else {
 						details["result"] = "allowed"
 					}
-					detailsJSON, _ := json.Marshal(details)
+					detailsJSON, err := json.Marshal(details)
+					if err != nil {
+						log.Error(ctx, err, "failed to marshal phone lookup details")
+					}
 					annotationValues[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = string(detailsJSON)
 				}
 			}

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -247,11 +247,7 @@ func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.Reg
 	if existingLookupHash == phoneHash {
 		return false, nil
 	}
-	lookupCtx := gocontext.Background()
-	if ctx.Request != nil {
-		lookupCtx = ctx.Request.Context()
-	}
-	result, lookupErr := s.PhoneLookupService.LookupPhone(lookupCtx, e164PhoneNumber)
+	result, lookupErr := s.PhoneLookupService.LookupPhone(e164PhoneNumber)
 	if lookupErr != nil {
 		log.Error(ctx, lookupErr, "phone lookup failed, proceeding (fail-open)")
 		return false, nil

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -161,7 +161,7 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 		excludedCountries := cfg.Verification().PhoneLookupExcludedCountries()
 		regionCode := regionCodeFromE164(e164PhoneNumber)
 		if mode != toolchainv1alpha1.PhoneLookupModeDisabled && !isCountryExcluded(regionCode, excludedCountries) {
-			existingLookupHash := phoneHashFromDetails(signup)
+			existingLookupHash := signup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey]
 			if existingLookupHash != phoneHash {
 				lookupCtx := gocontext.Background()
 				if ctx.Request != nil {
@@ -177,7 +177,6 @@ func (s *ServiceImpl) InitVerification(ctx *gin.Context, username, e164PhoneNumb
 						"risk_score":   strconv.Itoa(result.RiskScore),
 						"carrier_name": result.CarrierName,
 						"line_type":    result.LineType,
-						"phone_hash":   phoneHash,
 					}
 					if isHighRiskPhone(result) {
 						details["result"] = "rejected"
@@ -299,19 +298,6 @@ func isLookupRejected(signup *toolchainv1alpha1.UserSignup) bool {
 		return false
 	}
 	return details["result"] == "rejected"
-}
-
-// phoneHashFromDetails extracts the phone_hash from the JSON details annotation.
-func phoneHashFromDetails(signup *toolchainv1alpha1.UserSignup) string {
-	raw := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey]
-	if raw == "" {
-		return ""
-	}
-	var details map[string]string
-	if err := json.Unmarshal([]byte(raw), &details); err != nil {
-		return ""
-	}
-	return details["phone_hash"]
 }
 
 func generateVerificationCode() (string, error) {

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -874,7 +874,7 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 
 const lookupUKPhone = "+447700900000"
 
-func (s *TestVerificationServiceSuite) setPhoneLookupMode(mode string) {
+func (s *TestVerificationServiceSuite) setPhoneLookupMode(mode toolchainv1alpha1.PhoneLookupMode) {
 	s.SetConfig(testconfig.RegistrationService().Verification().PhoneLookupMode(mode))
 }
 
@@ -919,7 +919,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 	s.Run("lookup high risk and mode enabled", func() {
 		defer gock.Off()
-		s.setPhoneLookupMode("enabled")
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
 		mockTwilioLookup(lookupUKPhone, highRiskBody)
 
 		userSignup := testusersignup.NewUserSignup(
@@ -943,7 +943,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 	s.Run("lookup high risk and mode log", func() {
 		defer gock.Off()
-		s.setPhoneLookupMode("log")
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog)
 		mockTwilioLookup(lookupUKPhone, highRiskBody)
 		mockTwilioSMS()
 
@@ -965,7 +965,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 	s.Run("lookup low risk", func() {
 		defer gock.Off()
-		s.setPhoneLookupMode("enabled")
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
 		mockTwilioLookup(lookupUKPhone, lowRiskBody)
 		mockTwilioSMS()
 
@@ -987,7 +987,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 	s.Run("lookup API error fail open", func() {
 		defer gock.Off()
-		s.setPhoneLookupMode("enabled")
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
 		gock.New("https://lookups.twilio.com").
 			Get("/v2/PhoneNumbers/" + lookupUKPhone).
 			Reply(http.StatusInternalServerError)
@@ -1010,7 +1010,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 	s.Run("country code US skips lookup", func() {
 		defer gock.Off()
-		s.setPhoneLookupMode("enabled")
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
 		mockTwilioSMS()
 
 		userSignup := testusersignup.NewUserSignup(
@@ -1031,7 +1031,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 	s.Run("mode disabled skips lookup", func() {
 		defer gock.Off()
-		s.setPhoneLookupMode("disabled")
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeDisabled)
 		mockTwilioSMS()
 
 		userSignup := testusersignup.NewUserSignup(
@@ -1052,7 +1052,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 	s.Run("already rejected usersignup retries", func() {
 		defer gock.Off()
-		s.setPhoneLookupMode("enabled")
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
 
 		userSignup := testusersignup.NewUserSignup(
 			testusersignup.WithEncodedName("lookup-retry@kubesaw"),
@@ -1071,7 +1071,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 	s.Run("same phone retry skips lookup", func() {
 		defer gock.Off()
-		s.setPhoneLookupMode("enabled")
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
 		mockTwilioSMS()
 
 		phoneHash := hash.EncodeString(lookupUKPhone)
@@ -1094,7 +1094,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 	s.Run("different phone retry calls lookup", func() {
 		defer gock.Off()
-		s.setPhoneLookupMode("enabled")
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
 		newPhone := "+447700900001"
 		mockTwilioLookup(newPhone, lowRiskBody)
 		mockTwilioSMS()

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -899,6 +899,57 @@ func mockTwilioSMS() {
 		BodyString("")
 }
 
+type initVerificationPhoneLookupCase struct {
+	name           string
+	mode           toolchainv1alpha1.PhoneLookupMode
+	username       string
+	phone          string
+	countryCode    string
+	signupOpts     []testusersignup.Modifier
+	setupMocks     func(highRiskBody, lowRiskBody map[string]interface{})
+	wantErr        bool
+	wantErrStatus  int
+	assertSignup   func(updated *toolchainv1alpha1.UserSignup)
+	assertGockDone bool
+}
+
+func (s *TestVerificationServiceSuite) runInitVerificationPhoneLookupCase(tc initVerificationPhoneLookupCase, highRiskBody, lowRiskBody map[string]interface{}) {
+	defer gock.Off()
+	s.setPhoneLookupMode(tc.mode)
+	if tc.setupMocks != nil {
+		tc.setupMocks(highRiskBody, lowRiskBody)
+	}
+
+	opts := append([]testusersignup.Modifier{
+		testusersignup.WithEncodedName(tc.username),
+		testusersignup.VerificationRequiredAgo(time.Second),
+	}, tc.signupOpts...)
+	userSignup := testusersignup.NewUserSignup(opts...)
+	fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+	err := application.VerificationService().InitVerification(newInitVerificationContext(), tc.username, tc.phone, tc.countryCode)
+	if tc.wantErr {
+		require.Error(s.T(), err)
+		if tc.wantErrStatus != 0 {
+			var e *crterrors.Error
+			require.ErrorAs(s.T(), err, &e)
+			assert.Equal(s.T(), tc.wantErrStatus, e.Code)
+		}
+	} else {
+		require.NoError(s.T(), err)
+	}
+
+	if tc.assertSignup != nil {
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		tc.assertSignup(updated)
+	}
+
+	if tc.assertGockDone {
+		assert.True(s.T(), gock.IsDone())
+	}
+}
+
 func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 	s.ServiceConfiguration("xxx", "yyy", "CodeReady")
 
@@ -917,206 +968,161 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		},
 	}
 
-	s.Run("lookup high risk and mode enabled", func() {
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
-		mockTwilioLookup(lookupUKPhone, highRiskBody)
+	cases := []initVerificationPhoneLookupCase{
+		{
+			name:        "lookup high risk and mode enabled",
+			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
+			username:    "lookup@kubesaw",
+			phone:       lookupUKPhone,
+			countryCode: "44",
+			setupMocks: func(_, _ map[string]interface{}) {
+				mockTwilioLookup(lookupUKPhone, highRiskBody)
+			},
+			wantErr:       true,
+			wantErrStatus: http.StatusForbidden,
+			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
+				assert.Equal(s.T(), "rejected", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+				assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+			},
+			assertGockDone: true,
+		},
+		{
+			name:        "lookup high risk and mode log",
+			mode:        toolchainv1alpha1.PhoneLookupModeLog,
+			username:    "lookup-log@kubesaw",
+			phone:       lookupUKPhone,
+			countryCode: "44",
+			setupMocks: func(_, _ map[string]interface{}) {
+				mockTwilioLookup(lookupUKPhone, highRiskBody)
+				mockTwilioSMS()
+			},
+			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
+				assert.Equal(s.T(), "rejected", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+			},
+			assertGockDone: true,
+		},
+		{
+			name:        "lookup low risk",
+			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
+			username:    "lookup-ok@kubesaw",
+			phone:       lookupUKPhone,
+			countryCode: "44",
+			setupMocks: func(_, lowRiskBody map[string]interface{}) {
+				mockTwilioLookup(lookupUKPhone, lowRiskBody)
+				mockTwilioSMS()
+			},
+			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
+				assert.Equal(s.T(), "allowed", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+				assert.Equal(s.T(), hash.EncodeString(lookupUKPhone), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
+				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+			},
+		},
+		{
+			name:        "lookup API error fail open",
+			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
+			username:    "lookup-err@kubesaw",
+			phone:       lookupUKPhone,
+			countryCode: "44",
+			setupMocks: func(_, _ map[string]interface{}) {
+				gock.New("https://lookups.twilio.com").
+					Get("/v2/PhoneNumbers/" + lookupUKPhone).
+					Reply(http.StatusInternalServerError)
+				mockTwilioSMS()
+			},
+			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
+				assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+			},
+		},
+		{
+			name:        "country code US skips lookup",
+			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
+			username:    "lookup-us@kubesaw",
+			phone:       "+1NUMBER",
+			countryCode: "1",
+			setupMocks: func(_, _ map[string]interface{}) {
+				mockTwilioSMS()
+			},
+			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
+				assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+			},
+			assertGockDone: true,
+		},
+		{
+			name:        "mode disabled skips lookup",
+			mode:        toolchainv1alpha1.PhoneLookupModeDisabled,
+			username:    "lookup-off@kubesaw",
+			phone:       lookupUKPhone,
+			countryCode: "44",
+			setupMocks: func(_, _ map[string]interface{}) {
+				mockTwilioSMS()
+			},
+			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
+				assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+			},
+			assertGockDone: true,
+		},
+		{
+			name:        "already rejected usersignup retries",
+			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
+			username:    "lookup-retry@kubesaw",
+			phone:       lookupUKPhone,
+			countryCode: "44",
+			signupOpts: []testusersignup.Modifier{
+				testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "rejected"),
+			},
+			wantErr:        true,
+			wantErrStatus:  http.StatusForbidden,
+			assertGockDone: true,
+		},
+		{
+			name:        "same phone retry skips lookup",
+			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
+			username:    "lookup-same@kubesaw",
+			phone:       lookupUKPhone,
+			countryCode: "44",
+			signupOpts: []testusersignup.Modifier{
+				testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey, hash.EncodeString(lookupUKPhone)),
+				testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "allowed"),
+			},
+			setupMocks: func(_, _ map[string]interface{}) {
+				mockTwilioSMS()
+			},
+			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
+				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+			},
+			assertGockDone: true,
+		},
+		{
+			name:        "different phone retry calls lookup",
+			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
+			username:    "lookup-diff@kubesaw",
+			phone:       "+447700900001",
+			countryCode: "44",
+			signupOpts: []testusersignup.Modifier{
+				testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey, hash.EncodeString(lookupUKPhone)),
+				testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "allowed"),
+			},
+			setupMocks: func(_, lowRiskBody map[string]interface{}) {
+				mockTwilioLookup("+447700900001", lowRiskBody)
+				mockTwilioSMS()
+			},
+			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
+				assert.Equal(s.T(), hash.EncodeString("+447700900001"), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
+				assert.Equal(s.T(), "allowed", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+			},
+		},
+	}
 
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup@kubesaw"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		ctx := newInitVerificationContext()
-		err := application.VerificationService().InitVerification(ctx, "lookup@kubesaw", lookupUKPhone, "44")
-		require.Error(s.T(), err)
-		var e *crterrors.Error
-		require.ErrorAs(s.T(), err, &e)
-		assert.Equal(s.T(), http.StatusForbidden, e.Code)
-
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assert.Equal(s.T(), "rejected", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-		assert.True(s.T(), gock.IsDone())
-	})
-
-	s.Run("lookup high risk and mode log", func() {
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog)
-		mockTwilioLookup(lookupUKPhone, highRiskBody)
-		mockTwilioSMS()
-
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-log@kubesaw"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		ctx := newInitVerificationContext()
-		err := application.VerificationService().InitVerification(ctx, "lookup-log@kubesaw", lookupUKPhone, "44")
-		require.NoError(s.T(), err)
-
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assert.Equal(s.T(), "rejected", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-		assert.True(s.T(), gock.IsDone())
-	})
-
-	s.Run("lookup low risk", func() {
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
-		mockTwilioLookup(lookupUKPhone, lowRiskBody)
-		mockTwilioSMS()
-
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-ok@kubesaw"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		ctx := newInitVerificationContext()
-		err := application.VerificationService().InitVerification(ctx, "lookup-ok@kubesaw", lookupUKPhone, "44")
-		require.NoError(s.T(), err)
-
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assert.Equal(s.T(), "allowed", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-		assert.Equal(s.T(), hash.EncodeString(lookupUKPhone), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
-		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-	})
-
-	s.Run("lookup API error fail open", func() {
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
-		gock.New("https://lookups.twilio.com").
-			Get("/v2/PhoneNumbers/" + lookupUKPhone).
-			Reply(http.StatusInternalServerError)
-		mockTwilioSMS()
-
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-err@kubesaw"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		ctx := newInitVerificationContext()
-		err := application.VerificationService().InitVerification(ctx, "lookup-err@kubesaw", lookupUKPhone, "44")
-		require.NoError(s.T(), err)
-
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-	})
-
-	s.Run("country code US skips lookup", func() {
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
-		mockTwilioSMS()
-
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-us@kubesaw"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		ctx := newInitVerificationContext()
-		err := application.VerificationService().InitVerification(ctx, "lookup-us@kubesaw", "+1NUMBER", "1")
-		require.NoError(s.T(), err)
-
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-		assert.True(s.T(), gock.IsDone())
-	})
-
-	s.Run("mode disabled skips lookup", func() {
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeDisabled)
-		mockTwilioSMS()
-
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-off@kubesaw"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		ctx := newInitVerificationContext()
-		err := application.VerificationService().InitVerification(ctx, "lookup-off@kubesaw", lookupUKPhone, "44")
-		require.NoError(s.T(), err)
-
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-		assert.True(s.T(), gock.IsDone())
-	})
-
-	s.Run("already rejected usersignup retries", func() {
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
-
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-retry@kubesaw"),
-			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "rejected"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		ctx := newInitVerificationContext()
-		err := application.VerificationService().InitVerification(ctx, "lookup-retry@kubesaw", lookupUKPhone, "44")
-		require.Error(s.T(), err)
-		var e *crterrors.Error
-		require.ErrorAs(s.T(), err, &e)
-		assert.Equal(s.T(), http.StatusForbidden, e.Code)
-		assert.True(s.T(), gock.IsDone())
-	})
-
-	s.Run("same phone retry skips lookup", func() {
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
-		mockTwilioSMS()
-
-		phoneHash := hash.EncodeString(lookupUKPhone)
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-same@kubesaw"),
-			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey, phoneHash),
-			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "allowed"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		ctx := newInitVerificationContext()
-		err := application.VerificationService().InitVerification(ctx, "lookup-same@kubesaw", lookupUKPhone, "44")
-		require.NoError(s.T(), err)
-
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-		assert.True(s.T(), gock.IsDone())
-	})
-
-	s.Run("different phone retry calls lookup", func() {
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
-		newPhone := "+447700900001"
-		mockTwilioLookup(newPhone, lowRiskBody)
-		mockTwilioSMS()
-
-		phoneHash := hash.EncodeString(lookupUKPhone)
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-diff@kubesaw"),
-			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey, phoneHash),
-			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "allowed"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		ctx := newInitVerificationContext()
-		err := application.VerificationService().InitVerification(ctx, "lookup-diff@kubesaw", newPhone, "44")
-		require.NoError(s.T(), err)
-
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assert.Equal(s.T(), hash.EncodeString(newPhone), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
-		assert.Equal(s.T(), "allowed", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-	})
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			s.runInitVerificationPhoneLookupCase(tc, highRiskBody, lowRiskBody)
+		})
+	}
 }
 
 func (s *TestVerificationServiceSuite) TestPhoneNumberAlreadyInUse() {

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -872,6 +872,253 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 
 }
 
+const lookupUKPhone = "+447700900000"
+
+func (s *TestVerificationServiceSuite) setPhoneLookupMode(mode string) {
+	s.SetConfig(testconfig.RegistrationService().Verification().PhoneLookupMode(mode))
+}
+
+func newInitVerificationContext() (*gin.Context, *httptest.ResponseRecorder) {
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+	return ctx, recorder
+}
+
+func mockTwilioLookup(phone string, body interface{}) {
+	gock.New("https://lookups.twilio.com").
+		Get("/v2/PhoneNumbers/" + phone).
+		MatchParam("Fields", "sms_pumping_risk,line_type_intelligence").
+		Reply(http.StatusOK).
+		JSON(body)
+}
+
+func mockTwilioSMS() {
+	gock.New("https://api.twilio.com").
+		Reply(http.StatusNoContent).
+		BodyString("")
+}
+
+func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
+	s.ServiceConfiguration("xxx", "yyy", "CodeReady")
+
+	highRiskBody := map[string]interface{}{
+		"sms_pumping_risk": map[string]interface{}{
+			"carrier_risk_category":  "high",
+			"number_blocked":         true,
+			"sms_pumping_risk_score": 34,
+		},
+	}
+	lowRiskBody := map[string]interface{}{
+		"sms_pumping_risk": map[string]interface{}{
+			"carrier_risk_category":  "low",
+			"number_blocked":         false,
+			"sms_pumping_risk_score": 2,
+		},
+	}
+
+	s.Run("lookup high risk and mode enabled", func() {
+		defer gock.Off()
+		s.setPhoneLookupMode("enabled")
+		mockTwilioLookup(lookupUKPhone, highRiskBody)
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		ctx, _ := newInitVerificationContext()
+		err := application.VerificationService().InitVerification(ctx, "lookup@kubesaw", lookupUKPhone, "44")
+		require.Error(s.T(), err)
+		var e *crterrors.Error
+		require.True(s.T(), errors.As(err, &e))
+		assert.Equal(s.T(), http.StatusForbidden, e.Code)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.Equal(s.T(), "rejected", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("lookup high risk and mode log", func() {
+		defer gock.Off()
+		s.setPhoneLookupMode("log")
+		mockTwilioLookup(lookupUKPhone, highRiskBody)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-log@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		ctx, _ := newInitVerificationContext()
+		err := application.VerificationService().InitVerification(ctx, "lookup-log@kubesaw", lookupUKPhone, "44")
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.Equal(s.T(), "rejected", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("lookup low risk", func() {
+		defer gock.Off()
+		s.setPhoneLookupMode("enabled")
+		mockTwilioLookup(lookupUKPhone, lowRiskBody)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-ok@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		ctx, _ := newInitVerificationContext()
+		err := application.VerificationService().InitVerification(ctx, "lookup-ok@kubesaw", lookupUKPhone, "44")
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.Equal(s.T(), "allowed", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+		assert.Equal(s.T(), hash.EncodeString(lookupUKPhone), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	})
+
+	s.Run("lookup API error fail open", func() {
+		defer gock.Off()
+		s.setPhoneLookupMode("enabled")
+		gock.New("https://lookups.twilio.com").
+			Get("/v2/PhoneNumbers/" + lookupUKPhone).
+			Reply(http.StatusInternalServerError)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-err@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		ctx, _ := newInitVerificationContext()
+		err := application.VerificationService().InitVerification(ctx, "lookup-err@kubesaw", lookupUKPhone, "44")
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	})
+
+	s.Run("country code US skips lookup", func() {
+		defer gock.Off()
+		s.setPhoneLookupMode("enabled")
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-us@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		ctx, _ := newInitVerificationContext()
+		err := application.VerificationService().InitVerification(ctx, "lookup-us@kubesaw", "+1NUMBER", "1")
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("mode disabled skips lookup", func() {
+		defer gock.Off()
+		s.setPhoneLookupMode("disabled")
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-off@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		ctx, _ := newInitVerificationContext()
+		err := application.VerificationService().InitVerification(ctx, "lookup-off@kubesaw", lookupUKPhone, "44")
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("already rejected usersignup retries", func() {
+		defer gock.Off()
+		s.setPhoneLookupMode("enabled")
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-retry@kubesaw"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "rejected"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		ctx, _ := newInitVerificationContext()
+		err := application.VerificationService().InitVerification(ctx, "lookup-retry@kubesaw", lookupUKPhone, "44")
+		require.Error(s.T(), err)
+		var e *crterrors.Error
+		require.True(s.T(), errors.As(err, &e))
+		assert.Equal(s.T(), http.StatusForbidden, e.Code)
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("same phone retry skips lookup", func() {
+		defer gock.Off()
+		s.setPhoneLookupMode("enabled")
+		mockTwilioSMS()
+
+		phoneHash := hash.EncodeString(lookupUKPhone)
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-same@kubesaw"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey, phoneHash),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "allowed"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		ctx, _ := newInitVerificationContext()
+		err := application.VerificationService().InitVerification(ctx, "lookup-same@kubesaw", lookupUKPhone, "44")
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("different phone retry calls lookup", func() {
+		defer gock.Off()
+		s.setPhoneLookupMode("enabled")
+		newPhone := "+447700900001"
+		mockTwilioLookup(newPhone, lowRiskBody)
+		mockTwilioSMS()
+
+		phoneHash := hash.EncodeString(lookupUKPhone)
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-diff@kubesaw"),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey, phoneHash),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "allowed"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		ctx, _ := newInitVerificationContext()
+		err := application.VerificationService().InitVerification(ctx, "lookup-diff@kubesaw", newPhone, "44")
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.Equal(s.T(), hash.EncodeString(newPhone), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
+		assert.Equal(s.T(), "allowed", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	})
+}
+
 func (s *TestVerificationServiceSuite) TestPhoneNumberAlreadyInUse() {
 	bannedUser := &toolchainv1alpha1.BannedUser{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -878,16 +878,16 @@ func (s *TestVerificationServiceSuite) setPhoneLookupMode(mode string) {
 	s.SetConfig(testconfig.RegistrationService().Verification().PhoneLookupMode(mode))
 }
 
-func newInitVerificationContext() (*gin.Context, *httptest.ResponseRecorder) {
+func newInitVerificationContext() *gin.Context {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodPost, "/", nil)
-	return ctx, recorder
+	return ctx
 }
 
 func mockTwilioLookup(phone string, body interface{}) {
 	gock.New("https://lookups.twilio.com").
-		Get("/v2/PhoneNumbers/" + phone).
+		Get("/v2/PhoneNumbers/"+phone).
 		MatchParam("Fields", "sms_pumping_risk,line_type_intelligence").
 		Reply(http.StatusOK).
 		JSON(body)
@@ -927,11 +927,11 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			testusersignup.VerificationRequiredAgo(time.Second))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
-		ctx, _ := newInitVerificationContext()
+		ctx := newInitVerificationContext()
 		err := application.VerificationService().InitVerification(ctx, "lookup@kubesaw", lookupUKPhone, "44")
 		require.Error(s.T(), err)
 		var e *crterrors.Error
-		require.True(s.T(), errors.As(err, &e))
+		require.ErrorAs(s.T(), err, &e)
 		assert.Equal(s.T(), http.StatusForbidden, e.Code)
 
 		updated := &toolchainv1alpha1.UserSignup{}
@@ -952,7 +952,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			testusersignup.VerificationRequiredAgo(time.Second))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
-		ctx, _ := newInitVerificationContext()
+		ctx := newInitVerificationContext()
 		err := application.VerificationService().InitVerification(ctx, "lookup-log@kubesaw", lookupUKPhone, "44")
 		require.NoError(s.T(), err)
 
@@ -974,7 +974,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			testusersignup.VerificationRequiredAgo(time.Second))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
-		ctx, _ := newInitVerificationContext()
+		ctx := newInitVerificationContext()
 		err := application.VerificationService().InitVerification(ctx, "lookup-ok@kubesaw", lookupUKPhone, "44")
 		require.NoError(s.T(), err)
 
@@ -998,7 +998,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			testusersignup.VerificationRequiredAgo(time.Second))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
-		ctx, _ := newInitVerificationContext()
+		ctx := newInitVerificationContext()
 		err := application.VerificationService().InitVerification(ctx, "lookup-err@kubesaw", lookupUKPhone, "44")
 		require.NoError(s.T(), err)
 
@@ -1018,7 +1018,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			testusersignup.VerificationRequiredAgo(time.Second))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
-		ctx, _ := newInitVerificationContext()
+		ctx := newInitVerificationContext()
 		err := application.VerificationService().InitVerification(ctx, "lookup-us@kubesaw", "+1NUMBER", "1")
 		require.NoError(s.T(), err)
 
@@ -1039,7 +1039,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			testusersignup.VerificationRequiredAgo(time.Second))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
-		ctx, _ := newInitVerificationContext()
+		ctx := newInitVerificationContext()
 		err := application.VerificationService().InitVerification(ctx, "lookup-off@kubesaw", lookupUKPhone, "44")
 		require.NoError(s.T(), err)
 
@@ -1060,11 +1060,11 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			testusersignup.VerificationRequiredAgo(time.Second))
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
-		ctx, _ := newInitVerificationContext()
+		ctx := newInitVerificationContext()
 		err := application.VerificationService().InitVerification(ctx, "lookup-retry@kubesaw", lookupUKPhone, "44")
 		require.Error(s.T(), err)
 		var e *crterrors.Error
-		require.True(s.T(), errors.As(err, &e))
+		require.ErrorAs(s.T(), err, &e)
 		assert.Equal(s.T(), http.StatusForbidden, e.Code)
 		assert.True(s.T(), gock.IsDone())
 	})
@@ -1082,7 +1082,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			testusersignup.VerificationRequiredAgo(time.Second))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
-		ctx, _ := newInitVerificationContext()
+		ctx := newInitVerificationContext()
 		err := application.VerificationService().InitVerification(ctx, "lookup-same@kubesaw", lookupUKPhone, "44")
 		require.NoError(s.T(), err)
 
@@ -1107,7 +1107,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			testusersignup.VerificationRequiredAgo(time.Second))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
-		ctx, _ := newInitVerificationContext()
+		ctx := newInitVerificationContext()
 		err := application.VerificationService().InitVerification(ctx, "lookup-diff@kubesaw", newPhone, "44")
 		require.NoError(s.T(), err)
 

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -900,7 +900,10 @@ func phoneLookupDetailsJSON(result, phoneHash string) string {
 		"result":     result,
 		"phone_hash": phoneHash,
 	}
-	b, _ := json.Marshal(details)
+	b, err := json.Marshal(details)
+	if err != nil {
+		panic(err)
+	}
 	return string(b)
 }
 

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"bytes"
 	gocontext "context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -875,14 +876,9 @@ func (s *TestVerificationServiceSuite) testVerifyActivationCode(targetCluster st
 const lookupUKPhone = "+447700900000"
 
 func (s *TestVerificationServiceSuite) setPhoneLookupMode(mode toolchainv1alpha1.PhoneLookupMode) {
-	s.SetConfig(testconfig.RegistrationService().Verification().PhoneLookupMode(mode))
-}
-
-func newInitVerificationContext() *gin.Context {
-	recorder := httptest.NewRecorder()
-	ctx, _ := gin.CreateTestContext(recorder)
-	ctx.Request = httptest.NewRequest(http.MethodPost, "/", nil)
-	return ctx
+	s.SetConfig(testconfig.RegistrationService().
+		Verification().PhoneLookupMode(mode).
+		Verification().PhoneLookupExcludedCountries([]string{"US", "CA"}))
 }
 
 func mockTwilioLookup(phone string, body interface{}) {
@@ -899,55 +895,23 @@ func mockTwilioSMS() {
 		BodyString("")
 }
 
-type initVerificationPhoneLookupCase struct {
-	name           string
-	mode           toolchainv1alpha1.PhoneLookupMode
-	username       string
-	phone          string
-	countryCode    string
-	signupOpts     []testusersignup.Modifier
-	setupMocks     func(highRiskBody, lowRiskBody map[string]interface{})
-	wantErr        bool
-	wantErrStatus  int
-	assertSignup   func(updated *toolchainv1alpha1.UserSignup)
-	assertGockDone bool
+func phoneLookupDetailsJSON(result, phoneHash string) string {
+	details := map[string]string{
+		"result":     result,
+		"phone_hash": phoneHash,
+	}
+	b, _ := json.Marshal(details)
+	return string(b)
 }
 
-func (s *TestVerificationServiceSuite) runInitVerificationPhoneLookupCase(tc initVerificationPhoneLookupCase, highRiskBody, lowRiskBody map[string]interface{}) {
-	defer gock.Off()
-	s.setPhoneLookupMode(tc.mode)
-	if tc.setupMocks != nil {
-		tc.setupMocks(highRiskBody, lowRiskBody)
-	}
-
-	opts := append([]testusersignup.Modifier{
-		testusersignup.WithEncodedName(tc.username),
-		testusersignup.VerificationRequiredAgo(time.Second),
-	}, tc.signupOpts...)
-	userSignup := testusersignup.NewUserSignup(opts...)
-	fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-	err := application.VerificationService().InitVerification(newInitVerificationContext(), tc.username, tc.phone, tc.countryCode)
-	if tc.wantErr {
-		require.Error(s.T(), err)
-		if tc.wantErrStatus != 0 {
-			var e *crterrors.Error
-			require.ErrorAs(s.T(), err, &e)
-			assert.Equal(s.T(), tc.wantErrStatus, e.Code)
-		}
-	} else {
-		require.NoError(s.T(), err)
-	}
-
-	if tc.assertSignup != nil {
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		tc.assertSignup(updated)
-	}
-
-	if tc.assertGockDone {
-		assert.True(s.T(), gock.IsDone())
-	}
+func assertLookupDetails(t *testing.T, signup *toolchainv1alpha1.UserSignup, expectedResult, expectedPhoneHash string) {
+	t.Helper()
+	raw := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey]
+	require.NotEmpty(t, raw, "expected phone-lookup-details annotation to be set")
+	var details map[string]string
+	require.NoError(t, json.Unmarshal([]byte(raw), &details))
+	assert.Equal(t, expectedResult, details["result"])
+	assert.Equal(t, expectedPhoneHash, details["phone_hash"])
 }
 
 func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
@@ -968,161 +932,238 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		},
 	}
 
-	cases := []initVerificationPhoneLookupCase{
-		{
-			name:        "lookup high risk and mode enabled",
-			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
-			username:    "lookup@kubesaw",
-			phone:       lookupUKPhone,
-			countryCode: "44",
-			setupMocks: func(_, _ map[string]interface{}) {
-				mockTwilioLookup(lookupUKPhone, highRiskBody)
-			},
-			wantErr:       true,
-			wantErrStatus: http.StatusForbidden,
-			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
-				assert.Equal(s.T(), "rejected", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-				assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-			},
-			assertGockDone: true,
-		},
-		{
-			name:        "lookup high risk and mode log",
-			mode:        toolchainv1alpha1.PhoneLookupModeLog,
-			username:    "lookup-log@kubesaw",
-			phone:       lookupUKPhone,
-			countryCode: "44",
-			setupMocks: func(_, _ map[string]interface{}) {
-				mockTwilioLookup(lookupUKPhone, highRiskBody)
-				mockTwilioSMS()
-			},
-			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
-				assert.Equal(s.T(), "rejected", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-			},
-			assertGockDone: true,
-		},
-		{
-			name:        "lookup low risk",
-			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
-			username:    "lookup-ok@kubesaw",
-			phone:       lookupUKPhone,
-			countryCode: "44",
-			setupMocks: func(_, lowRiskBody map[string]interface{}) {
-				mockTwilioLookup(lookupUKPhone, lowRiskBody)
-				mockTwilioSMS()
-			},
-			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
-				assert.Equal(s.T(), "allowed", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-				assert.Equal(s.T(), hash.EncodeString(lookupUKPhone), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
-				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-			},
-		},
-		{
-			name:        "lookup API error fail open",
-			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
-			username:    "lookup-err@kubesaw",
-			phone:       lookupUKPhone,
-			countryCode: "44",
-			setupMocks: func(_, _ map[string]interface{}) {
-				gock.New("https://lookups.twilio.com").
-					Get("/v2/PhoneNumbers/" + lookupUKPhone).
-					Reply(http.StatusInternalServerError)
-				mockTwilioSMS()
-			},
-			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
-				assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-			},
-		},
-		{
-			name:        "country code US skips lookup",
-			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
-			username:    "lookup-us@kubesaw",
-			phone:       "+1NUMBER",
-			countryCode: "1",
-			setupMocks: func(_, _ map[string]interface{}) {
-				mockTwilioSMS()
-			},
-			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
-				assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-			},
-			assertGockDone: true,
-		},
-		{
-			name:        "mode disabled skips lookup",
-			mode:        toolchainv1alpha1.PhoneLookupModeDisabled,
-			username:    "lookup-off@kubesaw",
-			phone:       lookupUKPhone,
-			countryCode: "44",
-			setupMocks: func(_, _ map[string]interface{}) {
-				mockTwilioSMS()
-			},
-			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
-				assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-			},
-			assertGockDone: true,
-		},
-		{
-			name:        "already rejected usersignup retries",
-			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
-			username:    "lookup-retry@kubesaw",
-			phone:       lookupUKPhone,
-			countryCode: "44",
-			signupOpts: []testusersignup.Modifier{
-				testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "rejected"),
-			},
-			wantErr:        true,
-			wantErrStatus:  http.StatusForbidden,
-			assertGockDone: true,
-		},
-		{
-			name:        "same phone retry skips lookup",
-			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
-			username:    "lookup-same@kubesaw",
-			phone:       lookupUKPhone,
-			countryCode: "44",
-			signupOpts: []testusersignup.Modifier{
-				testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey, hash.EncodeString(lookupUKPhone)),
-				testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "allowed"),
-			},
-			setupMocks: func(_, _ map[string]interface{}) {
-				mockTwilioSMS()
-			},
-			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
-				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-			},
-			assertGockDone: true,
-		},
-		{
-			name:        "different phone retry calls lookup",
-			mode:        toolchainv1alpha1.PhoneLookupModeEnabled,
-			username:    "lookup-diff@kubesaw",
-			phone:       "+447700900001",
-			countryCode: "44",
-			signupOpts: []testusersignup.Modifier{
-				testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey, hash.EncodeString(lookupUKPhone)),
-				testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey, "allowed"),
-			},
-			setupMocks: func(_, lowRiskBody map[string]interface{}) {
-				mockTwilioLookup("+447700900001", lowRiskBody)
-				mockTwilioSMS()
-			},
-			assertSignup: func(updated *toolchainv1alpha1.UserSignup) {
-				assert.Equal(s.T(), hash.EncodeString("+447700900001"), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
-				assert.Equal(s.T(), "allowed", updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
-				assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-			},
-		},
-	}
+	s.Run("high risk phone with mode enabled returns forbidden", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
+		mockTwilioLookup(lookupUKPhone, highRiskBody)
 
-	for _, tc := range cases {
-		s.Run(tc.name, func() {
-			s.runInitVerificationPhoneLookupCase(tc, highRiskBody, lowRiskBody)
-		})
-	}
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup@kubesaw", lookupUKPhone, "44")
+
+		// then
+		require.Error(s.T(), err)
+		var e *crterrors.Error
+		require.ErrorAs(s.T(), err, &e)
+		assert.Equal(s.T(), http.StatusForbidden, e.Code)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assertLookupDetails(s.T(), updated, "rejected", hash.EncodeString(lookupUKPhone))
+		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("high risk phone with mode log proceeds with SMS", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog)
+		mockTwilioLookup(lookupUKPhone, highRiskBody)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-log@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup-log@kubesaw", lookupUKPhone, "44")
+
+		// then
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assertLookupDetails(s.T(), updated, "rejected", hash.EncodeString(lookupUKPhone))
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("low risk phone proceeds with SMS", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
+		mockTwilioLookup(lookupUKPhone, lowRiskBody)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-ok@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup-ok@kubesaw", lookupUKPhone, "44")
+
+		// then
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assertLookupDetails(s.T(), updated, "allowed", hash.EncodeString(lookupUKPhone))
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	})
+
+	s.Run("lookup API error fails open", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
+		gock.New("https://lookups.twilio.com").
+			Get("/v2/PhoneNumbers/" + lookupUKPhone).
+			Reply(http.StatusInternalServerError)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-err@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup-err@kubesaw", lookupUKPhone, "44")
+
+		// then
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	})
+
+	s.Run("excluded country US skips lookup", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-us@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup-us@kubesaw", "+12025551234", "1")
+
+		// then
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("mode disabled skips lookup", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeDisabled)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-off@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup-off@kubesaw", lookupUKPhone, "44")
+
+		// then
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("already rejected usersignup returns forbidden", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-retry@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey,
+				phoneLookupDetailsJSON("rejected", hash.EncodeString(lookupUKPhone))))
+		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup-retry@kubesaw", lookupUKPhone, "44")
+
+		// then
+		require.Error(s.T(), err)
+		var e *crterrors.Error
+		require.ErrorAs(s.T(), err, &e)
+		assert.Equal(s.T(), http.StatusForbidden, e.Code)
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("same phone retry skips lookup", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-same@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey,
+				phoneLookupDetailsJSON("allowed", hash.EncodeString(lookupUKPhone))))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup-same@kubesaw", lookupUKPhone, "44")
+
+		// then
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("different phone retry calls lookup again", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
+		mockTwilioLookup("+447700900001", lowRiskBody)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-diff@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second),
+			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey,
+				phoneLookupDetailsJSON("allowed", hash.EncodeString(lookupUKPhone))))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup-diff@kubesaw", "+447700900001", "44")
+
+		// then
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assertLookupDetails(s.T(), updated, "allowed", hash.EncodeString("+447700900001"))
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	})
 }
 
 func (s *TestVerificationServiceSuite) TestPhoneNumberAlreadyInUse() {

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -895,10 +895,9 @@ func mockTwilioSMS() {
 		BodyString("")
 }
 
-func phoneLookupDetailsJSON(result, phoneHash string) string {
+func phoneLookupDetailsJSON(result string) string {
 	details := map[string]string{
-		"result":     result,
-		"phone_hash": phoneHash,
+		"result": result,
 	}
 	b, err := json.Marshal(details)
 	if err != nil {
@@ -907,14 +906,13 @@ func phoneLookupDetailsJSON(result, phoneHash string) string {
 	return string(b)
 }
 
-func assertLookupDetails(t *testing.T, signup *toolchainv1alpha1.UserSignup, expectedResult, expectedPhoneHash string) {
+func assertLookupDetails(t *testing.T, signup *toolchainv1alpha1.UserSignup, expectedResult string) {
 	t.Helper()
 	raw := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey]
 	require.NotEmpty(t, raw, "expected phone-lookup-details annotation to be set")
 	var details map[string]string
 	require.NoError(t, json.Unmarshal([]byte(raw), &details))
 	assert.Equal(t, expectedResult, details["result"])
-	assert.Equal(t, expectedPhoneHash, details["phone_hash"])
 }
 
 func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
@@ -958,7 +956,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 		updated := &toolchainv1alpha1.UserSignup{}
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated, "rejected", hash.EncodeString(lookupUKPhone))
+		assertLookupDetails(s.T(), updated, "rejected")
 		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 		assert.True(s.T(), gock.IsDone())
 	})
@@ -984,7 +982,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 		updated := &toolchainv1alpha1.UserSignup{}
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated, "rejected", hash.EncodeString(lookupUKPhone))
+		assertLookupDetails(s.T(), updated, "rejected")
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 		assert.True(s.T(), gock.IsDone())
 	})
@@ -1010,7 +1008,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 		updated := &toolchainv1alpha1.UserSignup{}
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated, "allowed", hash.EncodeString(lookupUKPhone))
+		assertLookupDetails(s.T(), updated, "allowed")
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 	})
 
@@ -1100,7 +1098,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			testusersignup.WithEncodedName("lookup-retry@kubesaw"),
 			testusersignup.VerificationRequiredAgo(time.Second),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey,
-				phoneLookupDetailsJSON("rejected", hash.EncodeString(lookupUKPhone))))
+				phoneLookupDetailsJSON("rejected")))
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		// when
@@ -1124,8 +1122,9 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		userSignup := testusersignup.NewUserSignup(
 			testusersignup.WithEncodedName("lookup-same@kubesaw"),
 			testusersignup.VerificationRequiredAgo(time.Second),
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, hash.EncodeString(lookupUKPhone)),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey,
-				phoneLookupDetailsJSON("allowed", hash.EncodeString(lookupUKPhone))))
+				phoneLookupDetailsJSON("allowed")))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		// when
@@ -1151,8 +1150,9 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		userSignup := testusersignup.NewUserSignup(
 			testusersignup.WithEncodedName("lookup-diff@kubesaw"),
 			testusersignup.VerificationRequiredAgo(time.Second),
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, hash.EncodeString(lookupUKPhone)),
 			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey,
-				phoneLookupDetailsJSON("allowed", hash.EncodeString(lookupUKPhone))))
+				phoneLookupDetailsJSON("allowed")))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		// when
@@ -1164,7 +1164,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 		updated := &toolchainv1alpha1.UserSignup{}
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated, "allowed", hash.EncodeString("+447700900001"))
+		assertLookupDetails(s.T(), updated, "allowed")
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 	})
 }

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -1028,6 +1028,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
 		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.False(s.T(), states.Rejected(updated))
 	})
 
 	s.Run("excluded country US skips lookup", func() {
@@ -1052,6 +1053,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
 		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.False(s.T(), states.Rejected(updated))
 		assert.True(s.T(), gock.IsDone())
 	})
 
@@ -1077,6 +1079,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
 		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.False(s.T(), states.Rejected(updated))
 		assert.True(s.T(), gock.IsDone())
 	})
 
@@ -1100,7 +1103,6 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		var e *crterrors.Error
 		require.ErrorAs(s.T(), err, &e)
 		assert.Equal(s.T(), http.StatusForbidden, e.Code)
-		assert.True(s.T(), gock.IsDone())
 	})
 
 	s.Run("same phone retry skips lookup", func() {
@@ -1125,7 +1127,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		updated := &toolchainv1alpha1.UserSignup{}
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-		assert.True(s.T(), gock.IsDone())
+		assert.False(s.T(), states.Rejected(updated))
 	})
 
 	s.Run("different phone retry calls lookup again", func() {
@@ -1152,6 +1154,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
 		assertLookupDetails(s.T(), updated)
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.False(s.T(), states.Rejected(updated))
 	})
 }
 

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -895,24 +895,12 @@ func mockTwilioSMS() {
 		BodyString("")
 }
 
-func phoneLookupDetailsJSON(result string) string {
-	details := map[string]string{
-		"result": result,
-	}
-	b, err := json.Marshal(details)
-	if err != nil {
-		panic(err)
-	}
-	return string(b)
-}
-
-func assertLookupDetails(t *testing.T, signup *toolchainv1alpha1.UserSignup, expectedResult string) {
+func assertLookupDetails(t *testing.T, signup *toolchainv1alpha1.UserSignup) {
 	t.Helper()
 	raw := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey]
 	require.NotEmpty(t, raw, "expected phone-lookup-details annotation to be set")
-	var details map[string]string
+	var details senderpkg.PhoneLookupResultDetails
 	require.NoError(t, json.Unmarshal([]byte(raw), &details))
-	assert.Equal(t, expectedResult, details["result"])
 }
 
 func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
@@ -956,7 +944,8 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 		updated := &toolchainv1alpha1.UserSignup{}
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated, "rejected")
+		assertLookupDetails(s.T(), updated)
+		assert.True(s.T(), states.Rejected(updated))
 		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 		assert.True(s.T(), gock.IsDone())
 	})
@@ -982,7 +971,8 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 		updated := &toolchainv1alpha1.UserSignup{}
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated, "rejected")
+		assertLookupDetails(s.T(), updated)
+		assert.False(s.T(), states.Rejected(updated))
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 		assert.True(s.T(), gock.IsDone())
 	})
@@ -1008,7 +998,8 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 		updated := &toolchainv1alpha1.UserSignup{}
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated, "allowed")
+		assertLookupDetails(s.T(), updated)
+		assert.False(s.T(), states.Rejected(updated))
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 	})
 
@@ -1096,9 +1087,8 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 		userSignup := testusersignup.NewUserSignup(
 			testusersignup.WithEncodedName("lookup-retry@kubesaw"),
-			testusersignup.VerificationRequiredAgo(time.Second),
-			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey,
-				phoneLookupDetailsJSON("rejected")))
+			testusersignup.VerificationRequiredAgo(time.Second))
+		states.SetRejected(userSignup, true)
 		_, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		// when
@@ -1122,9 +1112,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		userSignup := testusersignup.NewUserSignup(
 			testusersignup.WithEncodedName("lookup-same@kubesaw"),
 			testusersignup.VerificationRequiredAgo(time.Second),
-			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, hash.EncodeString(lookupUKPhone)),
-			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey,
-				phoneLookupDetailsJSON("allowed")))
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, hash.EncodeString(lookupUKPhone)))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		// when
@@ -1150,9 +1138,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		userSignup := testusersignup.NewUserSignup(
 			testusersignup.WithEncodedName("lookup-diff@kubesaw"),
 			testusersignup.VerificationRequiredAgo(time.Second),
-			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, hash.EncodeString(lookupUKPhone)),
-			testusersignup.WithAnnotation(toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey,
-				phoneLookupDetailsJSON("allowed")))
+			testusersignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, hash.EncodeString(lookupUKPhone)))
 		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
 		// when
@@ -1164,7 +1150,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 
 		updated := &toolchainv1alpha1.UserSignup{}
 		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated, "allowed")
+		assertLookupDetails(s.T(), updated)
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 	})
 }


### PR DESCRIPTION
## Summary
- Add Twilio Lookup v2 phone  check integration
- Introduce tri-state `PhoneLookupMode` config (disabled/log/enabled) for gradual rollout
- Store lookup results as UserSignup annotations


Depends on:
- https://github.com/codeready-toolchain/api/pull/487
- https://github.com/codeready-toolchain/toolchain-common/pull/597
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1285 
- https://github.com/codeready-toolchain/host-operator/pull/1268

Assisted by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Twilio phone lookup added to assess number risk (carrier, line type, country, block status, risk score).
  * New configuration accessor for phone-lookup mode (default: log).

* **Behavior Changes**
  * Modes: enabled (block), log (warn/fail-open), disabled.
  * Lookups skipped for US numbers and certain retry/unchanged-number cases; results recorded on signups; high-risk numbers can be rejected when enabled.

* **Tests**
  * Expanded coverage for parsing, edge cases, error handling, modes, retries, and annotation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->