### PR TITLE
SANDBOX-1892: add Prometheus metrics for Twilio phone lookup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/codeready-toolchain/registration-service/pkg/proxy"
 	"github.com/codeready-toolchain/registration-service/pkg/proxy/metrics"
 	"github.com/codeready-toolchain/registration-service/pkg/server"
+	verificationsvc "github.com/codeready-toolchain/registration-service/pkg/verification/service"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	errs "github.com/pkg/errors"
@@ -121,6 +122,7 @@ func main() {
 	// ---------------------------------------------
 	regsvcRegistry := prometheus.NewRegistry()
 	configuration.RegisterVersionMetrics(regsvcRegistry)
+	verificationsvc.RegisterPhoneLookupMetrics(regsvcRegistry)
 	regsvcMetricsSrv, _ := server.StartMetricsServer(regsvcRegistry, server.RegSvcMetricsPort)
 	regsvcSrv := server.New(app)
 	err = regsvcSrv.SetupRoutes(proxy.DefaultPort, regsvcRegistry, nsClient)

--- a/pkg/verification/sender/phone_lookup.go
+++ b/pkg/verification/sender/phone_lookup.go
@@ -1,8 +1,11 @@
 package sender
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
+	"strconv"
 
 	twilioclient "github.com/twilio/twilio-go"
 	twiliohttp "github.com/twilio/twilio-go/client"
@@ -72,4 +75,29 @@ func (t *TwilioPhoneLookup) LookupPhone(phoneNumber string) (*PhoneLookupResult,
 	result.LineType = resp.LineTypeIntelligence.Type
 
 	return result, nil
+}
+
+// Matches the status Twilio embeds when the error response body cannot be decoded:
+// "error decoding the response for an HTTP error code: 503".
+var httpStatusInTwilioErrMsg = regexp.MustCompile(`HTTP error code: (\d{3})`)
+
+// LookupErrorType returns a metric label for a phone lookup failure.
+// Prefer the HTTP status code from Twilio REST errors (e.g. "500", "503");
+// fall back to parsing the status from Twilio's decode-error message, then "unknown".
+func LookupErrorType(err error) string {
+	if err == nil {
+		return "unknown"
+	}
+	var restErr *twiliohttp.TwilioRestError
+	if errors.As(err, &restErr) && restErr.Status != 0 {
+		return strconv.Itoa(restErr.Status)
+	}
+	var restErrV1 *twiliohttp.RestErrorV1
+	if errors.As(err, &restErrV1) && restErrV1.HttpStatusCode != 0 {
+		return strconv.Itoa(restErrV1.HttpStatusCode)
+	}
+	if m := httpStatusInTwilioErrMsg.FindStringSubmatch(err.Error()); len(m) == 2 {
+		return m[1]
+	}
+	return "unknown"
 }

--- a/pkg/verification/sender/phone_lookup_test.go
+++ b/pkg/verification/sender/phone_lookup_test.go
@@ -86,9 +86,12 @@ func TestTwilioPhoneLookup(t *testing.T) {
 	})
 
 	t.Run("API error handling", func(t *testing.T) {
-		// given
+		// given — Twilio REST error body includes status so the SDK returns TwilioRestError
 		lookup := setupLookup(t, http.StatusInternalServerError, map[string]interface{}{
-			"message": "Internal Server Error",
+			"status":    500,
+			"code":      20500,
+			"message":   "Internal Server Error",
+			"more_info": "",
 		})
 
 		// when
@@ -98,6 +101,46 @@ func TestTwilioPhoneLookup(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "twilio phone lookup")
+		assert.Equal(t, "500", sender.LookupErrorType(err))
+	})
+
+	t.Run("API error type for service unavailable", func(t *testing.T) {
+		// given
+		lookup := setupLookup(t, http.StatusServiceUnavailable, map[string]interface{}{
+			"status":    503,
+			"code":      20503,
+			"message":   "Service Unavailable",
+			"more_info": "",
+		})
+
+		// when
+		_, err := lookup.LookupPhone(phone)
+
+		// then
+		require.Error(t, err)
+		assert.Equal(t, "503", sender.LookupErrorType(err))
+	})
+
+	t.Run("API error type from undecodable body", func(t *testing.T) {
+		// given — empty/invalid body: Twilio embeds status in the decode-error message
+		t.Cleanup(gock.Off)
+		gock.New("https://lookups.twilio.com").
+			Get("/v2/PhoneNumbers/"+phone).
+			MatchParam("Fields", "sms_pumping_risk,line_type_intelligence").
+			Reply(http.StatusBadGateway).
+			BodyString("not-json")
+		lookup := sender.NewTwilioPhoneLookup(accountSID, authToken, nil)
+
+		// when
+		_, err := lookup.LookupPhone(phone)
+
+		// then
+		require.Error(t, err)
+		assert.Equal(t, "502", sender.LookupErrorType(err))
+	})
+
+	t.Run("LookupErrorType unknown for non-Twilio errors", func(t *testing.T) {
+		assert.Equal(t, "unknown", sender.LookupErrorType(assert.AnError))
 	})
 
 	t.Run("response with missing fields", func(t *testing.T) {

--- a/pkg/verification/service/phone_lookup_metrics.go
+++ b/pkg/verification/service/phone_lookup_metrics.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// PhoneLookupTotal counts successful Twilio Lookup API responses by result and risk category.
+	PhoneLookupTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandbox_signup_phone_lookup_total",
+			Help: "Total successful phone lookup operations by result and risk category.",
+		},
+		[]string{"result", "risk_category"},
+	)
+
+	// PhoneLookupErrorsTotal counts Twilio Lookup API failures (fail-open cases).
+	PhoneLookupErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandbox_signup_phone_lookup_errors_total",
+			Help: "Phone lookup API errors (fail-open cases).",
+		},
+		[]string{"error_type"},
+	)
+)
+
+// RegisterPhoneLookupMetrics registers phone lookup metrics with the given registry.
+func RegisterPhoneLookupMetrics(reg *prometheus.Registry) {
+	reg.MustRegister(PhoneLookupTotal, PhoneLookupErrorsTotal)
+}

