### PR TITLE
Require both high carrier risk and Number blocked for User rejection

### DIFF
--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -270,10 +270,10 @@ func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.Reg
 	return false, nil
 }
 
-// isHighRiskPhone returns true when Twilio Lookup reports the highest risk category ("high";
-// available categories are low, mild, moderate, high) or when the number is blocked.
+// isHighRiskPhone returns true when Twilio Lookup reports both the highest risk category
+// ("high"; available categories are low, mild, moderate, high) and that the number is blocked.
 func isHighRiskPhone(result *sender.PhoneLookupResult) bool {
-	return result.CarrierRiskCategory == "high" || result.NumberBlocked
+	return result.CarrierRiskCategory == "high" && result.NumberBlocked
 }
 
 // countryCodeFromE164 parses an E.164 phone number and returns its ISO 3166-1 alpha-2 country code.

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -913,6 +913,20 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 			"sms_pumping_risk_score": 34,
 		},
 	}
+	highRiskNotBlockedBody := map[string]interface{}{
+		"sms_pumping_risk": map[string]interface{}{
+			"carrier_risk_category":  "high",
+			"number_blocked":         false,
+			"sms_pumping_risk_score": 34,
+		},
+	}
+	lowRiskBlockedBody := map[string]interface{}{
+		"sms_pumping_risk": map[string]interface{}{
+			"carrier_risk_category":  "low",
+			"number_blocked":         true,
+			"sms_pumping_risk_score": 2,
+		},
+	}
 	lowRiskBody := map[string]interface{}{
 		"sms_pumping_risk": map[string]interface{}{
 			"carrier_risk_category":  "low",
@@ -1001,6 +1015,60 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		assertLookupDetails(s.T(), updated)
 		assert.False(s.T(), states.Rejected(updated))
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	})
+
+	s.Run("high risk without blocked proceeds with SMS", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
+		mockTwilioLookup(lookupUKPhone, highRiskNotBlockedBody)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-high-only@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup-high-only@kubesaw", lookupUKPhone, "44")
+
+		// then
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assertLookupDetails(s.T(), updated)
+		assert.False(s.T(), states.Rejected(updated))
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
+	})
+
+	s.Run("blocked without high risk proceeds with SMS", func() {
+		// given
+		defer gock.Off()
+		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
+		mockTwilioLookup(lookupUKPhone, lowRiskBlockedBody)
+		mockTwilioSMS()
+
+		userSignup := testusersignup.NewUserSignup(
+			testusersignup.WithEncodedName("lookup-blocked-only@kubesaw"),
+			testusersignup.VerificationRequiredAgo(time.Second))
+		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+
+		// when
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		err := application.VerificationService().InitVerification(ctx, "lookup-blocked-only@kubesaw", lookupUKPhone, "44")
+
+		// then
+		require.NoError(s.T(), err)
+
+		updated := &toolchainv1alpha1.UserSignup{}
+		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+		assertLookupDetails(s.T(), updated)
+		assert.False(s.T(), states.Rejected(updated))
+		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.True(s.T(), gock.IsDone())
 	})
 
 	s.Run("lookup API error fails open", func() {

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -991,85 +991,54 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		assert.True(s.T(), gock.IsDone())
 	})
 
-	s.Run("low risk phone proceeds with SMS", func() {
-		// given
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
-		mockTwilioLookup(lookupUKPhone, lowRiskBody)
-		mockTwilioSMS()
+	for _, tc := range []struct {
+		name       string
+		username   string
+		lookupBody map[string]interface{}
+	}{
+		{
+			name:       "low risk phone proceeds with SMS",
+			username:   "lookup-ok@kubesaw",
+			lookupBody: lowRiskBody,
+		},
+		{
+			name:       "high risk without blocked proceeds with SMS",
+			username:   "lookup-high-only@kubesaw",
+			lookupBody: highRiskNotBlockedBody,
+		},
+		{
+			name:       "blocked without high risk proceeds with SMS",
+			username:   "lookup-blocked-only@kubesaw",
+			lookupBody: lowRiskBlockedBody,
+		},
+	} {
+		s.Run(tc.name, func() {
+			// given
+			defer gock.Off()
+			s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
+			mockTwilioLookup(lookupUKPhone, tc.lookupBody)
+			mockTwilioSMS()
 
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-ok@kubesaw"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
+			userSignup := testusersignup.NewUserSignup(
+				testusersignup.WithEncodedName(tc.username),
+				testusersignup.VerificationRequiredAgo(time.Second))
+			fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
 
-		// when
-		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().InitVerification(ctx, "lookup-ok@kubesaw", lookupUKPhone, "44")
+			// when
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			err := application.VerificationService().InitVerification(ctx, tc.username, lookupUKPhone, "44")
 
-		// then
-		require.NoError(s.T(), err)
+			// then
+			require.NoError(s.T(), err)
 
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated)
-		assert.False(s.T(), states.Rejected(updated))
-		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-	})
-
-	s.Run("high risk without blocked proceeds with SMS", func() {
-		// given
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
-		mockTwilioLookup(lookupUKPhone, highRiskNotBlockedBody)
-		mockTwilioSMS()
-
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-high-only@kubesaw"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		// when
-		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().InitVerification(ctx, "lookup-high-only@kubesaw", lookupUKPhone, "44")
-
-		// then
-		require.NoError(s.T(), err)
-
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated)
-		assert.False(s.T(), states.Rejected(updated))
-		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-		assert.True(s.T(), gock.IsDone())
-	})
-
-	s.Run("blocked without high risk proceeds with SMS", func() {
-		// given
-		defer gock.Off()
-		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
-		mockTwilioLookup(lookupUKPhone, lowRiskBlockedBody)
-		mockTwilioSMS()
-
-		userSignup := testusersignup.NewUserSignup(
-			testusersignup.WithEncodedName("lookup-blocked-only@kubesaw"),
-			testusersignup.VerificationRequiredAgo(time.Second))
-		fakeClient, application := testutil.PrepareInClusterApp(s.T(), userSignup)
-
-		// when
-		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
-		err := application.VerificationService().InitVerification(ctx, "lookup-blocked-only@kubesaw", lookupUKPhone, "44")
-
-		// then
-		require.NoError(s.T(), err)
-
-		updated := &toolchainv1alpha1.UserSignup{}
-		require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
-		assertLookupDetails(s.T(), updated)
-		assert.False(s.T(), states.Rejected(updated))
-		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-		assert.True(s.T(), gock.IsDone())
-	})
+			updated := &toolchainv1alpha1.UserSignup{}
+			require.NoError(s.T(), fakeClient.Get(gocontext.TODO(), client.ObjectKeyFromObject(userSignup), updated))
+			assertLookupDetails(s.T(), updated)
+			assert.False(s.T(), states.Rejected(updated))
+			assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+			assert.True(s.T(), gock.IsDone())
+		})
+	}
 
 	s.Run("lookup API error fails open", func() {
 		// given


### PR DESCRIPTION
With recent user complaints relaxing the criteria for phone user rejections for more info [slack](https://redhat-internal.slack.com/archives/C061H0CGYBZ/p1783098906778719)
- Treat phone as high-risk only when carrier_risk is high AND number_blocked
- Cover partial-risk cases that should proceed with SMS

Assisted by : Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated phone risk evaluation so a number is flagged as high risk only when both the carrier risk is high and the number is blocked.
  * Improved SMS verification flow for edge cases (high-risk but not blocked, or blocked but low-risk) so users proceed correctly and are not incorrectly marked as rejected.
* **Tests**
  * Added/expanded unit test coverage to validate the expected verification outcomes for these phone lookup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->