### PR TITLE
SANDBOX-1889: update PhoneLookupMode default fallback to disabled

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -333,7 +333,7 @@ func (r VerificationConfig) PhoneLookupMode() toolchainv1alpha1.PhoneLookupMode 
 	if r.c.PhoneLookupMode != nil {
 		return *r.c.PhoneLookupMode
 	}
-	return toolchainv1alpha1.PhoneLookupModeLog
+	return toolchainv1alpha1.PhoneLookupModeDisabled
 }
 
 func (r VerificationConfig) PhoneLookupExcludedCountries() []string {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -69,7 +69,7 @@ func TestRegistrationService(t *testing.T) {
 		assert.InDelta(t, float32(0), regServiceCfg.Verification().CaptchaRequiredScore(), 0.01)
 		assert.True(t, regServiceCfg.Verification().CaptchaAllowLowScoreReactivation())
 		assert.Empty(t, regServiceCfg.Verification().CaptchaServiceAccountFileContents())
-		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeLog, regServiceCfg.Verification().PhoneLookupMode())
+		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeDisabled, regServiceCfg.Verification().PhoneLookupMode())
 		assert.Empty(t, regServiceCfg.Verification().PhoneLookupExcludedCountries())
 		assert.False(t, regServiceCfg.PublicViewerEnabled())
 		assert.Empty(t, regServiceCfg.AccountVerifierURL())


### PR DESCRIPTION
Change the runtime nil fallback in PhoneLookupMode() from PhoneLookupModeLog to PhoneLookupModeDisabled, and update the corresponding test assertion.

Related Prs
API: https://github.com/codeready-toolchain/api/pull/515
host-operator: https://github.com/codeready-toolchain/host-operator/pull/1274

Toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/1292


Assisted By : Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default phone lookup setting to be disabled when no value is configured.
  * Aligned the expected default behavior in tests with the new configuration default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->