--- a/pkg/verification/service/phone_lookup_metrics.go
+++ b/pkg/verification/service/phone_lookup_metrics.go
@@ -6,10 +6,12 @@ import (
 
 var (
 	// PhoneLookupTotal counts successful Twilio Lookup API responses by result and risk category.
+	// result=blocked is incremented only when the signup is actually rejected (mode=enabled).
+	// result=allowed covers low-risk numbers and high-risk detections in log mode.
 	PhoneLookupTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "sandbox_signup_phone_lookup_total",
-			Help: "Total successful phone lookup operations by result and risk category.",
+			Help: "Total successful phone lookup operations by result and risk category. result=blocked means the signup was rejected.",
 		},
 		[]string{"result", "risk_category"},
 	)

--- a/pkg/verification/service/phone_lookup_metrics.go
+++ b/pkg/verification/service/phone_lookup_metrics.go
@@ -4,6 +4,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	PhoneLookupResultAllowed = "allowed"
+	PhoneLookupResultBlocked = "blocked"
+)
+
 var (
 	// PhoneLookupTotal counts successful Twilio Lookup API responses by result and risk category.
 	// result=blocked is incremented only when the signup is actually rejected (mode=enabled).
@@ -17,10 +22,11 @@ var (
 	)
 
 	// PhoneLookupErrorsTotal counts Twilio Lookup API failures (fail-open cases).
+	// error_type is the HTTP status code when available (e.g. "500", "503"), otherwise "unknown".
 	PhoneLookupErrorsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "sandbox_signup_phone_lookup_errors_total",
-			Help: "Phone lookup API errors (fail-open cases).",
+			Help: "Phone lookup API errors (fail-open cases), labeled by HTTP status code when available.",
 		},
 		[]string{"error_type"},
 	)

