### PR TITLE
use account-verifier response types from api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.13
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20260622140427-920c974c5ea8
+	github.com/codeready-toolchain/api v0.0.0-20260623133516-6f421bfacf3d
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible
@@ -18,8 +18,6 @@ require (
 	k8s.io/client-go v0.33.4
 	sigs.k8s.io/controller-runtime v0.21.0
 )
-
-replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20260623121953-53ec4fa1b5b7
 
 require (
 	cloud.google.com/go/recaptchaenterprise/v2 v2.13.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.13
 
 require (
 	github.com/aws/aws-sdk-go v1.44.100
-	github.com/codeready-toolchain/api v0.0.0-20260609071155-c8f486b1a581
+	github.com/codeready-toolchain/api v0.0.0-20260622140427-920c974c5ea8
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/uuid v4.2.0+incompatible
@@ -18,6 +18,8 @@ require (
 	k8s.io/client-go v0.33.4
 	sigs.k8s.io/controller-runtime v0.21.0
 )
+
+replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20260623121953-53ec4fa1b5b7
 
 require (
 	cloud.google.com/go/recaptchaenterprise/v2 v2.13.0

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,6 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
-github.com/codeready-toolchain/api v0.0.0-20260609071155-c8f486b1a581 h1:KE14RYWzMatSrwGa2wOB4SoVkbvpTm8hfnUH/nrpnfw=
-github.com/codeready-toolchain/api v0.0.0-20260609071155-c8f486b1a581/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579 h1:1qfOdNV6gRQSE0xOmJggqQxAiEjOpV7nZ6Xph75Mb1I=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579/go.mod h1:aYvTzEtTuw3O+kjWMMkH/1YgV4pgUPC3v3X2Li3ixlM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -273,6 +271,8 @@ github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaW
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/matousjobanek/api v0.0.0-20260623121953-53ec4fa1b5b7 h1:eAqdi1Jtk5bvgUWv+bfzm4CPkulJ6IPwnGFhTCyU2iw=
+github.com/matousjobanek/api v0.0.0-20260623121953-53ec4fa1b5b7/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215 h1:hDa3vAq/Zo5gjfJ46XMsGFbH+hTizpR4fUzQCk2nxgk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215/go.mod h1:LH+NgPY9AJpDfqAFtzyer01N9MYNsAKUf3DC9DV1xIY=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
+github.com/codeready-toolchain/api v0.0.0-20260623133516-6f421bfacf3d h1:GvfFKaibrW5oLPnaPFG/pL3FmNDT4btKaTElc0vExQ4=
+github.com/codeready-toolchain/api v0.0.0-20260623133516-6f421bfacf3d/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579 h1:1qfOdNV6gRQSE0xOmJggqQxAiEjOpV7nZ6Xph75Mb1I=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579/go.mod h1:aYvTzEtTuw3O+kjWMMkH/1YgV4pgUPC3v3X2Li3ixlM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -271,8 +273,6 @@ github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaW
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/matousjobanek/api v0.0.0-20260623121953-53ec4fa1b5b7 h1:eAqdi1Jtk5bvgUWv+bfzm4CPkulJ6IPwnGFhTCyU2iw=
-github.com/matousjobanek/api v0.0.0-20260623121953-53ec4fa1b5b7/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215 h1:hDa3vAq/Zo5gjfJ46XMsGFbH+hTizpR4fUzQCk2nxgk=
 github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215/go.mod h1:LH+NgPY9AJpDfqAFtzyer01N9MYNsAKUf3DC9DV1xIY=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/pkg/signup/service/signup_service.go
+++ b/pkg/signup/service/signup_service.go
@@ -66,7 +66,7 @@ func NewSignupService(client namespaced.Client) *ServiceImpl {
 
 // newUserSignup generates a new UserSignup resource with the specified username and available claims.
 // This resource then can be used to create a new UserSignup in the host cluster or to update the existing one.
-func (s *ServiceImpl) newUserSignup(ctx *gin.Context, accountVerifierResp *accountVerifierResponse) (*toolchainv1alpha1.UserSignup, error) {
+func (s *ServiceImpl) newUserSignup(ctx *gin.Context, accountVerifierResp *toolchainv1alpha1.AccountVerifierResponse) (*toolchainv1alpha1.UserSignup, error) {
 	username := ctx.GetString(context.UsernameKey)
 
 	userID := ctx.GetString(context.UserIDKey)
@@ -145,7 +145,7 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context, accountVerifierResp *accou
 	states.SetVerificationRequired(userSignup, verificationRequired)
 
 	if accountVerifierResp != nil {
-		userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey] = accountVerifierResp.Result
+		userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey] = string(accountVerifierResp.Result)
 		if len(accountVerifierResp.Reasons) > 0 {
 			reasonsJSON, err := json.Marshal(accountVerifierResp.Reasons)
 			if err == nil {
@@ -154,10 +154,10 @@ func (s *ServiceImpl) newUserSignup(ctx *gin.Context, accountVerifierResp *accou
 				log.Error(ctx, err, "failed to marshal account verifier reasons")
 			}
 		}
-		if accountVerifierResp.Result == accountVerifierResultPhoneVerification {
+		if accountVerifierResp.Result == toolchainv1alpha1.AccountVerifierResultPhoneVerification {
 			states.SetVerificationRequired(userSignup, true)
 		}
-		if accountVerifierResp.Result == accountVerifierResultReject {
+		if isAccountVerifierRejected(accountVerifierResp) {
 			states.SetRejected(userSignup, true)
 		}
 	}
@@ -265,9 +265,6 @@ func extractEmailHost(email string) string {
 }
 
 const (
-	accountVerifierResultReject            = "reject"
-	accountVerifierResultPhoneVerification = "phone-verification"
-
 	accountVerifierModeDisabled = "disabled"
 	accountVerifierModeLog      = "log"
 	accountVerifierModeEnabled  = "enabled"
@@ -277,20 +274,9 @@ type accountVerifierRequest struct {
 	Email string `json:"email"`
 }
 
-type accountVerifierResponse struct {
-	Result  string                  `json:"result"`
-	Reasons []accountVerifierReason `json:"reasons"`
-	Error   string                  `json:"error"`
-}
-
-type accountVerifierReason struct {
-	Check  string `json:"check"`
-	Detail string `json:"detail"`
-}
-
 var accountVerifierHTTPClient = &http.Client{Timeout: 3 * time.Second}
 
-func callAccountVerifier(ctx *gin.Context, verifierURL, email string) (*accountVerifierResponse, error) {
+func callAccountVerifier(ctx *gin.Context, verifierURL, email string) (*toolchainv1alpha1.AccountVerifierResponse, error) {
 	reqBody, err := json.Marshal(accountVerifierRequest{Email: email})
 	if err != nil {
 		return nil, errs.Wrap(err, "failed to marshal account verifier request")
@@ -311,7 +297,7 @@ func callAccountVerifier(ctx *gin.Context, verifierURL, email string) (*accountV
 		return nil, fmt.Errorf("account verifier returned status %d for email %s: %s", resp.StatusCode, email, string(respBody))
 	}
 
-	var verifierResp accountVerifierResponse
+	var verifierResp toolchainv1alpha1.AccountVerifierResponse
 	if err := json.Unmarshal(respBody, &verifierResp); err != nil {
 		return nil, errs.Wrapf(err, "failed to unmarshal account verifier response for email %s", email)
 	}
@@ -321,7 +307,7 @@ func callAccountVerifier(ctx *gin.Context, verifierURL, email string) (*accountV
 	return &verifierResp, nil
 }
 
-func (s *ServiceImpl) verifyAccount(ctx *gin.Context) *accountVerifierResponse {
+func (s *ServiceImpl) verifyAccount(ctx *gin.Context) *toolchainv1alpha1.AccountVerifierResponse {
 	cfg := configuration.GetRegistrationServiceConfig()
 	if cfg.AccountVerifierMode() == accountVerifierModeDisabled {
 		return nil
@@ -346,8 +332,8 @@ func (s *ServiceImpl) verifyAccount(ctx *gin.Context) *accountVerifierResponse {
 	return nil
 }
 
-func isAccountVerifierRejected(resp *accountVerifierResponse) bool {
-	return resp != nil && resp.Result == accountVerifierResultReject
+func isAccountVerifierRejected(resp *toolchainv1alpha1.AccountVerifierResponse) bool {
+	return resp != nil && resp.Result == toolchainv1alpha1.AccountVerifierResultRejected
 }
 
 // Signup reactivates the deactivated UserSignup resource or creates a new one with the specified username
@@ -403,7 +389,7 @@ func (s *ServiceImpl) Signup(ctx *gin.Context) (*toolchainv1alpha1.UserSignup, e
 }
 
 // createUserSignup creates a new UserSignup resource with the specified username
-func (s *ServiceImpl) createUserSignup(ctx *gin.Context, accountVerifierResp *accountVerifierResponse) (*toolchainv1alpha1.UserSignup, error) {
+func (s *ServiceImpl) createUserSignup(ctx *gin.Context, accountVerifierResp *toolchainv1alpha1.AccountVerifierResponse) (*toolchainv1alpha1.UserSignup, error) {
 	userSignup, err := s.newUserSignup(ctx, accountVerifierResp)
 	if err != nil {
 		return nil, err
@@ -413,7 +399,7 @@ func (s *ServiceImpl) createUserSignup(ctx *gin.Context, accountVerifierResp *ac
 }
 
 // reactivateUserSignup reactivates the deactivated UserSignup resource with the specified username
-func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing *toolchainv1alpha1.UserSignup, accountVerifierResp *accountVerifierResponse) (*toolchainv1alpha1.UserSignup, error) {
+func (s *ServiceImpl) reactivateUserSignup(ctx *gin.Context, existing *toolchainv1alpha1.UserSignup, accountVerifierResp *toolchainv1alpha1.AccountVerifierResponse) (*toolchainv1alpha1.UserSignup, error) {
 	// Update the existing usersignup's spec and annotations/labels by new values from a freshly generated one.
 	// We don't want to deal with merging/patching the usersignup resource
 	// and just want to reset the spec and annotations/labels so they are the same as in a freshly created usersignup resource.

--- a/pkg/signup/service/signup_service_test.go
+++ b/pkg/signup/service/signup_service_test.go
@@ -1539,12 +1539,12 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		assert.JSONEq(s.T(), `[{"check":"check-1","detail":"passed"}]`, userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
 	})
 
-	s.Run("reject result creates rejected UserSignup and returns forbidden error", func() {
+	s.Run("rejected result creates rejected UserSignup and returns forbidden error", func() {
 		// given
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"result":"reject","reasons":[{"check":"check-1","detail":"failed"}],"error":""}`))
+			_, _ = w.Write([]byte(`{"result":"rejected","reasons":[{"check":"check-1","detail":"failed"}],"error":""}`))
 		}))
 		defer verifierServer.Close()
 
@@ -1586,7 +1586,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		require.Len(s.T(), userSignups.Items, 1)
 		createdUS := userSignups.Items[0]
 		assert.True(s.T(), states.Rejected(&createdUS))
-		assert.Equal(s.T(), "reject", createdUS.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
+		assert.Equal(s.T(), "rejected", createdUS.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
 		assert.JSONEq(s.T(), `[{"check":"check-1","detail":"failed"}]`, createdUS.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
 	})
 
@@ -1637,12 +1637,12 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		assert.False(s.T(), verifierCalled, "account verifier should not be called for an already-rejected UserSignup")
 	})
 
-	s.Run("phone-verification result forces verification required", func() {
+	s.Run("phone_verification result forces verification required", func() {
 		// given
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"result":"phone-verification","reasons":[{"check":"check-1","detail":"needs verification"}],"error":""}`))
+			_, _ = w.Write([]byte(`{"result":"phone_verification","reasons":[{"check":"check-1","detail":"needs verification"}],"error":""}`))
 		}))
 		defer verifierServer.Close()
 
@@ -1674,7 +1674,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		// then
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), userSignup)
-		assert.Equal(s.T(), "phone-verification", userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
+		assert.Equal(s.T(), "phone_verification", userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
 		assert.True(s.T(), states.VerificationRequired(userSignup))
 	})
 
@@ -1761,12 +1761,12 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 		assert.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupAccountVerifierReasonsAnnotationKey])
 	})
 
-	s.Run("reject on reactivation returns forbidden error", func() {
+	s.Run("rejected on reactivation returns forbidden error", func() {
 		// given
 		verifierServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"result":"reject","reasons":[{"check":"check-1","detail":"failed"}],"error":""}`))
+			_, _ = w.Write([]byte(`{"result":"rejected","reasons":[{"check":"check-1","detail":"failed"}],"error":""}`))
 		}))
 		defer verifierServer.Close()
 
@@ -1812,7 +1812,7 @@ func (s *TestSignupServiceSuite) TestSignupWithAccountVerifierMode() {
 			Namespace: commontest.HostOperatorNs,
 		}, updatedUS))
 		assert.True(s.T(), states.Rejected(updatedUS))
-		assert.Equal(s.T(), "reject", updatedUS.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
+		assert.Equal(s.T(), "rejected", updatedUS.Annotations[toolchainv1alpha1.UserSignupAccountVerifierResultAnnotationKey])
 	})
 
 	s.Run("disabled mode does not call account verifier", func() {


### PR DESCRIPTION
related PR https://github.com/codeready-toolchain/api/pull/511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Account verification system updated to use the shared toolchain account-verifier response format for consistent signup and reactivation outcomes.
  * Updated account-verifier handling for rejected and phone-verification results to match API-provided result values.
  * Test coverage adjusted to reflect the corrected verifier JSON responses and expected annotation values.
  * Updated account-verifier-related dependency to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->