--- a/pkg/verification/service/phone_lookup_metrics_test.go
+++ b/pkg/verification/service/phone_lookup_metrics_test.go
@@ -12,6 +12,8 @@ import (
 func TestRegisterPhoneLookupMetrics(t *testing.T) {
 	// given
 	reg := prometheus.NewRegistry()
+	PhoneLookupTotal.Reset()
+	PhoneLookupErrorsTotal.Reset()
 
 	// when
 	require.NotPanics(t, func() {
@@ -33,43 +35,31 @@ func TestRegisterPhoneLookupMetrics(t *testing.T) {
 }
 
 func TestPhoneLookupTotalIncrements(t *testing.T) {
-	// given — use a fresh CounterVec so tests don't share global state
-	total := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "sandbox_signup_phone_lookup_total_test",
-			Help: "test",
-		},
-		[]string{"result", "risk_category"},
-	)
+	// given
+	PhoneLookupTotal.Reset()
 
 	// when
-	total.WithLabelValues("allowed", "low").Inc()
-	total.WithLabelValues("blocked", "high").Inc()
-	total.WithLabelValues("blocked", "high").Inc()
+	PhoneLookupTotal.WithLabelValues("allowed", "low").Inc()
+	PhoneLookupTotal.WithLabelValues("blocked", "high").Inc()
+	PhoneLookupTotal.WithLabelValues("blocked", "high").Inc()
 
 	// then
-	assert.InDelta(t, float64(1), promtestutil.ToFloat64(total.WithLabelValues("allowed", "low")), 0.01)
-	assert.InDelta(t, float64(2), promtestutil.ToFloat64(total.WithLabelValues("blocked", "high")), 0.01)
-	assert.Equal(t, 2, promtestutil.CollectAndCount(total))
+	assert.InDelta(t, float64(1), promtestutil.ToFloat64(PhoneLookupTotal.WithLabelValues("allowed", "low")), 0.01)
+	assert.InDelta(t, float64(2), promtestutil.ToFloat64(PhoneLookupTotal.WithLabelValues("blocked", "high")), 0.01)
+	assert.Equal(t, 2, promtestutil.CollectAndCount(PhoneLookupTotal))
 }
 
 func TestPhoneLookupErrorsTotalIncrements(t *testing.T) {
 	// given
-	errors := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "sandbox_signup_phone_lookup_errors_total_test",
-			Help: "test",
-		},
-		[]string{"error_type"},
-	)
+	PhoneLookupErrorsTotal.Reset()
 
 	// when
-	errors.WithLabelValues("api_error").Inc()
-	errors.WithLabelValues("api_error").Inc()
-	errors.WithLabelValues("timeout").Inc()
+	PhoneLookupErrorsTotal.WithLabelValues("api_error").Inc()
+	PhoneLookupErrorsTotal.WithLabelValues("api_error").Inc()
+	PhoneLookupErrorsTotal.WithLabelValues("timeout").Inc()
 
 	// then
-	assert.InDelta(t, float64(2), promtestutil.ToFloat64(errors.WithLabelValues("api_error")), 0.01)
-	assert.InDelta(t, float64(1), promtestutil.ToFloat64(errors.WithLabelValues("timeout")), 0.01)
-	assert.Equal(t, 2, promtestutil.CollectAndCount(errors))
+	assert.InDelta(t, float64(2), promtestutil.ToFloat64(PhoneLookupErrorsTotal.WithLabelValues("api_error")), 0.01)
+	assert.InDelta(t, float64(1), promtestutil.ToFloat64(PhoneLookupErrorsTotal.WithLabelValues("timeout")), 0.01)
+	assert.Equal(t, 2, promtestutil.CollectAndCount(PhoneLookupErrorsTotal))
 }

--- a/pkg/verification/service/phone_lookup_metrics_test.go
+++ b/pkg/verification/service/phone_lookup_metrics_test.go
@@ -48,8 +48,8 @@ func TestPhoneLookupTotalIncrements(t *testing.T) {
 	total.WithLabelValues("blocked", "high").Inc()
 
 	// then
-	assert.Equal(t, float64(1), promtestutil.ToFloat64(total.WithLabelValues("allowed", "low")))
-	assert.Equal(t, float64(2), promtestutil.ToFloat64(total.WithLabelValues("blocked", "high")))
+	assert.InDelta(t, float64(1), promtestutil.ToFloat64(total.WithLabelValues("allowed", "low")), 0.01)
+	assert.InDelta(t, float64(2), promtestutil.ToFloat64(total.WithLabelValues("blocked", "high")), 0.01)
 	assert.Equal(t, 2, promtestutil.CollectAndCount(total))
 }
 
@@ -69,7 +69,7 @@ func TestPhoneLookupErrorsTotalIncrements(t *testing.T) {
 	errors.WithLabelValues("timeout").Inc()
 
 	// then
-	assert.Equal(t, float64(2), promtestutil.ToFloat64(errors.WithLabelValues("api_error")))
-	assert.Equal(t, float64(1), promtestutil.ToFloat64(errors.WithLabelValues("timeout")))
+	assert.InDelta(t, float64(2), promtestutil.ToFloat64(errors.WithLabelValues("api_error")), 0.01)
+	assert.InDelta(t, float64(1), promtestutil.ToFloat64(errors.WithLabelValues("timeout")), 0.01)
 	assert.Equal(t, 2, promtestutil.CollectAndCount(errors))
 }

--- a/pkg/verification/service/phone_lookup_metrics_test.go
+++ b/pkg/verification/service/phone_lookup_metrics_test.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterPhoneLookupMetrics(t *testing.T) {
+	// given
+	reg := prometheus.NewRegistry()
+
+	// when
+	require.NotPanics(t, func() {
+		RegisterPhoneLookupMetrics(reg)
+	})
+
+	// then — observe once so Gather includes the vectors
+	PhoneLookupTotal.WithLabelValues("allowed", "low").Inc()
+	PhoneLookupErrorsTotal.WithLabelValues("api_error").Inc()
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+	names := make(map[string]bool, len(gathered))
+	for _, m := range gathered {
+		names[m.GetName()] = true
+	}
+	assert.True(t, names["sandbox_signup_phone_lookup_total"])
+	assert.True(t, names["sandbox_signup_phone_lookup_errors_total"])
+}
+
+func TestPhoneLookupTotalIncrements(t *testing.T) {
+	// given — use a fresh CounterVec so tests don't share global state
+	total := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandbox_signup_phone_lookup_total_test",
+			Help: "test",
+		},
+		[]string{"result", "risk_category"},
+	)
+
+	// when
+	total.WithLabelValues("allowed", "low").Inc()
+	total.WithLabelValues("blocked", "high").Inc()
+	total.WithLabelValues("blocked", "high").Inc()
+
+	// then
+	assert.Equal(t, float64(1), promtestutil.ToFloat64(total.WithLabelValues("allowed", "low")))
+	assert.Equal(t, float64(2), promtestutil.ToFloat64(total.WithLabelValues("blocked", "high")))
+	assert.Equal(t, 2, promtestutil.CollectAndCount(total))
+}
+
+func TestPhoneLookupErrorsTotalIncrements(t *testing.T) {
+	// given
+	errors := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandbox_signup_phone_lookup_errors_total_test",
+			Help: "test",
+		},
+		[]string{"error_type"},
+	)
+
+	// when
+	errors.WithLabelValues("api_error").Inc()
+	errors.WithLabelValues("api_error").Inc()
+	errors.WithLabelValues("timeout").Inc()
+
+	// then
+	assert.Equal(t, float64(2), promtestutil.ToFloat64(errors.WithLabelValues("api_error")))
+	assert.Equal(t, float64(1), promtestutil.ToFloat64(errors.WithLabelValues("timeout")))
+	assert.Equal(t, 2, promtestutil.CollectAndCount(errors))
+}

--- a/pkg/verification/service/phone_lookup_metrics_test.go
+++ b/pkg/verification/service/phone_lookup_metrics_test.go
@@ -21,8 +21,8 @@ func TestRegisterPhoneLookupMetrics(t *testing.T) {
 	})
 
 	// then — observe once so Gather includes the vectors
-	PhoneLookupTotal.WithLabelValues("allowed", "low").Inc()
-	PhoneLookupErrorsTotal.WithLabelValues("api_error").Inc()
+	PhoneLookupTotal.WithLabelValues(PhoneLookupResultAllowed, "low").Inc()
+	PhoneLookupErrorsTotal.WithLabelValues("500").Inc()
 
 	gathered, err := reg.Gather()
 	require.NoError(t, err)
@@ -39,13 +39,13 @@ func TestPhoneLookupTotalIncrements(t *testing.T) {
 	PhoneLookupTotal.Reset()
 
 	// when
-	PhoneLookupTotal.WithLabelValues("allowed", "low").Inc()
-	PhoneLookupTotal.WithLabelValues("blocked", "high").Inc()
-	PhoneLookupTotal.WithLabelValues("blocked", "high").Inc()
+	PhoneLookupTotal.WithLabelValues(PhoneLookupResultAllowed, "low").Inc()
+	PhoneLookupTotal.WithLabelValues(PhoneLookupResultBlocked, "high").Inc()
+	PhoneLookupTotal.WithLabelValues(PhoneLookupResultBlocked, "high").Inc()
 
 	// then
-	assert.InDelta(t, float64(1), promtestutil.ToFloat64(PhoneLookupTotal.WithLabelValues("allowed", "low")), 0.01)
-	assert.InDelta(t, float64(2), promtestutil.ToFloat64(PhoneLookupTotal.WithLabelValues("blocked", "high")), 0.01)
+	assert.InDelta(t, float64(1), promtestutil.ToFloat64(PhoneLookupTotal.WithLabelValues(PhoneLookupResultAllowed, "low")), 0.01)
+	assert.InDelta(t, float64(2), promtestutil.ToFloat64(PhoneLookupTotal.WithLabelValues(PhoneLookupResultBlocked, "high")), 0.01)
 	assert.Equal(t, 2, promtestutil.CollectAndCount(PhoneLookupTotal))
 }
 
@@ -54,12 +54,12 @@ func TestPhoneLookupErrorsTotalIncrements(t *testing.T) {
 	PhoneLookupErrorsTotal.Reset()
 
 	// when
-	PhoneLookupErrorsTotal.WithLabelValues("api_error").Inc()
-	PhoneLookupErrorsTotal.WithLabelValues("api_error").Inc()
-	PhoneLookupErrorsTotal.WithLabelValues("timeout").Inc()
+	PhoneLookupErrorsTotal.WithLabelValues("500").Inc()
+	PhoneLookupErrorsTotal.WithLabelValues("500").Inc()
+	PhoneLookupErrorsTotal.WithLabelValues("503").Inc()
 
 	// then
-	assert.InDelta(t, float64(2), promtestutil.ToFloat64(PhoneLookupErrorsTotal.WithLabelValues("api_error")), 0.01)
-	assert.InDelta(t, float64(1), promtestutil.ToFloat64(PhoneLookupErrorsTotal.WithLabelValues("timeout")), 0.01)
+	assert.InDelta(t, float64(2), promtestutil.ToFloat64(PhoneLookupErrorsTotal.WithLabelValues("500")), 0.01)
+	assert.InDelta(t, float64(1), promtestutil.ToFloat64(PhoneLookupErrorsTotal.WithLabelValues("503")), 0.01)
 	assert.Equal(t, 2, promtestutil.CollectAndCount(PhoneLookupErrorsTotal))
 }

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -262,15 +262,18 @@ func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.Reg
 		annotationValues[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = string(detailsJSON)
 	}
 	if isHighRiskPhone(result) {
-		PhoneLookupTotal.WithLabelValues("blocked", result.CarrierRiskCategory).Inc()
 		log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t, phone_lookup_mode=%s)",
 			result.CarrierRiskCategory, result.NumberBlocked, mode))
 		if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
+			// Count as blocked only when the signup is actually rejected.
+			PhoneLookupTotal.WithLabelValues("blocked", result.CarrierRiskCategory).Inc()
 			return true, crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
 		}
-	} else {
+		// mode == log: high-risk is detected but not enforced; still charged, user proceeds.
 		PhoneLookupTotal.WithLabelValues("allowed", result.CarrierRiskCategory).Inc()
+		return false, nil
 	}
+	PhoneLookupTotal.WithLabelValues("allowed", result.CarrierRiskCategory).Inc()
 	return false, nil
 }
 

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -249,7 +249,7 @@ func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.Reg
 	}
 	result, lookupErr := s.PhoneLookupService.LookupPhone(e164PhoneNumber)
 	if lookupErr != nil {
-		PhoneLookupErrorsTotal.WithLabelValues("api_error").Inc()
+		PhoneLookupErrorsTotal.WithLabelValues(sender.LookupErrorType(lookupErr)).Inc()
 		log.Error(ctx, lookupErr, "phone lookup failed, proceeding (fail-open)")
 		return false, nil
 	}
@@ -266,14 +266,14 @@ func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.Reg
 			result.CarrierRiskCategory, result.NumberBlocked, mode))
 		if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
 			// Count as blocked only when the signup is actually rejected.
-			PhoneLookupTotal.WithLabelValues("blocked", result.CarrierRiskCategory).Inc()
+			PhoneLookupTotal.WithLabelValues(PhoneLookupResultBlocked, result.CarrierRiskCategory).Inc()
 			return true, crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
 		}
 		// mode == log: high-risk is detected but not enforced; still charged, user proceeds.
-		PhoneLookupTotal.WithLabelValues("allowed", result.CarrierRiskCategory).Inc()
+		PhoneLookupTotal.WithLabelValues(PhoneLookupResultAllowed, result.CarrierRiskCategory).Inc()
 		return false, nil
 	}
-	PhoneLookupTotal.WithLabelValues("allowed", result.CarrierRiskCategory).Inc()
+	PhoneLookupTotal.WithLabelValues(PhoneLookupResultAllowed, result.CarrierRiskCategory).Inc()
 	return false, nil
 }
 

--- a/pkg/verification/service/verification_service.go
+++ b/pkg/verification/service/verification_service.go
@@ -249,6 +249,7 @@ func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.Reg
 	}
 	result, lookupErr := s.PhoneLookupService.LookupPhone(e164PhoneNumber)
 	if lookupErr != nil {
+		PhoneLookupErrorsTotal.WithLabelValues("api_error").Inc()
 		log.Error(ctx, lookupErr, "phone lookup failed, proceeding (fail-open)")
 		return false, nil
 	}
@@ -261,11 +262,14 @@ func (s *ServiceImpl) performPhoneLookup(ctx *gin.Context, cfg configuration.Reg
 		annotationValues[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = string(detailsJSON)
 	}
 	if isHighRiskPhone(result) {
+		PhoneLookupTotal.WithLabelValues("blocked", result.CarrierRiskCategory).Inc()
 		log.Info(ctx, fmt.Sprintf("high risk phone detected (carrier_risk=%s, blocked=%t, phone_lookup_mode=%s)",
 			result.CarrierRiskCategory, result.NumberBlocked, mode))
 		if mode == toolchainv1alpha1.PhoneLookupModeEnabled {
 			return true, crterrors.NewForbiddenError("phone verification rejected", "cannot proceed with verification")
 		}
+	} else {
+		PhoneLookupTotal.WithLabelValues("allowed", result.CarrierRiskCategory).Inc()
 	}
 	return false, nil
 }

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -1095,7 +1095,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 		assert.False(s.T(), states.Rejected(updated))
-		assert.InDelta(s.T(), float64(1), phoneLookupErrors("api_error"), 0.01)
+		assert.InDelta(s.T(), float64(1), phoneLookupErrors("500"), 0.01)
 		assert.Equal(s.T(), 0, promtestutil.CollectAndCount(verificationservice.PhoneLookupTotal))
 	})
 

--- a/pkg/verification/service/verification_service_test.go
+++ b/pkg/verification/service/verification_service_test.go
@@ -33,6 +33,7 @@ import (
 	testusersignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
 	"github.com/gin-gonic/gin"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -903,6 +904,19 @@ func assertLookupDetails(t *testing.T, signup *toolchainv1alpha1.UserSignup) {
 	require.NoError(t, json.Unmarshal([]byte(raw), &details))
 }
 
+func resetPhoneLookupMetrics() {
+	verificationservice.PhoneLookupTotal.Reset()
+	verificationservice.PhoneLookupErrorsTotal.Reset()
+}
+
+func phoneLookupTotal(result, riskCategory string) float64 {
+	return promtestutil.ToFloat64(verificationservice.PhoneLookupTotal.WithLabelValues(result, riskCategory))
+}
+
+func phoneLookupErrors(errorType string) float64 {
+	return promtestutil.ToFloat64(verificationservice.PhoneLookupErrorsTotal.WithLabelValues(errorType))
+}
+
 func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 	s.ServiceConfiguration("xxx", "yyy", "CodeReady")
 
@@ -924,6 +938,7 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 	s.Run("high risk phone with mode enabled returns forbidden", func() {
 		// given
 		defer gock.Off()
+		resetPhoneLookupMetrics()
 		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
 		mockTwilioLookup(lookupUKPhone, highRiskBody)
 
@@ -948,11 +963,14 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		assert.True(s.T(), states.Rejected(updated))
 		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 		assert.True(s.T(), gock.IsDone())
+		assert.InDelta(s.T(), float64(1), phoneLookupTotal("blocked", "high"), 0.01)
+		assert.InDelta(s.T(), float64(0), phoneLookupTotal("allowed", "high"), 0.01)
 	})
 
 	s.Run("high risk phone with mode log proceeds with SMS", func() {
 		// given
 		defer gock.Off()
+		resetPhoneLookupMetrics()
 		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog)
 		mockTwilioLookup(lookupUKPhone, highRiskBody)
 		mockTwilioSMS()
@@ -975,11 +993,15 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		assert.False(s.T(), states.Rejected(updated))
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 		assert.True(s.T(), gock.IsDone())
+		// log mode detects high risk but does not reject — count as allowed (still charged)
+		assert.InDelta(s.T(), float64(1), phoneLookupTotal("allowed", "high"), 0.01)
+		assert.InDelta(s.T(), float64(0), phoneLookupTotal("blocked", "high"), 0.01)
 	})
 
 	s.Run("low risk phone proceeds with SMS", func() {
 		// given
 		defer gock.Off()
+		resetPhoneLookupMetrics()
 		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
 		mockTwilioLookup(lookupUKPhone, lowRiskBody)
 		mockTwilioSMS()
@@ -1001,11 +1023,14 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		assertLookupDetails(s.T(), updated)
 		assert.False(s.T(), states.Rejected(updated))
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.InDelta(s.T(), float64(1), phoneLookupTotal("allowed", "low"), 0.01)
+		assert.InDelta(s.T(), float64(0), phoneLookupTotal("blocked", "high"), 0.01)
 	})
 
 	s.Run("lookup API error fails open", func() {
 		// given
 		defer gock.Off()
+		resetPhoneLookupMetrics()
 		s.setPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled)
 		gock.New("https://lookups.twilio.com").
 			Get("/v2/PhoneNumbers/" + lookupUKPhone).
@@ -1029,6 +1054,8 @@ func (s *TestVerificationServiceSuite) TestInitVerificationPhoneLookup() {
 		assert.Empty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
 		assert.NotEmpty(s.T(), updated.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 		assert.False(s.T(), states.Rejected(updated))
+		assert.InDelta(s.T(), float64(1), phoneLookupErrors("api_error"), 0.01)
+		assert.Equal(s.T(), 0, promtestutil.CollectAndCount(verificationservice.PhoneLookupTotal))
 	})
 
 	s.Run("excluded country US skips lookup", func() {


### PR DESCRIPTION
Emit counters for successful lookups (allowed/blocked by risk category) and API errors so Grafana can track bot blocking and Lookup spend.

Related PR
Sandbox-Sre - https://github.com/codeready-toolchain/sandbox-sre/pull/3248

Assisted by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for phone lookup outcomes, including allowed/blocked states and risk categories.
  * Added Prometheus metrics for phone lookup failures (fail-open) with error-type labeling.
  * Metrics are now registered during service startup for immediate monitoring.

* **Bug Fixes**
  * Phone-lookup verification now consistently records metrics for both success paths and error/fail-open scenarios.

* **Tests**
  * Added/extended unit tests to verify metric registration and correct counter increments by label values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->